### PR TITLE
Add email property to process

### DIFF
--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -323,6 +323,13 @@ export default class ProcessesProcessIndexController extends Controller {
     this.validateForm();
   }
 
+  @action
+  setProcessEmail(event) {
+    if (!this.process) return;
+    this.process.email = event.target.value;
+    this.validateForm();
+  }
+
   validateForm() {
     this.formIsValid =
       this.process?.validate() && this.process?.hasDirtyAttributes;

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -1,7 +1,10 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { modelValidator } from 'ember-model-validator';
 import ENV from 'frontend-openproceshuis/config/environment';
-import { isOnlyWhitespace } from 'frontend-openproceshuis/utils/custom-validators';
+import {
+  isOnlyWhitespace,
+  isEmptyOrEmail,
+} from 'frontend-openproceshuis/utils/custom-validators';
 
 @modelValidator
 export default class ProcessModel extends Model {
@@ -26,6 +29,9 @@ export default class ProcessModel extends Model {
         maximum: 3000,
       },
       custom: (_, value) => !isOnlyWhitespace(value),
+    },
+    email: {
+      custom: (_, value) => isEmptyOrEmail(value),
     },
   };
 

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -7,6 +7,7 @@ import { isOnlyWhitespace } from 'frontend-openproceshuis/utils/custom-validator
 export default class ProcessModel extends Model {
   @attr('string') title;
   @attr('string') description;
+  @attr('string') email;
   @attr('iso-date') created;
   @attr('iso-date') modified;
   @attr('string') status;

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -47,6 +47,16 @@
                   />
                 </:content>
               </Item>
+              <Item>
+                <:label>Contact proces</:label>
+                <:content>
+                  <AuInput
+                    value={{this.process.email}}
+                    {{on "input" this.setProcessEmail}}
+                    @width="block"
+                  />
+                </:content>
+              </Item>
             </:left>
             <:right as |Item|>
               <Item>
@@ -125,7 +135,12 @@
                 {{or this.process.description "/"}}
               </:content>
             </Item>
-
+            <Item>
+              <:label>Contact proces</:label>
+              <:content>
+                {{or this.process.email "/"}}
+              </:content>
+            </Item>
           </:left>
           <:right as |Item|>
             <Item>
@@ -134,7 +149,6 @@
                 {{this.process.publisher.name}}
               </:content>
             </Item>
-
             <Item>
               <:label>Contact</:label>
               <:content>

--- a/app/utils/custom-validators.js
+++ b/app/utils/custom-validators.js
@@ -3,3 +3,14 @@ export function isOnlyWhitespace(str) {
   if (str.trim() !== '') return false; // non-whitespace characters present
   return true;
 }
+
+export function isEmptyOrEmail(str) {
+  if (!str) return true; // undefined, null or ''
+  if (
+    String(str).match(
+      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/ // email format
+    ) !== null
+  )
+    return true;
+  return false;
+}


### PR DESCRIPTION
OPH-323

Corresponding PR backend: https://github.com/lblod/app-openproceshuis/pull/26

Next to a Bestuur having an email address, a process can also have specific email address. By default, it is empty, but users can choose to fill it in (not required).