### PR TITLE
Disallow description containing only whitespaces

### DIFF
--- a/app/models/process.js
+++ b/app/models/process.js
@@ -1,6 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { modelValidator } from 'ember-model-validator';
 import ENV from 'frontend-openproceshuis/config/environment';
+import { isOnlyWhitespace } from 'frontend-openproceshuis/utils/custom-validators';
 
 @modelValidator
 export default class ProcessModel extends Model {
@@ -23,11 +24,7 @@ export default class ProcessModel extends Model {
       length: {
         maximum: 3000,
       },
-      custom: (_, value) => {
-        if (!value) return true;
-        if (value.trim() !== '') return true;
-        return false;
-      },
+      custom: (_, value) => !isOnlyWhitespace(value),
     },
   };
 

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -23,6 +23,11 @@ export default class ProcessModel extends Model {
       length: {
         maximum: 3000,
       },
+      custom: (_, value) => {
+        if (!value) return true;
+        if (value.trim() !== '') return true;
+        return false;
+      },
     },
   };
 

--- a/app/utils/custom-validators.js
+++ b/app/utils/custom-validators.js
@@ -1,0 +1,5 @@
+export function isOnlyWhitespace(str) {
+  if (!str) return false; // undefined, null or ''
+  if (str.trim() !== '') return false; // non-whitespace characters present
+  return true;
+}


### PR DESCRIPTION
OPH-306

Users shouldn't be able to upload any data field containing only whitespaces:
- Process title: was already present since it cannot be empty/blank
- Process description: fixed with this PR --> can be empty or filled, but can't be only whitespaces