### PR TITLE
Download BPMN files in different formats, generated client-side

### DIFF
--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -29,6 +29,12 @@ export default class BpmnViewerComponent extends Component {
     element.addEventListener('blur', () => {
       this.disableZoomScroll();
     });
+
+    if (this.args.onBpmnLoaded) this.args.onBpmnLoaded(bpmnXml);
+    if (this.args.onSvgLoaded) {
+      const { svg } = await this.viewer.saveSVG();
+      this.args.onSvgLoaded(svg);
+    }
   }
 
   @restartableTask

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -5,6 +5,10 @@ import { task, dropTask } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import downloadFileByUrl from 'frontend-openproceshuis/utils/file-downloader';
 import removeFileNameExtension from 'frontend-openproceshuis/utils/file-extension-remover';
+import {
+  convertSvgToPdf,
+  convertSvgToPng,
+} from 'frontend-openproceshuis/utils/svg-convertors';
 import FileSaver from 'file-saver';
 
 export default class ProcessesProcessIndexController extends Controller {
@@ -186,7 +190,7 @@ export default class ProcessesProcessIndexController extends Controller {
   }
 
   @action
-  downloadLatestBpmnFile(targetExtension) {
+  async downloadLatestBpmnFile(targetExtension) {
     if (!this.latestBpmnFile) return;
 
     let blob = undefined;
@@ -198,6 +202,10 @@ export default class ProcessesProcessIndexController extends Controller {
       blob = new Blob([this.latestBpmnFileAsSvg], {
         type: 'image/svg+xml;charset=utf-8',
       });
+    } else if (targetExtension === 'pdf' && this.latestBpmnFileAsSvg) {
+      blob = await convertSvgToPdf(this.latestBpmnFileAsSvg);
+    } else if (targetExtension === 'png' && this.latestBpmnFileAsSvg) {
+      blob = await convertSvgToPng(this.latestBpmnFileAsSvg);
     }
     if (!blob) return;
 

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -189,8 +189,8 @@ export default class ProcessesProcessIndexController extends Controller {
     this.trackDownloadFileEvent(file.id, file.name, file.extension);
   }
 
-  @action
-  async downloadLatestBpmnFile(targetExtension) {
+  @dropTask
+  *downloadLatestBpmnFile(targetExtension) {
     if (!this.latestBpmnFile) return;
 
     let blob = undefined;
@@ -203,9 +203,9 @@ export default class ProcessesProcessIndexController extends Controller {
         type: 'image/svg+xml;charset=utf-8',
       });
     } else if (targetExtension === 'pdf' && this.latestBpmnFileAsSvg) {
-      blob = await convertSvgToPdf(this.latestBpmnFileAsSvg);
+      blob = yield convertSvgToPdf(this.latestBpmnFileAsSvg);
     } else if (targetExtension === 'png' && this.latestBpmnFileAsSvg) {
-      blob = await convertSvgToPng(this.latestBpmnFileAsSvg);
+      blob = yield convertSvgToPng(this.latestBpmnFileAsSvg);
     }
     if (!blob) return;
 

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -43,10 +43,11 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked downloadModalOpened = false;
   @tracked replaceModalOpened = false;
   @tracked addModalOpened = false;
+  @tracked deleteModalOpened = false;
+
   @tracked edit = false;
   @tracked formIsValid = false;
   @tracked fileToDelete = undefined;
-  @tracked deleteModalOpened = false;
 
   latestBpmnFileAsBpmn = undefined;
   latestBpmnFileAsSvg = undefined;
@@ -320,8 +321,6 @@ export default class ProcessesProcessIndexController extends Controller {
   @action
   resetModel() {
     this.process?.rollbackAttributes();
-    this.replaceModalOpened = false;
-    this.addModalOpened = false;
     this.edit = false;
   }
 
@@ -380,5 +379,17 @@ export default class ProcessesProcessIndexController extends Controller {
 
     this.closeDeleteModal();
     this.router.refresh();
+  }
+
+  reset() {
+    this.resetModel();
+
+    this.downloadModalOpened = false;
+    this.replaceModalOpened = false;
+    this.addModalOpened = false;
+    this.deleteModalOpened = false;
+
+    this.latestBpmnFileAsBpmn = undefined;
+    this.latestBpmnFileAsSvg = undefined;
   }
 }

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -43,25 +43,6 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked fileToDelete = undefined;
   @tracked deleteModalOpened = false;
 
-  downloadTypes = [
-    {
-      extension: 'bpmn',
-      label: 'origineel',
-    },
-    {
-      extension: 'png',
-      label: 'afbeelding',
-    },
-    {
-      extension: 'svg',
-      label: 'vectorafbeelding',
-    },
-    {
-      extension: 'pdf',
-      label: 'PDF',
-    },
-  ];
-
   // Process
 
   get process() {
@@ -185,7 +166,13 @@ export default class ProcessesProcessIndexController extends Controller {
   }
 
   @action
-  async downloadLatestBpmnFile(targetExtension) {
+  async downloadFile(file) {
+    await downloadFileByUrl(file.id, file.name, file.extension);
+    this.trackDownloadFileEvent(file.id, file.name, file.extension);
+  }
+
+  @action
+  downloadLatestBpmnFile(targetExtension) {
     if (!this.latestBpmnFile) return;
 
     const fileName = `${removeFileNameExtension(
@@ -193,22 +180,17 @@ export default class ProcessesProcessIndexController extends Controller {
       this.latestBpmnFile.extension
     )}.${targetExtension}`;
 
-    await this.downloadFile(
+    console.log('Download', fileName);
+
+    this.trackDownloadFileEvent(
       this.latestBpmnFile.id,
-      fileName,
-      this.latestBpmnFile.extension,
+      this.latestBpmnFile.name,
+      'bpmn',
       targetExtension
     );
   }
 
-  @action
-  async downloadOriginalFile(file) {
-    await this.downloadFile(file.id, file.name, file.extension);
-  }
-
-  async downloadFile(fileId, fileName, fileExtension, targetExtension) {
-    await downloadFileByUrl(fileId, fileName, fileExtension, targetExtension);
-
+  trackDownloadFileEvent(fileId, fileName, fileExtension, targetExtension) {
     this.plausible.trackEvent('Download bestand', {
       'Bestand-ID': fileId,
       Bestandsnaam: fileName,

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -189,25 +189,23 @@ export default class ProcessesProcessIndexController extends Controller {
   downloadLatestBpmnFile(targetExtension) {
     if (!this.latestBpmnFile) return;
 
-    let result = undefined;
-    let type = undefined;
-
+    let blob = undefined;
     if (targetExtension === 'bpmn' && this.latestBpmnFileAsBpmn) {
-      result = this.latestBpmnFileAsBpmn;
-      type = 'application/xml;charset=utf-8';
+      blob = new Blob([this.latestBpmnFileAsBpmn], {
+        type: 'application/xml;charset=utf-8',
+      });
     } else if (targetExtension === 'svg' && this.latestBpmnFileAsSvg) {
-      result = this.latestBpmnFileAsSvg;
-      type = 'image/svg+xml;charset=utf-8';
+      blob = new Blob([this.latestBpmnFileAsSvg], {
+        type: 'image/svg+xml;charset=utf-8',
+      });
     }
-
-    if (!result) return;
+    if (!blob) return;
 
     const fileName = `${removeFileNameExtension(
       this.latestBpmnFile.name,
       this.latestBpmnFile.extension
     )}.${targetExtension}`;
 
-    const blob = new Blob([result], { type: type });
     FileSaver.saveAs(blob, fileName);
 
     this.trackDownloadFileEvent(

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -170,6 +170,6 @@ export default class ProcessesProcessIndexRoute extends Route {
 
   resetController(controller) {
     super.resetController(...arguments);
-    controller.resetModel();
+    controller.reset();
   }
 }

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -562,28 +562,28 @@
       <AuButtonGroup class="au-u-flex au-u-flex--around">
         <AuButton
           @skin="primary"
-          {{on "click" (fn this.downloadLatestBpmnFile "bpmn")}}
+          {{on "click" (perform this.downloadLatestBpmnFile "bpmn")}}
         >
           Origineel
           <span class="au-u-para-tiny au-u-regular">(.bpmn)</span>
         </AuButton>
         <AuButton
           @skin="secondary"
-          {{on "click" (fn this.downloadLatestBpmnFile "png")}}
+          {{on "click" (perform this.downloadLatestBpmnFile "png")}}
         >
           Afbeelding
           <span class="au-u-para-tiny au-u-regular">(.png)</span>
         </AuButton>
         <AuButton
           @skin="secondary"
-          {{on "click" (fn this.downloadLatestBpmnFile "svg")}}
+          {{on "click" (perform this.downloadLatestBpmnFile "svg")}}
         >
           Vectorafbeelding
           <span class="au-u-para-tiny au-u-regular">(.svg)</span>
         </AuButton>
         <AuButton
           @skin="secondary"
-          {{on "click" (fn this.downloadLatestBpmnFile "pdf")}}
+          {{on "click" (perform this.downloadLatestBpmnFile "pdf")}}
         >
           PDF
           <span class="au-u-para-tiny au-u-regular">(.pdf)</span>

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -388,7 +388,7 @@
                     @skin="link"
                     @width="block"
                     @hideText="true"
-                    {{on "click" (fn this.downloadOriginalFile bpmnFile)}}
+                    {{on "click" (fn this.downloadFile bpmnFile)}}
                   >Download</AuButton>
                 </td>
                 {{#if this.canEdit}}
@@ -495,7 +495,7 @@
                     @skin="link"
                     @width="block"
                     @hideText="true"
-                    {{on "click" (fn this.downloadOriginalFile attachment)}}
+                    {{on "click" (fn this.downloadFile attachment)}}
                   >Download</AuButton>
                 </td>
                 {{#if this.canEdit}}
@@ -556,22 +556,34 @@
       <p>Het geselecteerde BPMN-bestand is beschikbaar in verschillende
         formaten:</p>
       <AuButtonGroup class="au-u-flex au-u-flex--around">
-        {{#each this.downloadTypes as |downloadType|}}
-          <AuButton
-            @skin={{if
-              (eq downloadType.extension "bpmn")
-              "primary"
-              "secondary"
-            }}
-            {{on
-              "click"
-              (fn this.downloadLatestBpmnFile downloadType.extension)
-            }}
-          >{{capitalize downloadType.label}}
-            <span
-              class="au-u-para-tiny au-u-regular"
-            >(.{{downloadType.extension}})</span></AuButton>
-        {{/each}}
+        <AuButton
+          @skin="primary"
+          {{on "click" (fn this.downloadLatestBpmnFile "bpmn")}}
+        >
+          Origineel
+          <span class="au-u-para-tiny au-u-regular">(.bpmn)</span>
+        </AuButton>
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.downloadLatestBpmnFile "png")}}
+        >
+          Afbeelding
+          <span class="au-u-para-tiny au-u-regular">(.png)</span>
+        </AuButton>
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.downloadLatestBpmnFile "svg")}}
+        >
+          Vectorafbeelding
+          <span class="au-u-para-tiny au-u-regular">(.svg)</span>
+        </AuButton>
+        <AuButton
+          @skin="secondary"
+          {{on "click" (fn this.downloadLatestBpmnFile "pdf")}}
+        >
+          PDF
+          <span class="au-u-para-tiny au-u-regular">(.pdf)</span>
+        </AuButton>
       </AuButtonGroup>
     </div>
   </:body>

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -216,7 +216,11 @@
             Klik en hou vast om diagram te bedienen. Gebruik ctrl en scrollwiel
             om in en uit te zoomen. Klik elders om bediening uit te schakelen.
           </AuHelpText>
-          <BpmnViewer @bpmnFile={{this.latestBpmnFile}} />
+          <BpmnViewer
+            @bpmnFile={{this.latestBpmnFile}}
+            @onBpmnLoaded={{this.setLatestBpmnFileAsBpmn}}
+            @onSvgLoaded={{this.setLatestBpmnFileAsSvg}}
+          />
           <DataCard class="au-u-margin-top-small">
             <:header></:header>
             <:title>

--- a/app/utils/file-download-url.js
+++ b/app/utils/file-download-url.js
@@ -1,12 +1,4 @@
-export default function generateFileDownloadUrl(
-  fileId,
-  fileExtension,
-  targetExtension
-) {
+export default function generateFileDownloadUrl(fileId) {
   if (!fileId) return null;
-
-  if (fileExtension && targetExtension && fileExtension !== targetExtension)
-    return `/files/${fileId}/converted/download`;
-
   return `/files/${fileId}/download`;
 }

--- a/app/utils/file-downloader.js
+++ b/app/utils/file-downloader.js
@@ -3,15 +3,11 @@ import generateFileDownloadUrl from './file-download-url';
 export default async function downloadFileByUrl(
   fileId,
   fileName,
-  fileExtension,
-  targetExtension
+  fileExtension
 ) {
-  const url = generateFileDownloadUrl(fileId, fileExtension, targetExtension);
+  const url = generateFileDownloadUrl(fileId, fileExtension);
 
-  const mimeType = mimeTypes[targetExtension];
-  const headers = mimeType ? { Accept: mimeType } : {};
-
-  const response = await fetch(url, { headers });
+  const response = await fetch(url);
   if (!response.ok) throw Error(response.status);
 
   const blob = await response.blob();
@@ -25,10 +21,3 @@ export default async function downloadFileByUrl(
   window.URL.revokeObjectURL(downloadUrl);
   a.remove();
 }
-
-const mimeTypes = {
-  bpmn: 'text/xml',
-  png: 'image/png',
-  svg: 'image/svg+xml',
-  pdf: 'application/pdf',
-};

--- a/app/utils/svg-convertors.js
+++ b/app/utils/svg-convertors.js
@@ -1,4 +1,5 @@
 import jsPDF from 'jspdf';
+import svg64 from 'svg64';
 
 export async function convertSvgToPng(svg) {
   const canvas = await convertSvgToCanvas(svg);
@@ -36,8 +37,6 @@ async function convertSvgToCanvas(svg) {
       resolve(canvas);
     };
     img.onerror = reject;
-    img.src = `data:image/svg+xml;base64,${btoa(
-      unescape(encodeURIComponent(svg))
-    )}`;
+    img.src = svg64(svg);
   });
 }

--- a/app/utils/svg-convertors.js
+++ b/app/utils/svg-convertors.js
@@ -1,0 +1,43 @@
+import jsPDF from 'jspdf';
+
+export async function convertSvgToPng(svg) {
+  const canvas = await convertSvgToCanvas(svg);
+  return new Promise((resolve) => {
+    canvas.toBlob(resolve, 'image/png');
+  });
+}
+
+export async function convertSvgToPdf(svg) {
+  const canvas = await convertSvgToCanvas(svg);
+  const width = canvas.width;
+  const height = canvas.height;
+
+  const pdf = new jsPDF({
+    orientation: width > height ? 'landscape' : 'portrait',
+    unit: 'px',
+    format: [width, height],
+    hotfixes: ['px_scaling'],
+  });
+  pdf.addImage(canvas, 'PNG', 0, 0, width, height);
+  return pdf.output('blob');
+}
+
+async function convertSvgToCanvas(svg) {
+  const scaleFactor = 2;
+  return new Promise((resolve, reject) => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    img.onload = () => {
+      canvas.width = img.width * scaleFactor;
+      canvas.height = img.height * scaleFactor;
+      ctx.scale(scaleFactor, scaleFactor);
+      ctx.drawImage(img, 0, 0, img.width, img.height);
+      resolve(canvas);
+    };
+    img.onerror = reject;
+    img.src = `data:image/svg+xml;base64,${btoa(
+      unescape(encodeURIComponent(svg))
+    )}`;
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "bpmn-js": "^16.3.2"
+        "bpmn-js": "^16.3.2",
+        "file-saver": "^2.0.5"
       },
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^2.7.0",
@@ -21205,6 +21206,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/file-uri-to-path": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "bpmn-js": "^16.3.2",
         "file-saver": "^2.0.5",
-        "jspdf": "^2.5.1"
+        "jspdf": "^2.5.1",
+        "svg64": "^2.0.0"
       },
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^2.7.0",
@@ -32560,6 +32561,14 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
+    },
+    "node_modules/svg64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg64/-/svg64-2.0.0.tgz",
+      "integrity": "sha512-EVgAisxMctUNDSjKGFcx4tkcFrvdqtLIy/MdbBdqcwfpPwsBcwoSKQi+WYoc82c4XWFNVVIwpCup3rpY+M9KJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/scriptex"
+      }
     },
     "node_modules/svgo": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "bpmn-js": "^16.3.2",
-        "file-saver": "^2.0.5"
+        "file-saver": "^2.0.5",
+        "jspdf": "^2.5.1"
       },
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^2.7.0",
@@ -2038,7 +2039,6 @@
       "version": "7.23.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
       "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -4450,6 +4450,12 @@
       "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
       "dev": true
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -5747,7 +5753,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -6400,6 +6405,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -9043,6 +9057,17 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -10963,6 +10988,15 @@
         "node": ">=12 || >=16"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css-loader": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
@@ -11733,7 +11767,7 @@
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.5.tgz",
       "integrity": "sha512-FgbqnEPiv5Vdtwt6Mxl7XSylttCC03cqP5ldNT2z+Kj0nLxPHJH4+1Cyf5Jasxhw93Rl4Oo11qRoUV72fmya2Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/domutils": {
       "version": "3.1.0",
@@ -21173,6 +21207,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -22910,6 +22949,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -24550,6 +24602,59 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/jspdf/node_modules/core-js": {
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/jspdf/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/jsuri": {
       "version": "1.3.1",
@@ -28346,6 +28451,12 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -29296,6 +29407,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -29586,8 +29706,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -30257,6 +30376,15 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
@@ -31443,6 +31571,15 @@
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
       "dev": true
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stagehand": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stagehand/-/stagehand-1.0.1.tgz",
@@ -32409,6 +32546,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -33169,6 +33315,15 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -34281,6 +34436,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   },
   "dependencies": {
     "bpmn-js": "^16.3.2",
-    "file-saver": "^2.0.5"
+    "file-saver": "^2.0.5",
+    "jspdf": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   "dependencies": {
     "bpmn-js": "^16.3.2",
     "file-saver": "^2.0.5",
-    "jspdf": "^2.5.1"
+    "jspdf": "^2.5.1",
+    "svg64": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "npm": "8.3.1"
   },
   "dependencies": {
-    "bpmn-js": "^16.3.2"
+    "bpmn-js": "^16.3.2",
+    "file-saver": "^2.0.5"
   }
 }


### PR DESCRIPTION
OPH-328

Corresponding PR bpmn-service: https://github.com/lblod/openproceshuis-bpmn-service/pull/13

The conversion of BPMN files to SVG, PNG and PDF - as available for download - is no longer handled by the BPMN service, but by the frontend.