### PR TITLE
Sort and paginate process's verions and attachments tables

### DIFF
--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -30,7 +30,7 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked sortProcessSteps = 'name';
   @tracked pageVersions = 0;
   sizeVersions = 10;
-  @tracked sortVersions = 'created';
+  @tracked sortVersions = '-created';
   @tracked pageAttachments = 0;
   sizeAttachments = 10;
   @tracked sortAttachments = 'name';

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -8,15 +8,15 @@ import removeFileNameExtension from 'frontend-openproceshuis/utils/file-extensio
 
 export default class ProcessesProcessIndexController extends Controller {
   queryParams = [
-    { pageProcessSteps: 'processtappen-pagina' },
-    { sizeProcessSteps: 'processtappen-aantal' },
-    { sortProcessSteps: 'processtappen-sorteer' },
-    { pageVersions: 'versies-pagina' },
-    { sizeVersions: 'versies-aantal' },
-    { sortVersions: 'versies-sorteer' },
-    { pageAttachments: 'bijlagen-pagina' },
-    { sizeAttachments: 'bijlagen-aantal' },
-    { sortAttachments: 'bijlagen-sorteer' },
+    { pageProcessSteps: 'process-steps-page' },
+    { sizeProcessSteps: 'process-steps-size' },
+    { sortProcessSteps: 'process-steps-sort' },
+    { pageVersions: 'versions-page' },
+    { sizeVersions: 'versions-size' },
+    { sortVersions: 'versions-sort' },
+    { pageAttachments: 'attachments-page' },
+    { sizeAttachments: 'attachments-size' },
+    { sortAttachments: 'attachments-sort' },
   ];
 
   @service store;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -7,7 +7,17 @@ import downloadFileByUrl from 'frontend-openproceshuis/utils/file-downloader';
 import removeFileNameExtension from 'frontend-openproceshuis/utils/file-extension-remover';
 
 export default class ProcessesProcessIndexController extends Controller {
-  queryParams = ['page', 'size', 'sort'];
+  queryParams = [
+    { pageProcessSteps: 'processtappen-pagina' },
+    { sizeProcessSteps: 'processtappen-aantal' },
+    { sortProcessSteps: 'processtappen-sorteer' },
+    { pageVersions: 'versies-pagina' },
+    { sizeVersions: 'versies-aantal' },
+    { sortVersions: 'versies-sorteer' },
+    { pageAttachments: 'bijlagen-pagina' },
+    { sizeAttachments: 'bijlagen-aantal' },
+    { sortAttachments: 'bijlagen-sorteer' },
+  ];
 
   @service store;
   @service router;
@@ -15,9 +25,9 @@ export default class ProcessesProcessIndexController extends Controller {
   @service toaster;
   @service plausible;
 
-  @tracked page = 0;
-  size = 20;
-  @tracked sort = 'name';
+  @tracked pageProcessSteps = 0;
+  sizeProcessSteps = 20;
+  @tracked sortProcessSteps = 'name';
   @tracked downloadModalOpened = false;
   @tracked replaceModalOpened = false;
   @tracked addModalOpened = false;
@@ -157,11 +167,11 @@ export default class ProcessesProcessIndexController extends Controller {
 
   @action
   resetFilters() {
-    this.page = 0;
-    this.sort = 'name';
+    this.pageProcessSteps = 0;
+    this.sortProcessSteps = 'name';
 
     // Triggers a refresh of the model
-    this.page = null;
+    this.pageProcessSteps = null;
   }
 
   @action
@@ -256,7 +266,7 @@ export default class ProcessesProcessIndexController extends Controller {
     this.replaceModalOpened = false;
     this.addModalOpened = false;
 
-    this.page = 0;
+    this.pageProcessSteps = 0;
     this.router.refresh();
   }
 

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -28,6 +28,13 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked pageProcessSteps = 0;
   sizeProcessSteps = 20;
   @tracked sortProcessSteps = 'name';
+  @tracked pageVersions = 0;
+  sizeVersions = 10;
+  @tracked sortVersions = 'created';
+  @tracked pageAttachments = 0;
+  sizeAttachments = 10;
+  @tracked sortAttachments = 'name';
+
   @tracked downloadModalOpened = false;
   @tracked replaceModalOpened = false;
   @tracked addModalOpened = false;
@@ -163,15 +170,6 @@ export default class ProcessesProcessIndexController extends Controller {
       this.process?.publisher &&
       this.process.publisher.id === this.currentSession.group.id
     );
-  }
-
-  @action
-  resetFilters() {
-    this.pageProcessSteps = 0;
-    this.sortProcessSteps = 'name';
-
-    // Triggers a refresh of the model
-    this.pageProcessSteps = null;
   }
 
   @action

--- a/app/routes/processes/process.js
+++ b/app/routes/processes/process.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { keepLatestTask, waitForProperty } from 'ember-concurrency';
+import { keepLatestTask } from 'ember-concurrency';
 import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessesProcessRoute extends Route {
@@ -8,26 +8,11 @@ export default class ProcessesProcessRoute extends Route {
   @service plausible;
 
   async model() {
-    const loadProcessTaskInstance = this.loadProcessTask.perform();
-    const loadedProcess = this.loadProcessTask.lastSuccesful?.value;
-
-    const loadBpmnFilesTaskInstance = this.loadBpmnFilesTask.perform(
-      loadProcessTaskInstance
-    );
-    const loadedBpmnFiles = this.loadBpmnFilesTask.lastSuccessful?.value;
-
-    const loadLatestBpmnFileTaskInstance =
-      this.loadLatestBpmnFileTask.perform();
-    const loadedLatestBpmnFile =
-      this.loadLatestBpmnFileTask.lastSuccesful?.value;
-
     return {
-      loadProcessTaskInstance,
-      loadedProcess,
-      loadBpmnFilesTaskInstance,
-      loadedBpmnFiles,
-      loadLatestBpmnFileTaskInstance,
-      loadedLatestBpmnFile,
+      loadProcessTaskInstance: this.loadProcessTask.perform(),
+      loadedProcess: this.loadProcessTask.lastSuccesful?.value,
+      loadLatestBpmnFileTaskInstance: this.loadLatestBpmnFileTask.perform(),
+      loadedLatestBpmnFile: this.loadLatestBpmnFileTask.lastSuccesful?.value,
     };
   }
 
@@ -51,16 +36,6 @@ export default class ProcessesProcessRoute extends Route {
     });
 
     return process;
-  }
-
-  @keepLatestTask({ cancelOn: 'deactivate' })
-  *loadBpmnFilesTask(loadProcessTaskInstance) {
-    yield waitForProperty(loadProcessTaskInstance, 'isFinished');
-
-    const files = loadProcessTaskInstance.value?.files;
-    return files
-      ?.filter((file) => file.isBpmnFile)
-      .sort((fileA, fileB) => fileB.created - fileA.created); // FIXME: should be handled by backend
   }
 
   @keepLatestTask({ cancelOn: 'deactivate' })

--- a/app/routes/processes/process.js
+++ b/app/routes/processes/process.js
@@ -16,11 +16,6 @@ export default class ProcessesProcessRoute extends Route {
     );
     const loadedBpmnFiles = this.loadBpmnFilesTask.lastSuccessful?.value;
 
-    const loadAttachmentsTaskInstance = this.loadAttachmentsTask.perform(
-      loadProcessTaskInstance
-    );
-    const loadedAttachments = this.loadAttachmentsTask.lastSuccessful?.value;
-
     const loadLatestBpmnFileTaskInstance = this.loadLatestBpmnFileTask.perform(
       loadBpmnFilesTaskInstance
     );
@@ -32,8 +27,6 @@ export default class ProcessesProcessRoute extends Route {
       loadedProcess,
       loadBpmnFilesTaskInstance,
       loadedBpmnFiles,
-      loadAttachmentsTaskInstance,
-      loadedAttachments,
       loadLatestBpmnFileTaskInstance,
       loadedLatestBpmnFile,
     };
@@ -69,16 +62,6 @@ export default class ProcessesProcessRoute extends Route {
     return files
       ?.filter((file) => file.isBpmnFile)
       .sort((fileA, fileB) => fileB.created - fileA.created); // FIXME: should be handled by backend
-  }
-
-  @keepLatestTask({ cancelOn: 'deactivate' })
-  *loadAttachmentsTask(loadProcessTaskInstance) {
-    yield waitForProperty(loadProcessTaskInstance, 'isFinished');
-
-    const files = loadProcessTaskInstance.value?.files;
-    return files
-      ?.filter((file) => !file.isBpmnFile)
-      .sort((fileA, fileB) => fileA.name.localeCompare(fileB.name)); // FIXME: should be handled by backend
   }
 
   @keepLatestTask({ cancelOn: 'deactivate' })

--- a/app/routes/processes/process.js
+++ b/app/routes/processes/process.js
@@ -42,6 +42,7 @@ export default class ProcessesProcessRoute extends Route {
   *loadLatestBpmnFileTask() {
     const { id: processId } = this.paramsFor('processes.process');
     const query = {
+      reload: true,
       page: {
         number: 0,
         size: 1,

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -6,8 +6,15 @@ export default class ProcessesProcessIndexRoute extends Route {
   @service store;
 
   queryParams = {
-    page: { refreshModel: true },
-    sort: { refreshModel: true },
+    pageProcessSteps: { as: 'processtappen-pagina', refreshModel: true },
+    sizeProcessSteps: { as: 'processtappen-aantal', refreshModel: true },
+    sortProcessSteps: { as: 'processtappen-sorteer', refreshModel: true },
+    pageVersions: { as: 'versies-pagina', refreshModel: true },
+    sizeVersions: { as: 'versies-aantal', refreshModel: true },
+    sortVersions: { as: 'versies-sorteer', refreshModel: true },
+    pageAttachments: { as: 'bijlagen-pagina', refreshModel: true },
+    sizeAttachments: { as: 'bijlagen-aantal', refreshModel: true },
+    sortAttachments: { as: 'bijlagen-sorteer', refreshModel: true },
   };
 
   async model() {
@@ -49,18 +56,20 @@ export default class ProcessesProcessIndexRoute extends Route {
 
     let query = {
       page: {
-        number: params.page,
-        size: params.size,
+        number: params.pageProcessSteps,
+        size: params.sizeProcessSteps,
       },
       include: 'type',
       'filter[:has:name]': true,
       'filter[bpmn-process][bpmn-file][id]': latestBpmnFileId,
     };
 
-    if (params.sort) {
-      const isDescending = params.sort.startsWith('-');
+    if (params.sortProcessSteps) {
+      const isDescending = params.sortProcessSteps.startsWith('-');
 
-      let fieldName = isDescending ? params.sort.substring(1) : params.sort;
+      let fieldName = isDescending
+        ? params.sortProcessSteps.substring(1)
+        : params.sortProcessSteps;
       if (fieldName === 'type') fieldName = 'type.label';
 
       let sortValue = `:no-case:${fieldName}`;

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -83,6 +83,7 @@ export default class ProcessesProcessIndexRoute extends Route {
     const params = this.paramsFor('processes.process.index');
 
     const query = {
+      reload: true,
       page: {
         number: params.pageVersions,
         size: params.sizeVersions,
@@ -113,6 +114,7 @@ export default class ProcessesProcessIndexRoute extends Route {
     const params = this.paramsFor('processes.process.index');
 
     const query = {
+      reload: true,
       page: {
         number: params.pageAttachments,
         size: params.sizeAttachments,

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -6,15 +6,15 @@ export default class ProcessesProcessIndexRoute extends Route {
   @service store;
 
   queryParams = {
-    pageProcessSteps: { as: 'processtappen-pagina', refreshModel: true },
-    sizeProcessSteps: { as: 'processtappen-aantal', refreshModel: true },
-    sortProcessSteps: { as: 'processtappen-sorteer', refreshModel: true },
-    pageVersions: { as: 'versies-pagina', refreshModel: true },
-    sizeVersions: { as: 'versies-aantal', refreshModel: true },
-    sortVersions: { as: 'versies-sorteer', refreshModel: true },
-    pageAttachments: { as: 'bijlagen-pagina', refreshModel: true },
-    sizeAttachments: { as: 'bijlagen-aantal', refreshModel: true },
-    sortAttachments: { as: 'bijlagen-sorteer', refreshModel: true },
+    pageProcessSteps: { as: 'process-steps-page', refreshModel: true },
+    sizeProcessSteps: { as: 'process-steps-size', refreshModel: true },
+    sortProcessSteps: { as: 'process-steps-sort', refreshModel: true },
+    pageVersions: { as: 'versions-page', refreshModel: true },
+    sizeVersions: { as: 'versions-size', refreshModel: true },
+    sortVersions: { as: 'versions-sort', refreshModel: true },
+    pageAttachments: { as: 'attachments-page', refreshModel: true },
+    sizeAttachments: { as: 'attachments-size', refreshModel: true },
+    sortAttachments: { as: 'attachments-sort', refreshModel: true },
   };
 
   async model() {

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -121,7 +121,23 @@ export default class ProcessesProcessIndexRoute extends Route {
       'filter[:not:extension]': 'bpmn',
     };
 
-    if (params.sortAttachments) query.sort = params.sortAttachments;
+    if (params.sortAttachments) {
+      const isDescending = params.sortAttachments.startsWith('-');
+
+      let sortValue = isDescending
+        ? params.sortAttachments.substring(1)
+        : params.sortAttachments;
+
+      if (
+        sortValue === 'name' ||
+        sortValue === 'extension' ||
+        sortValue === 'format'
+      )
+        sortValue = `:no-case:${sortValue}`;
+      if (isDescending) sortValue = `-${sortValue}`;
+
+      query.sort = sortValue;
+    }
 
     return yield this.store.query('file', query);
   }

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -263,20 +263,20 @@
           <AuDataTable
             @content={{this.processSteps}}
             @isLoading={{this.processStepsBatchIsLoading}}
-            @page={{this.page}}
-            @size={{this.size}}
+            @page={{this.pageProcessSteps}}
+            @size={{this.sizeProcessSteps}}
             as |t|
           >
             <t.content class="au-c-data-table__table--small" as |c|>
               <c.header>
                 <AuDataTableThSortable
                   @field="name"
-                  @currentSorting={{this.sort}}
+                  @currentSorting={{this.sortProcessSteps}}
                   @label="Naam"
                 />
                 <AuDataTableThSortable
                   @field="type"
-                  @currentSorting={{this.sort}}
+                  @currentSorting={{this.sortProcessSteps}}
                   @label="Type"
                 />
               </c.header>

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -320,13 +320,27 @@
         <AuDataTable
           @content={{this.bpmnFiles}}
           @isLoading={{this.bpmnFilesAreLoading}}
+          @page={{this.pageVersions}}
+          @size={{this.sizeVersions}}
           as |t|
         >
           <t.content class="au-c-data-table__table--small" as |c|>
             <c.header>
-              <th>Toegevoegd op</th>
-              <th>Bestandsnaam</th>
-              <th>Grootte</th>
+              <AuDataTableThSortable
+                @field="created"
+                @currentSorting={{this.sortVersions}}
+                @label="Toegevoegd op"
+              />
+              <AuDataTableThSortable
+                @field="name"
+                @currentSorting={{this.sortVersions}}
+                @label="Bestandsnaam"
+              />
+              <AuDataTableThSortable
+                @field="size"
+                @currentSorting={{this.sortVersions}}
+                @label="Grootte"
+              />
               <th></th>
             </c.header>
             {{#if this.bpmnFilesHaveErrored}}
@@ -393,15 +407,37 @@
         <AuDataTable
           @content={{this.attachments}}
           @isLoading={{this.attachmentsAreLoading}}
+          @page={{this.pageAttachments}}
+          @size={{this.sizeAttachments}}
           as |t|
         >
           <t.content class="au-c-data-table__table--small" as |c|>
             <c.header>
-              <th>Bestandsnaam</th>
-              <th>Grootte</th>
-              <th>Extensie</th>
-              <th>Formaat</th>
-              <th>Toegevoegd op</th>
+              <AuDataTableThSortable
+                @field="name"
+                @currentSorting={{this.sortAttachments}}
+                @label="Bestandsnaam"
+              />
+              <AuDataTableThSortable
+                @field="size"
+                @currentSorting={{this.sortAttachments}}
+                @label="Grootte"
+              />
+              <AuDataTableThSortable
+                @field="extension"
+                @currentSorting={{this.sortAttachments}}
+                @label="Extensie"
+              />
+              <AuDataTableThSortable
+                @field="format"
+                @currentSorting={{this.sortAttachments}}
+                @label="Formaat"
+              />
+              <AuDataTableThSortable
+                @field="created"
+                @currentSorting={{this.sortAttachments}}
+                @label="Toegevoegd op"
+              />
               <th></th>
             </c.header>
             {{#if this.attachmentsHaveErrored}}


### PR DESCRIPTION
OPH-308

Changes:
- process route has page, size and sort query parameters for every table (process steps, bpmn file versions and attachemnts)
- bpmn file verions and attachemnts are queried seperately instead of being part of one large 'process' query
- bpmn file verions and attachments tables on process page allow paginating and sorting