### PR TITLE
Change app name to Open Proces Huis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# frontend-processendatabank
+# Open Proces Huis (frontend)
 
 This README outlines the details of collaborating on this Ember application.
 A short introduction of this app could easily go here.
@@ -7,22 +7,22 @@ A short introduction of this app could easily go here.
 
 You will need the following things properly installed on your computer.
 
-* [Git](https://git-scm.com/)
-* [Node.js](https://nodejs.org/) (with npm)
-* [Ember CLI](https://cli.emberjs.com/release/)
-* [Google Chrome](https://google.com/chrome/)
+- [Git](https://git-scm.com/)
+- [Node.js](https://nodejs.org/) (with npm)
+- [Ember CLI](https://cli.emberjs.com/release/)
+- [Google Chrome](https://google.com/chrome/)
 
 ## Installation
 
-* `git clone <repository-url>` this repository
-* `cd frontend-processendatabank`
-* `npm install`
+- `git clone <repository-url>` this repository
+- `cd frontend-openproceshuis`
+- `npm install`
 
 ## Running / Development
 
-* `npm run start`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
-* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+- `npm run start`
+- Visit your app at [http://localhost:4200](http://localhost:4200).
+- Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 
 ### Code Generators
 
@@ -30,18 +30,18 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Running Tests
 
-* `npm run test`
-* `npm run test:ember -- --server`
+- `npm run test`
+- `npm run test:ember -- --server`
 
 ### Linting
 
-* `npm run lint`
-* `npm run lint:fix`
+- `npm run lint`
+- `npm run lint:fix`
 
 ### Building
 
-* `npm exec ember build` (development)
-* `npm run build` (production)
+- `npm exec ember build` (development)
+- `npm run build` (production)
 
 ### Deploying
 
@@ -49,8 +49,8 @@ Specify what it takes to deploy your app.
 
 ## Further Reading / Useful Links
 
-* [ember.js](https://emberjs.com/)
-* [ember-cli](https://cli.emberjs.com/release/)
-* Development Browser Extensions
-  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
-  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
+- [ember.js](https://emberjs.com/)
+- [ember-cli](https://cli.emberjs.com/release/)
+- Development Browser Extensions
+  - [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  - [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)

--- a/app/app.js
+++ b/app/app.js
@@ -1,7 +1,7 @@
 import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
-import config from 'frontend-processendatabank/config/environment';
+import config from 'frontend-openproceshuis/config/environment';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/app/helpers/bpmn-download-url.js
+++ b/app/helpers/bpmn-download-url.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import generateBpmnDownloadUrl from 'frontend-processendatabank/utils/bpmn-download-url';
+import generateBpmnDownloadUrl from 'frontend-openproceshuis/utils/bpmn-download-url';
 
 export default helper(function bpmnDownloadUrl([fileId]) {
   return generateBpmnDownloadUrl(fileId);

--- a/app/index.html
+++ b/app/index.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
 <html lang="nl">
   <head>
-    <meta charset="utf-8">
-    <title>FrontendProcessendatabank</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <title>Open Proces Huis</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/frontend-processendatabank.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link
+      integrity=""
+      rel="stylesheet"
+      href="{{rootURL}}assets/frontend-openproceshuis.css"
+    />
 
     {{content-for "head-footer"}}
   </head>
@@ -17,7 +21,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/frontend-processendatabank.js"></script>
+    <script src="{{rootURL}}assets/frontend-openproceshuis.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/app/router.js
+++ b/app/router.js
@@ -1,5 +1,5 @@
 import EmberRouter from '@ember/routing/router';
-import config from 'frontend-processendatabank/config/environment';
+import config from 'frontend-openproceshuis/config/environment';
 
 export default class Router extends EmberRouter {
   location = config.locationType;

--- a/app/routes/bpmn-files/bpmn-file/index.js
+++ b/app/routes/bpmn-files/bpmn-file/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import generateBpmnDownloadUrl from 'frontend-processendatabank/utils/bpmn-download-url';
+import generateBpmnDownloadUrl from 'frontend-openproceshuis/utils/bpmn-download-url';
 
 export default class BpmnFilesBpmnFileIndexRoute extends Route {
   async model() {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{page-title
   (concat
-    "Organisatie Portaal"
+    "Open Proces Huis"
     (if this.showEnvironment (concat " - " this.environmentName))
   )
 }}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -33,7 +33,7 @@
           {{#if (config "showAppVersionHash")}}
             (<a
               class="au-c-link"
-              href="https://github.com/MartijnBogaert/frontend-processendatabank/commit/{{app-version
+              href="https://github.com/MartijnBogaert/frontend-openproceshuis/commit/{{app-version
                 shaOnly=true
               }}"
             >{{app-version shaOnly=true}}</a>)

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,7 +2,7 @@
 
 module.exports = function (environment) {
   const ENV = {
-    modulePrefix: 'frontend-processendatabank',
+    modulePrefix: 'frontend-openproceshuis',
     environment,
     rootURL: '/',
     locationType: 'history',
@@ -19,7 +19,7 @@ module.exports = function (environment) {
       // when it is created
     },
 
-    appName: 'ProcessenDatabank',
+    appName: 'Open Proces Huis',
   };
 
   if (environment === 'development') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "frontend-processendatabank",
+  "name": "frontend-openproceshuis",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend-processendatabank",
+      "name": "frontend-openproceshuis",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "frontend-processendatabank",
+  "name": "frontend-openproceshuis",
   "version": "0.0.0",
   "private": true,
   "description": "Frontend for processes",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MartijnBogaert/frontend-processendatabank.git"
+    "url": "git+https://github.com/MartijnBogaert/frontend-openproceshuis.git"
   },
   "license": "MIT",
   "author": "Martijn Bogaert",

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <title>FrontendProcessendatabank Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <title>Open Proces Huis Tests</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/frontend-processendatabank.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link
+      rel="stylesheet"
+      href="{{rootURL}}assets/frontend-openproceshuis.css"
+    />
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css" />
 
-    {{content-for "head-footer"}}
-    {{content-for "test-head-footer"}}
+    {{content-for "head-footer"}} {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for "body"}} {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -30,10 +30,9 @@
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
-    <script src="{{rootURL}}assets/frontend-processendatabank.js"></script>
+    <script src="{{rootURL}}assets/frontend-openproceshuis.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,5 @@
-import Application from 'frontend-processendatabank/app';
-import config from 'frontend-processendatabank/config/environment';
+import Application from 'frontend-openproceshuis/app';
+import config from 'frontend-openproceshuis/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';


### PR DESCRIPTION
All occurences of "Processendatabank" (or any of its derivatives) have been changed to "Open Proces Huis" (or any of  its derivatives).

Also, for `README.md`, `app/index.html` and `tests/index.html` some automatic formatting has happened.