### PR TITLE
Disable mock-login route on production

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,8 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
-  if (ENV.mockLogin.enabled) this.route('mock-login');
+  if (window.location.hostname !== 'openproceshuis.vlaanderen.be')
+    this.route('mock-login');
 
   this.route('switch-login');
   this.route('auth', { path: '/authorization' }, function () {

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,11 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
-  if (window.location.hostname !== 'openproceshuis.vlaanderen.be')
+  if (
+    ENV.mockLogin.disabled === '{{DISABLE_MOCK_LOGIN}}' ||
+    ENV.mockLogin.disabled === 'false' ||
+    !ENV.mockLogin.disabled
+  )
     this.route('mock-login');
 
   this.route('switch-login');

--- a/app/router.js
+++ b/app/router.js
@@ -1,13 +1,13 @@
 import EmberRouter from '@ember/routing/router';
-import config from 'frontend-openproceshuis/config/environment';
+import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class Router extends EmberRouter {
-  location = config.locationType;
-  rootURL = config.rootURL;
+  location = ENV.locationType;
+  rootURL = ENV.rootURL;
 }
 
 Router.map(function () {
-  this.route('mock-login');
+  if (ENV.mockLogin.enabled) this.route('mock-login');
 
   this.route('switch-login');
   this.route('auth', { path: '/authorization' }, function () {

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+
 export default class MockLoginRoute extends Route {
   @service() session;
   @service() store;

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,10 +38,6 @@ module.exports = function (environment) {
       extraPrefixes: '{{YASGUI_EXTRA_PREFIXES}}',
     },
 
-    mockLogin: {
-      enabled: '{{MOCKLOGIN_ENABLED}}', // enabled by default, set to false to disable
-    },
-
     acmidm: {
       clientId: '{{OAUTH_API_KEY}}',
       scope: '{{OAUTH_API_SCOPE}}',

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,6 +38,10 @@ module.exports = function (environment) {
       extraPrefixes: '{{YASGUI_EXTRA_PREFIXES}}',
     },
 
+    mockLogin: {
+      enabled: '{{MOCKLOGIN_ENABLED}}', // enabled by default, set to false to disable
+    },
+
     acmidm: {
       clientId: '{{OAUTH_API_KEY}}',
       scope: '{{OAUTH_API_SCOPE}}',

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,6 +38,10 @@ module.exports = function (environment) {
       extraPrefixes: '{{YASGUI_EXTRA_PREFIXES}}',
     },
 
+    mockLogin: {
+      disabled: '{{DISABLE_MOCK_LOGIN}}',
+    },
+
     acmidm: {
       clientId: '{{OAUTH_API_KEY}}',
       scope: '{{OAUTH_API_SCOPE}}',


### PR DESCRIPTION
OPH-355

Mock-login is already disabled on PROD but frontend should also disable route for it.
On QA mock-login service (and frontend route) should be enabled.