### PR TITLE
Bug fixes

### DIFF
--- a/app/components/process-select-by-title.hbs
+++ b/app/components/process-select-by-title.hbs
@@ -5,13 +5,13 @@
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @searchMessage="Typ om te zoeken"
-    @searchField="name"
+    @searchField="title"
     @search={{perform this.loadProcessesTask}}
     @selected={{@selected}}
     @onChange={{@onChange}}
     @triggerId={{@id}}
-    as |name|
+    as |title|
   >
-    {{name}}
+    {{title}}
   </PowerSelect>
 </div>

--- a/app/components/process-select-by-title.js
+++ b/app/components/process-select-by-title.js
@@ -13,13 +13,13 @@ export default class ProcessSelectByTitleComponent extends Component {
     };
 
     if (searchParams.trim() !== '') {
-      query['filter[name]'] = searchParams;
+      query['filter[title]'] = searchParams;
     }
 
-    const result = yield this.store.query('file', query);
+    const result = yield this.store.query('process', query);
 
     if (result) {
-      return [...[searchParams], ...new Set(result.map((r) => r.name))];
+      return [...[searchParams], ...new Set(result.map((r) => r.title))];
     }
   }
 }

--- a/app/components/process-select-by-title.js
+++ b/app/components/process-select-by-title.js
@@ -1,12 +1,16 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
+import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessSelectByTitleComponent extends Component {
   @service store;
 
-  @restartableTask *loadBpmnFilesTask(searchParams = '') {
-    const query = {};
+  @restartableTask
+  *loadProcessesTask(searchParams = '') {
+    const query = {
+      'filter[:not:status]': ENV.resourceStates.archived,
+    };
 
     if (searchParams.trim() !== '') {
       query['filter[name]'] = searchParams;

--- a/app/components/process-select-by-title.js
+++ b/app/components/process-select-by-title.js
@@ -12,9 +12,9 @@ export default class ProcessSelectByTitleComponent extends Component {
       'filter[:not:status]': ENV.resourceStates.archived,
     };
 
-    if (searchParams.trim() !== '') {
-      query['filter[title]'] = searchParams;
-    }
+    if (searchParams.trim() !== '') query['filter[title]'] = searchParams;
+    if (this.args.publisher)
+      query['filter[publisher][id]'] = this.args.publisher; // FIXME: should be handled by backend instead of frontend
 
     const result = yield this.store.query('process', query);
 

--- a/app/components/process-step-select-by-name.js
+++ b/app/components/process-step-select-by-name.js
@@ -1,12 +1,21 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
+import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessStepSelectByNameComponent extends Component {
   @service store;
 
   @restartableTask *loadProcessStepsTask(searchParams = '') {
-    const query = {};
+    const query = {
+      'filter[:has:bpmn-process]': true,
+      'filter[bpmn-process][:has:bpmn-file]': true,
+      'filter[bpmn-process][bpmn-file][:not:status]':
+        ENV.resourceStates.archived,
+      'filter[bpmn-process][bpmn-file][:has:processes]': true,
+      'filter[bpmn-process][bpmn-file][processes][:not:status]':
+        ENV.resourceStates.archived,
+    };
 
     if (searchParams.trim() !== '') {
       query['filter[name]'] = searchParams;

--- a/app/components/process-step-select-by-name.js
+++ b/app/components/process-step-select-by-name.js
@@ -6,7 +6,8 @@ import ENV from 'frontend-openproceshuis/config/environment';
 export default class ProcessStepSelectByNameComponent extends Component {
   @service store;
 
-  @restartableTask *loadProcessStepsTask(searchParams = '') {
+  @restartableTask
+  *loadProcessStepsTask(searchParams = '') {
     const query = {
       'filter[:has:bpmn-process]': true,
       'filter[bpmn-process][:has:bpmn-file]': true,

--- a/app/components/process-step-select-by-type.js
+++ b/app/components/process-step-select-by-type.js
@@ -18,11 +18,17 @@ export default class ProcessStepSelectByTypeComponent extends Component {
 
   @restartableTask
   *loadProcessStepTypesTask() {
-    const result = yield this.store.query('bpmn-element-type', {
+    const query = {
+      page: {
+        number: 0,
+        size: 45,
+      },
       sort: ':no-case:label',
       'filter[scheme]':
         'http://lblod.data.gift/concept-schemes/d4259f0b-6d6e-4a46-b9e1-114b774e0f1e',
-    });
+    };
+
+    const result = yield this.store.query('bpmn-element-type', query);
     this.types = result;
 
     if (this.args.selected) {

--- a/app/components/process-step-select-by-type.js
+++ b/app/components/process-step-select-by-type.js
@@ -20,6 +20,8 @@ export default class ProcessStepSelectByTypeComponent extends Component {
   *loadProcessStepTypesTask() {
     const result = yield this.store.query('bpmn-element-type', {
       sort: ':no-case:label',
+      'filter[scheme]':
+        'http://lblod.data.gift/concept-schemes/d4259f0b-6d6e-4a46-b9e1-114b774e0f1e',
     });
     this.types = result;
 

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -44,7 +44,8 @@ export default class ProcessesIndexRoute extends Route {
     }
 
     if (params.title) {
-      query['filter[title]'] = params.title;
+      query['filter[:or:][title]'] = params.title;
+      query['filter[:or:][description]'] = params.title;
     }
     query['filter[:not:status]'] = ENV.resourceStates.archived;
 

--- a/app/templates/shared-processes/index.hbs
+++ b/app/templates/shared-processes/index.hbs
@@ -12,6 +12,7 @@
               @id="filter-title"
               @selected={{this.title}}
               @onChange={{this.setTitle}}
+              @publisher={{this.currentSession.group.id}}
               class="grow"
             />
           </div>


### PR DESCRIPTION
OPH-286

Corresponding PR:
app-openproceshuis: https://github.com/lblod/app-openproceshuis/pull/22

These bugs were fixed:
- The process step types dropdown filter showed incorrect options
- The process step types dropdown filter didn't show all 45 process step types
- None of the dropdown filters filtered out archived processes/process steps
- The processes dropdown filter didn't work anymore after a previous commit
- The processes filter didn't allow for searching on description
- The process filter on the shared processes page didn't filter out processes published by another organization