### PR TITLE
Download bpmn files as images

### DIFF
--- a/app/controllers/bpmn-files/bpmn-file/index.js
+++ b/app/controllers/bpmn-files/bpmn-file/index.js
@@ -99,6 +99,11 @@ export default class BpmnUploadsBpmnFileIndexController extends Controller {
   }
 
   @action
+  downloadFile(type) {
+    console.log('Download', type);
+  }
+
+  @action
   openReplaceModal() {
     this.newFileId = undefined;
     this.replaceModalOpened = true;

--- a/app/controllers/bpmn-files/bpmn-file/index.js
+++ b/app/controllers/bpmn-files/bpmn-file/index.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { task, dropTask } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import generateBpmnDownloadUrl from 'frontend-openproceshuis/utils/bpmn-download-url';
+import downloadFileByUrl from 'frontend-openproceshuis/utils/file-downloader';
 
 export default class BpmnUploadsBpmnFileIndexController extends Controller {
   queryParams = ['page', 'size', 'sort'];
@@ -124,26 +125,12 @@ export default class BpmnUploadsBpmnFileIndexController extends Controller {
 
   @action
   async downloadFile(downloadType) {
-    console.log('Download', downloadType);
-
     const url = generateBpmnDownloadUrl(this.metadata.id);
-    const response = await fetch(url, {
-      headers: {
-        Accept: downloadType.mime,
-      },
-    });
-    if (!response.ok) throw Error(response.status);
-
-    const blob = await response.blob();
-    const downloadUrl = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.style.display = 'none';
-    a.href = downloadUrl;
-    a.download = `${this.metadata.name}.${downloadType.extension}`;
-    document.body.appendChild(a);
-    a.click();
-    window.URL.revokeObjectURL(downloadUrl);
-    a.remove();
+    const headers = {
+      Accept: downloadType.mime,
+    };
+    const fileName = `${this.metadata.name}.${downloadType.extension}`;
+    await downloadFileByUrl(url, headers, fileName);
   }
 
   @action

--- a/app/controllers/bpmn-files/bpmn-file/index.js
+++ b/app/controllers/bpmn-files/bpmn-file/index.js
@@ -15,6 +15,7 @@ export default class BpmnUploadsBpmnFileIndexController extends Controller {
   @tracked page = 0;
   size = 20;
   @tracked sort = 'name';
+  @tracked downloadModalOpened = false;
   @tracked replaceModalOpened = false;
   @tracked edit = false;
   @tracked newFileId = undefined;
@@ -85,6 +86,16 @@ export default class BpmnUploadsBpmnFileIndexController extends Controller {
 
     // Triggers a refresh of the model
     this.page = null;
+  }
+
+  @action
+  openDownloadModal() {
+    this.downloadModalOpened = true;
+  }
+
+  @action
+  closeDownloadModal() {
+    this.downloadModalOpened = false;
   }
 
   @action

--- a/app/helpers/bpmn-download-url.js
+++ b/app/helpers/bpmn-download-url.js
@@ -1,6 +1,0 @@
-import { helper } from '@ember/component/helper';
-import generateBpmnDownloadUrl from 'frontend-openproceshuis/utils/bpmn-download-url';
-
-export default helper(function bpmnDownloadUrl([fileId, fileName]) {
-  return generateBpmnDownloadUrl(fileId, fileName);
-});

--- a/app/routes/bpmn-files/bpmn-file.js
+++ b/app/routes/bpmn-files/bpmn-file.js
@@ -38,7 +38,11 @@ export default class BpmnFilesBpmnFileRoute extends Route {
     const fileId = loadMetadataTaskInstance.value.id;
 
     const url = generateBpmnDownloadUrl(fileId);
-    const response = yield fetch(url);
+    const response = yield fetch(url, {
+      headers: {
+        Accept: 'text/xml',
+      },
+    });
     if (!response.ok) throw Error(response.status);
     return yield response.text();
   }

--- a/app/templates/bpmn-files/bpmn-file/index.hbs
+++ b/app/templates/bpmn-files/bpmn-file/index.hbs
@@ -307,23 +307,19 @@
       <p>Het geselecteerde BPMN-bestand is beschikbaar in verschillende
         formaten:</p>
       <AuButtonGroup class="au-u-flex au-u-flex--around">
-        <AuButton {{on "click" (fn this.downloadFile "text/xml")}}>Origineel
-          <span class="au-u-para-tiny au-u-regular">(.bpmn)</span></AuButton>
-        <AuButton
-          @skin="secondary"
-          {{on "click" (fn this.downloadFile "image/png")}}
-        >Afbeelding
-          <span class="au-u-para-tiny au-u-regular">(.png)</span></AuButton>
-        <AuButton
-          @skin="secondary"
-          {{on "click" (fn this.downloadFile "image/svg+xml")}}
-        >Vectorafbeelding
-          <span class="au-u-para-tiny au-u-regular">(.svg)</span></AuButton>
-        <AuButton
-          @skin="secondary"
-          {{on "click" (fn this.downloadFile "application/pdf")}}
-        >PDF
-          <span class="au-u-para-tiny au-u-regular">(.pdf)</span></AuButton>
+        {{#each this.downloadTypes as |downloadType|}}
+          <AuButton
+            @skin={{if
+              (eq downloadType.extension "bpmn")
+              "primary"
+              "secondary"
+            }}
+            {{on "click" (fn this.downloadFile downloadType)}}
+          >{{capitalize-first downloadType.label}}
+            <span
+              class="au-u-para-tiny au-u-regular"
+            >(.{{downloadType.extension}})</span></AuButton>
+        {{/each}}
       </AuButtonGroup>
     </div>
   </:body>

--- a/app/templates/bpmn-files/bpmn-file/index.hbs
+++ b/app/templates/bpmn-files/bpmn-file/index.hbs
@@ -307,13 +307,22 @@
       <p>Het geselecteerde BPMN-bestand is beschikbaar in verschillende
         formaten:</p>
       <AuButtonGroup class="au-u-flex au-u-flex--around">
-        <AuButton>Origineel
+        <AuButton {{on "click" (fn this.downloadFile "text/xml")}}>Origineel
           <span class="au-u-para-tiny au-u-regular">(.bpmn)</span></AuButton>
-        <AuButton @skin="secondary">Afbeelding
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.downloadFile "image/png")}}
+        >Afbeelding
           <span class="au-u-para-tiny au-u-regular">(.png)</span></AuButton>
-        <AuButton @skin="secondary">Vectorafbeelding
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.downloadFile "image/svg+xml")}}
+        >Vectorafbeelding
           <span class="au-u-para-tiny au-u-regular">(.svg)</span></AuButton>
