### PR TITLE
Fetch process steps on extraction job completion

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -1,0 +1,10 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class JobModel extends Model {
+  @attr('string') status;
+  @attr('iso-date') created;
+  @attr('iso-date') modified;
+  @attr('string') resource;
+  @attr('string') operation;
+  @belongsTo('group', { inverse: null, async: false }) creator;
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -25,6 +25,14 @@ module.exports = function (environment) {
       archived: 'http://lblod.data.gift/concepts/concept-status/gearchiveerd',
     },
 
+    jobStates: {
+      scheduled: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      busy: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
+      success: 'http://redpencil.data.gift/id/concept/JobStatus/success',
+      failed: 'http://redpencil.data.gift/id/concept/JobStatus/failed',
+      canceled: 'http://redpencil.data.gift/id/concept/JobStatus/canceled',
+    },
+
     yasgui: {
       defaultQuery: '{{YASGUI_DEFAULT_QUERY}}',
       extraPrefixes: '{{YASGUI_EXTRA_PREFIXES}}',


### PR DESCRIPTION
OPH-320
OPH-321

Corresponding PRs:
- bpmn service
- app

On process creation (or BPMN file replacement) show process immediately after file upload and poll extraction job status. Once status indicates success, fetch and display process steps.