### PR TITLE
Filter processes on government

### DIFF
--- a/app/components/process-select-by-group.hbs
+++ b/app/components/process-select-by-group.hbs
@@ -1,0 +1,18 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelect
+    @allowClear={{true}}
+    @searchEnabled={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @searchField="group"
+    @search={{perform this.loadGroupsTask}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
+    @classification={{@classification}}
+    @triggerId={{@id}}
+    as |group|
+  >
+    {{group}}
+  </PowerSelect>
+</div>

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { restartableTask } from 'ember-concurrency';
+
+export default class ProcessSelectByGroupComponent extends Component {
+  @service store;
+
+  @restartableTask
+  *loadGroupsTask(searchParams = '') {
+    const query = {
+      page: {
+        size: 50,
+      },
+    };
+
+    if (searchParams.trim() !== '') query['filter[name]'] = searchParams;
+
+    if (this.args.classification)
+      query['filter[classification][:exact:label]'] = this.args.classification;
+
+    const result = yield this.store.query('group', query);
+
+    if (result) return [...new Set(result.map((r) => r.name))];
+  }
+}

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -1,19 +1,24 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class ProcessSelectByGroupComponent extends Component {
   @service store;
 
   @restartableTask
   *loadGroupsTask(searchParams = '') {
+    if (!searchParams?.trim()) return;
+
+    yield timeout(200);
+
     const query = {
       page: {
         size: 50,
       },
+      filter: {
+        name: searchParams,
+      },
     };
-
-    if (searchParams.trim() !== '') query['filter[name]'] = searchParams;
 
     if (this.args.classification)
       query['filter[classification][:exact:label]'] = this.args.classification;

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -18,6 +18,7 @@ export default class ProcessSelectByGroupComponent extends Component {
       filter: {
         name: searchParams,
       },
+      sort: ':no-case:name',
     };
 
     if (this.args.classification)

--- a/app/components/process-select-by-title.js
+++ b/app/components/process-select-by-title.js
@@ -14,7 +14,7 @@ export default class ProcessSelectByTitleComponent extends Component {
 
     if (searchParams.trim() !== '') query['filter[title]'] = searchParams;
     if (this.args.publisher)
-      query['filter[publisher][id]'] = this.args.publisher; // FIXME: should be handled by backend instead of frontend
+      query['filter[publisher][id]'] = this.args.publisher;
 
     const result = yield this.store.query('process', query);
 

--- a/app/components/process-select-by-title.js
+++ b/app/components/process-select-by-title.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessSelectByTitleComponent extends Component {
@@ -8,11 +8,17 @@ export default class ProcessSelectByTitleComponent extends Component {
 
   @restartableTask
   *loadProcessesTask(searchParams = '') {
+    if (!searchParams?.trim()) return;
+
+    yield timeout(200);
+
     const query = {
-      'filter[:not:status]': ENV.resourceStates.archived,
+      filter: {
+        title: searchParams,
+        ':not:status': ENV.resourceStates.archived,
+      },
     };
 
-    if (searchParams.trim() !== '') query['filter[title]'] = searchParams;
     if (this.args.publisher)
       query['filter[publisher][id]'] = this.args.publisher;
 

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -54,6 +54,7 @@ export default class ProcessesIndexController extends Controller {
   resetFilters() {
     this.title = '';
     this.classification = '';
+    this.group = '';
     this.page = 0;
     this.sort = 'title';
 

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -2,13 +2,14 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 export default class ProcessesIndexController extends Controller {
-  queryParams = ['page', 'size', 'sort', 'title', 'classification'];
+  queryParams = ['page', 'size', 'sort', 'title', 'classification', 'group'];
 
   @tracked page = 0;
   size = 20;
   @tracked sort = 'title';
   @tracked title = '';
   @tracked classification = '';
+  @tracked group = '';
 
   get processes() {
     return this.model.loadProcessesTaskInstance.isFinished
@@ -41,6 +42,12 @@ export default class ProcessesIndexController extends Controller {
   setClassification(selection) {
     this.page = null;
     this.classification = selection;
+  }
+
+  @action
+  setGroup(selection) {
+    this.page = null;
+    this.group = selection;
   }
 
   @action

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -11,6 +11,7 @@ export default class ProcessesIndexRoute extends Route {
     sort: { refreshModel: true },
     title: { refreshModel: true, replace: true },
     classification: { refreshModel: true, replace: true },
+    group: { refreshModel: true, replace: true },
   };
 
   async model(params) {
@@ -53,6 +54,8 @@ export default class ProcessesIndexRoute extends Route {
 
     if (params.classification)
       query['filter[publisher][classification][label]'] = params.classification;
+
+    if (params.group) query['filter[publisher][:exact:name]'] = params.group;
 
     query['filter[:not:status]'] = ENV.resourceStates.archived;
 

--- a/app/routes/shared-processes/index.js
+++ b/app/routes/shared-processes/index.js
@@ -54,7 +54,7 @@ export default class SharedProcessesIndexRoute extends Route {
     if (params.title) {
       query['filter[title]'] = params.title;
     }
-    query['filter[publisher][id]'] = this.currentSession.group.id; // FIXME: should be handled by backend instead of frontend
+    query['filter[publisher][id]'] = this.currentSession.group.id;
     query['filter[:not:status]'] = ENV.resourceStates.archived;
 
     return yield this.store.query('process', query);

--- a/app/styles/components/_sidebar-container.scss
+++ b/app/styles/components/_sidebar-container.scss
@@ -17,7 +17,6 @@ Tracking issue: https://github.com/appuniversum/ember-appuniversum/issues/86 */
 
 .au-c-sidebar-container__sidebar {
   flex-basis: 100%;
-  padding: $au-unit-small;
 
   @include mq(medium) {
     height: 100%;
@@ -47,7 +46,6 @@ Tracking issue: https://github.com/appuniversum/ember-appuniversum/issues/86 */
 
 .au-c-sidebar {
   border: 1px solid var(--au-gray-200);
-  border-radius: $au-radius;
 }
 
 .au-c-list-navigation {

--- a/app/templates/process-steps/index.hbs
+++ b/app/templates/process-steps/index.hbs
@@ -4,10 +4,11 @@
       <div class="au-c-sidebar__content">
         <form
           {{on "reset" this.resetFilters}}
-          class="au-o-box au-o-box--small au-o-flow au-o-flow--small"
+          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
         >
+          <h1 class="au-u-h3 au-u-medium">Filters</h1>
           <div>
-            <AuLabel for="filter-name">Filter op naam</AuLabel>
+            <AuLabel for="filter-name">Naam</AuLabel>
             <ProcessStepSelectByName
               @id="filter-name"
               @selected={{this.name}}
@@ -16,7 +17,7 @@
             />
           </div>
           <div>
-            <AuLabel for="filter-type">Filter op type</AuLabel>
+            <AuLabel for="filter-type">Type</AuLabel>
             <ProcessStepSelectByType
               @id="filter-type"
               @selected={{this.type}}
@@ -24,12 +25,12 @@
               class="grow"
             />
           </div>
-          <div>
+          <div class="au-u-flex au-u-flex--end">
             <AuButton
-              @icon="undo"
+              @icon="cross"
               @skin="link"
               type="reset"
-              class="au-u-padding-none"
+              class="au-u-padding-none au-u-medium"
             >
               Herstel alle filters
             </AuButton>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -25,6 +25,16 @@
               class="grow"
             />
           </div>
+          <div>
+            <AuLabel for="filter-group">Naam bestuur</AuLabel>
+            <ProcessSelectByGroup
+              @id="filter-group"
+              @selected={{this.group}}
+              @onChange={{this.setGroup}}
+              @classification={{this.classification}}
+              class="grow"
+            />
+          </div>
           <div class="au-u-flex au-u-flex--end">
             <AuButton
               @icon="cross"

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -4,8 +4,9 @@
       <div class="au-c-sidebar__content">
         <form
           {{on "reset" this.resetFilters}}
-          class="au-o-box au-o-box--small au-o-flow au-o-flow--small"
+          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
         >
+          <h1 class="au-u-h3 au-u-medium">Filters</h1>
           <div>
             <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
             <ProcessSelectByTitle
@@ -24,12 +25,12 @@
               class="grow"
             />
           </div>
-          <div>
+          <div class="au-u-flex au-u-flex--end">
             <AuButton
-              @icon="undo"
+              @icon="cross"
               @skin="link"
               type="reset"
-              class="au-u-padding-none"
+              class="au-u-padding-none au-u-medium"
             >
               Herstel alle filters
             </AuButton>

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -4,6 +4,8 @@
       Wijzig proces
     </:title>
     <:action>
+      <AuPill @icon="clock-rewind" @draft="true">Laatst aangepast op
+        {{date-format this.process.modified true}}</AuPill>
     </:action>
   </PageHeader>
 {{else}}
@@ -11,7 +13,10 @@
     <:title>
       {{this.process.title}}
     </:title>
-    <:action></:action>
+    <:action>
+      <AuPill @icon="clock-rewind">Laatst aangepast op
+        {{date-format this.process.modified true}}</AuPill>
+    </:action>
   </PageHeader>
 {{/if}}
 
@@ -107,12 +112,6 @@
                 <:label>Aangemaakt op</:label>
                 <:content>
                   {{date-format this.process.created true}}
-                </:content>
-              </Item>
-              <Item>
-                <:label>Laatst aangepast op</:label>
-                <:content>
-                  <span class="au-u-italic">Nu</span>
                 </:content>
               </Item>
             </:right>
@@ -213,12 +212,6 @@
               <:label>Aangemaakt op</:label>
               <:content>
                 {{date-format this.process.created true}}
-              </:content>
-            </Item>
-            <Item>
-              <:label>Laatst aangepast op</:label>
-              <:content>
-                {{date-format this.process.modified true}}
               </:content>
             </Item>
           </:right>

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -21,7 +21,7 @@
       <DataCard>
         <:header></:header>
         <:title>
-          Algemene info
+          Algemene informatie
         </:title>
         <:card as |Card|>
           <Card.Columns>
@@ -95,7 +95,7 @@
                 </:content>
               </Item>
               <Item>
-                <:label>Contact</:label>
+                <:label>Emailadres bestuur</:label>
                 <:content>
                   {{or
                     (contact-email this.process.publisher.primarySite.contacts)
@@ -146,7 +146,7 @@
         {{/if}}
       </:header>
       <:title>
-        Algemene info
+        Algemene informatie
       </:title>
       <:card as |Card|>
         <Card.Columns>
@@ -201,7 +201,7 @@
               </:content>
             </Item>
             <Item>
-              <:label>Contact</:label>
+              <:label>Emailadres bestuur</:label>
               <:content>
                 {{or
                   (contact-email this.process.publisher.primarySite.contacts)

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -24,10 +24,23 @@
   {{#if this.edit}}
     <form {{on "submit" (perform this.updateModel)}}>
       <DataCard>
-        <:header></:header>
         <:title>
           Algemene informatie
         </:title>
+        <:header>
+          <div class="au-u-flex au-u-flex--spaced-small au-u-flex--end">
+            <AuButton
+              @skin="secondary"
+              {{on "click" this.resetModel}}
+            >Annuleer</AuButton>
+            <AuButton
+              @skin="primary"
+              type="submit"
+              @loading={{this.updateModel.isRunning}}
+              @disabled={{or this.updateModel.isRunning (not this.formIsValid)}}
+            >Bewaar</AuButton>
+          </div>
+        </:header>
         <:card as |Card|>
           <Card.Columns>
             <:left as |Item|>
@@ -117,24 +130,13 @@
             </:right>
           </Card.Columns>
         </:card>
-        <:action>
-          <div class="au-u-flex au-u-flex--spaced-small au-u-flex--end">
-            <AuButton
-              @skin="secondary"
-              {{on "click" this.resetModel}}
-            >Annuleer</AuButton>
-            <AuButton
-              @skin="primary"
-              type="submit"
-              @loading={{this.updateModel.isRunning}}
-              @disabled={{or this.updateModel.isRunning (not this.formIsValid)}}
-            >Bewaar</AuButton>
-          </div>
-        </:action>
       </DataCard>
     </form>
   {{else}}
     <DataCard>
+      <:title>
+        Algemene informatie
+      </:title>
       <:header>
         {{#if this.canEdit}}
           <AuButton
@@ -144,9 +146,6 @@
           >Wijzig</AuButton>
         {{/if}}
       </:header>
-      <:title>
-        Algemene informatie
-      </:title>
       <:card as |Card|>
         <Card.Columns>
           <:left as |Item|>

--- a/app/templates/shared-processes/index.hbs
+++ b/app/templates/shared-processes/index.hbs
@@ -4,8 +4,9 @@
       <div class="au-c-sidebar__content">
         <form
           {{on "reset" this.resetFilters}}
-          class="au-o-box au-o-box--small au-o-flow au-o-flow--small"
+          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
         >
+          <h1 class="au-u-h3 au-u-medium">Filters</h1>
           <div>
             <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
             <ProcessSelectByTitle
@@ -16,12 +17,12 @@
               class="grow"
             />
           </div>
-          <div>
+          <div class="au-u-flex au-u-flex--end">
             <AuButton
-              @icon="undo"
+              @icon="cross"
               @skin="link"
               type="reset"
-              class="au-u-padding-none"
+              class="au-u-padding-none au-u-medium"
             >
               Herstel alle filters
             </AuButton>


### PR DESCRIPTION
OPH-361

On the processes overview page, a search box has been added to filter on processes' government names. The filter takes into account the possible prior selection of a governemnt type to allow users to really narrow down their selection.

In addition, some design tweaks have been implemented regarding the filter panels and the process details cards.