-        <AuButton @skin="secondary">PDF
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.downloadFile "application/pdf")}}
+        >PDF
           <span class="au-u-para-tiny au-u-regular">(.pdf)</span></AuButton>
       </AuButtonGroup>
     </div>

--- a/app/templates/bpmn-files/bpmn-file/index.hbs
+++ b/app/templates/bpmn-files/bpmn-file/index.hbs
@@ -19,15 +19,9 @@
             {{on "click" this.openReplaceModal}}
           >Vervang BPMN-bestand</AuButton>
         {{/if}}
-        <a
-          class="au-c-button au-c-button--primary"
-          href="{{bpmn-download-url this.metadata.id this.metadata.name}}"
-          download="{{this.metadata.name}}"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <AuButton {{on "click" this.openDownloadModal}}>
           Download BPMN-bestand
-        </a>
+        </AuButton>
       </AuButtonGroup>
     </:action>
   </PageHeader>
@@ -298,6 +292,37 @@
       <AuButton
         @skin="naked"
         {{on "click" this.closeReplaceModal}}
+      >Annuleer</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>
+
+<AuModal
+  @modalOpen={{this.downloadModalOpened}}
+  @closeModal={{this.closeDownloadModal}}
+>
+  <:title>Download BPMN-bestand</:title>
+  <:body>
+    <div class="au-o-flow">
+      <p>Het geselecteerde BPMN-bestand is beschikbaar in verschillende
+        formaten:</p>
+      <AuButtonGroup class="au-u-flex au-u-flex--around">
+        <AuButton>Origineel
+          <span class="au-u-para-tiny au-u-regular">(.bpmn)</span></AuButton>
+        <AuButton @skin="secondary">Afbeelding
+          <span class="au-u-para-tiny au-u-regular">(.png)</span></AuButton>
+        <AuButton @skin="secondary">Vectorafbeelding
+          <span class="au-u-para-tiny au-u-regular">(.svg)</span></AuButton>
+        <AuButton @skin="secondary">PDF
+          <span class="au-u-para-tiny au-u-regular">(.pdf)</span></AuButton>
+      </AuButtonGroup>
+    </div>
+  </:body>
+  <:footer>
+    <AuButtonGroup class="au-u-flex--end">
+      <AuButton
+        @skin="naked"
+        {{on "click" this.closeDownloadModal}}
       >Annuleer</AuButton>
     </AuButtonGroup>
   </:footer>

--- a/app/utils/bpmn-download-url.js
+++ b/app/utils/bpmn-download-url.js
@@ -1,5 +1,3 @@
-export default function generateBpmnDownloadUrl(fileId, fileName) {
-  let url = `/files/${fileId}/download`;
-  if (fileName) url += `?name=${fileName}`;
-  return url;
+export default function generateBpmnDownloadUrl(fileId) {
+  return `/files/${fileId}/download`;
 }

--- a/app/utils/file-downloader.js
+++ b/app/utils/file-downloader.js
@@ -1,0 +1,15 @@
+export default async function downloadFileByUrl(url, headers, fileName) {
+  const response = await fetch(url, { headers });
+  if (!response.ok) throw Error(response.status);
+
+  const blob = await response.blob();
+  const downloadUrl = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.style.display = 'none';
+  a.href = downloadUrl;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  window.URL.revokeObjectURL(downloadUrl);
+  a.remove();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "ember-source": "~4.12.0",
         "ember-svg-jar": "^2.4.6",
         "ember-template-lint": "^5.7.2",
-        "ember-truth-helpers": "^3.0.0",
+        "ember-truth-helpers": "^3.1.1",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-ember": "^11.5.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ember-source": "~4.12.0",
     "ember-svg-jar": "^2.4.6",
     "ember-template-lint": "^5.7.2",
-    "ember-truth-helpers": "^3.0.0",
+    "ember-truth-helpers": "^3.1.1",
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",


### PR DESCRIPTION
OPH-241

Corresponding PRs:
- bpmn-service: https://github.com/lblod/bpmn-service/pull/4
- app-openproceshuis: https://github.com/lblod/app-openproceshuis/pull/14

BPMN files can be downloaded as .bpmn, .png, .svg and .pdf files.