### PR TITLE
Disable diagram scrolling by default

### DIFF
--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -15,21 +15,26 @@ export default class BpmnViewerComponent extends Component {
 
     await this.viewer.importXML(bpmnXml);
     this.viewer.get('canvas').zoom('fit-viewport');
-    this.enableZoomScroll(false);
+    this.disableZoomScroll();
 
     element.addEventListener('focus', () => {
-      this.enableZoomScroll(true);
+      this.enableZoomScroll();
     });
 
     element.addEventListener('blur', () => {
-      this.enableZoomScroll(false);
+      this.disableZoomScroll();
     });
   }
 
-  enableZoomScroll(value) {
+  enableZoomScroll() {
     if (!this.viewer) return;
-
     const zoomScroll = this.viewer.get('zoomScroll');
-    zoomScroll.toggle(value);
+    zoomScroll.toggle(true);
+  }
+
+  disableZoomScroll() {
+    if (!this.viewer) return;
+    const zoomScroll = this.viewer.get('zoomScroll');
+    zoomScroll.toggle(false);
   }
 }

--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -16,6 +16,14 @@ export default class BpmnViewerComponent extends Component {
     await this.viewer.importXML(bpmnXml);
     this.viewer.get('canvas').zoom('fit-viewport');
     this.enableZoomScroll(false);
+
+    element.addEventListener('focus', () => {
+      this.enableZoomScroll(true);
+    });
+
+    element.addEventListener('blur', () => {
+      this.enableZoomScroll(false);
+    });
   }
 
   enableZoomScroll(value) {

--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -3,16 +3,25 @@ import { action } from '@ember/object';
 import NavigatedViewer from 'bpmn-js/lib/NavigatedViewer';
 
 export default class BpmnViewerComponent extends Component {
+  viewer = null;
+
   @action
   async setupViewer(element) {
     element.tabIndex = 0; // Make element focusable
-
-    const viewer = new NavigatedViewer({ container: element });
+    this.viewer = new NavigatedViewer({ container: element });
 
     const bpmnXml = this.args.bpmnXml;
-    if (bpmnXml) {
-      await viewer.importXML(bpmnXml);
-      viewer.get('canvas').zoom('fit-viewport');
-    }
+    if (!bpmnXml) return;
+
+    await this.viewer.importXML(bpmnXml);
+    this.viewer.get('canvas').zoom('fit-viewport');
+    this.enableZoomScroll(false);
+  }
+
+  enableZoomScroll(value) {
+    if (!this.viewer) return;
+
+    const zoomScroll = this.viewer.get('zoomScroll');
+    zoomScroll.toggle(value);
   }
 }

--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -5,6 +5,8 @@ import NavigatedViewer from 'bpmn-js/lib/NavigatedViewer';
 export default class BpmnViewerComponent extends Component {
   @action
   async setupViewer(element) {
+    element.tabIndex = 0; // Make element focusable
+
     const viewer = new NavigatedViewer({ container: element });
 
     const bpmnXml = this.args.bpmnXml;

--- a/app/styles/components/_bpmn-viewer.scss
+++ b/app/styles/components/_bpmn-viewer.scss
@@ -5,6 +5,11 @@
   border-radius: $au-radius;
   overflow: hidden;
   background-color: var(--au-gray-100);
+  outline: none;
+}
+
+.bpmn-container:focus {
+  outline: 0.2rem solid var(--au-blue-700);
 }
 
 .bjs-powered-by {


### PR DESCRIPTION
OPH-241

A user can now scroll through a process page without the bpmn diagram being targeted by this scrolling. However, the diagram's scrolling behaviour gets activated when the diagram gets clicked on (focus state).