### PR TITLE
Governement type filter fixes

### DIFF
--- a/app/components/process-select-by-classification.hbs
+++ b/app/components/process-select-by-classification.hbs
@@ -5,11 +5,11 @@
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @options={{this.classifications}}
-    @selected={{this.classification}}
-    @onChange={{this.setClassification}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
     @triggerId={{@id}}
     as |classification|
   >
-    {{capitalize classification.label}}
+    {{classification.label}}
   </PowerSelect>
 </div>

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -16,6 +16,8 @@ export default class ProcessSelectByClassificationComponent extends Component {
         number: 0,
         size: 20,
       },
+      'filter[:has:groups]': true,
+      'filter[groups][:has:processes]': true,
       sort: ':no-case:label',
     };
 

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -2,19 +2,12 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 export default class ProcessSelectByClassificationComponent extends Component {
+  @service router;
   @service store;
 
   @tracked classifications = [];
-  @tracked classification = null;
-
-  @action
-  setClassification(selected) {
-    this.classification = selected;
-    this.args.onChange(selected?.label ?? '');
-  }
 
   @restartableTask
   *loadProcessClassificationsTask() {
@@ -32,10 +25,13 @@ export default class ProcessSelectByClassificationComponent extends Component {
     );
     this.classifications = result;
 
-    if (this.args.selected) {
-      this.classification = result.find(
-        (classification) => classification.label === this.args.selected
+    const selectedClassificationLabel =
+      this.router.currentRoute.queryParams.classification;
+    if (selectedClassificationLabel) {
+      const selectedClassification = this.classifications.find(
+        (classification) => classification.label === selectedClassificationLabel
       );
+      this.args.onChange(selectedClassification);
     }
   }
 }

--- a/app/components/process-step-select-by-type.hbs
+++ b/app/components/process-step-select-by-type.hbs
@@ -5,8 +5,8 @@
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @options={{this.types}}
-    @selected={{this.type}}
-    @onChange={{this.setType}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
     @triggerId={{@id}}
     as |type|
   >

--- a/app/components/process-step-select-by-type.js
+++ b/app/components/process-step-select-by-type.js
@@ -2,19 +2,12 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 export default class ProcessStepSelectByTypeComponent extends Component {
+  @service router;
   @service store;
 
   @tracked types = [];
-  @tracked type = null;
-
-  @action
-  setType(selected) {
-    this.type = selected;
-    this.args.onChange(selected?.queryValue ?? '');
-  }
 
   @restartableTask
   *loadProcessStepTypesTask() {
@@ -31,8 +24,12 @@ export default class ProcessStepSelectByTypeComponent extends Component {
     const result = yield this.store.query('bpmn-element-type', query);
     this.types = result;
 
-    if (this.args.selected) {
-      this.type = result.find((type) => type.queryValue === this.args.selected);
+    const selectedTypeQueryValue = this.router.currentRoute.queryParams.type;
+    if (selectedTypeQueryValue) {
+      const selectedType = this.types.find(
+        (type) => type.queryValue === selectedTypeQueryValue
+      );
+      this.args.onChange(selectedType);
     }
   }
 }

--- a/app/controllers/process-steps/index.js
+++ b/app/controllers/process-steps/index.js
@@ -10,6 +10,7 @@ export default class ProcessStepsIndexController extends Controller {
   @tracked sort = '';
   @tracked name = '';
   @tracked type = '';
+  @tracked selectedType = '';
 
   get processSteps() {
     return this.model.loadProcessStepsTaskInstance.isFinished
@@ -41,13 +42,15 @@ export default class ProcessStepsIndexController extends Controller {
   @action
   setType(selection) {
     this.page = null;
-    this.type = selection;
+    this.selectedType = selection;
+    this.type = selection?.queryValue;
   }
 
   @action
   resetFilters() {
     this.name = '';
     this.type = '';
+    this.selectedType = '';
     this.page = 0;
     this.sort = '';
 

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -9,6 +9,7 @@ export default class ProcessesIndexController extends Controller {
   @tracked sort = 'title';
   @tracked title = '';
   @tracked classification = '';
+  @tracked selectedClassification = '';
   @tracked group = '';
 
   get processes() {
@@ -41,7 +42,8 @@ export default class ProcessesIndexController extends Controller {
   @action
   setClassification(selection) {
     this.page = null;
-    this.classification = selection;
+    this.selectedClassification = selection;
+    this.classification = selection?.label;
   }
 
   @action
@@ -54,6 +56,7 @@ export default class ProcessesIndexController extends Controller {
   resetFilters() {
     this.title = '';
     this.classification = '';
+    this.selectedClassification = '';
     this.group = '';
     this.page = 0;
     this.sort = 'title';

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -53,7 +53,8 @@ export default class ProcessesIndexRoute extends Route {
     }
 
     if (params.classification)
-      query['filter[publisher][classification][label]'] = params.classification;
+      query['filter[publisher][classification][:exact:label]'] =
+        params.classification;
 
     if (params.group) query['filter[publisher][:exact:name]'] = params.group;
 

--- a/app/templates/process-steps/index.hbs
+++ b/app/templates/process-steps/index.hbs
@@ -20,7 +20,7 @@
             <AuLabel for="filter-type">Type</AuLabel>
             <ProcessStepSelectByType
               @id="filter-type"
-              @selected={{this.type}}
+              @selected={{this.selectedType}}
               @onChange={{this.setType}}
               class="grow"
             />

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -20,7 +20,7 @@
             <AuLabel for="filter-classification">Type bestuur</AuLabel>
             <ProcessSelectByClassification
               @id="filter-classification"
-              @selected={{this.classification}}
+              @selected={{this.selectedClassification}}
               @onChange={{this.setClassification}}
               class="grow"
             />


### PR DESCRIPTION
OPH-447
OPH-449

Corresponding PR app: https://github.com/lblod/app-openproceshuis/pull/43

The following bugfixes/improvements concerning the government type filter were implemented:
- Strictly interpret selected government type (e.g. don't show "Autonoom gemeentebedrijf" when "Gemeente" is selected).
- Clear filter when "clear all filters" button is clicked.
- Only present government types for which processes exist.

An extra bug was fixed concerning the process steps type filter:
- Clear filter when "clear all filters" button is clicked.