### PR TITLE
Add check for admin before displaying "No write rights" banner

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -50,6 +50,9 @@ export default class CurrentSessionService extends Service {
   }
 
   get canOnlyReadWhileAuthenticated() {
+    if (this.isAdmin) {
+      return false;
+    }
     return this.session.isAuthenticated && !this.hasEditorRole;
   }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -50,10 +50,7 @@ export default class CurrentSessionService extends Service {
   }
 
   get canOnlyReadWhileAuthenticated() {
-    if (this.isAdmin) {
-      return false;
-    }
-    return this.session.isAuthenticated && !this.hasEditorRole;
+    return !this.isAdmin && this.session.isAuthenticated && !this.hasEditorRole;
   }
 
   get isAdmin() {


### PR DESCRIPTION
OPH-446

This PR fixes an occurrence where admins got shown a banner telling them they have "no write rights".
This happened because not every admin was specifically assigned an editor role, which in turn displayed the error.
Every admin should have write rights, so this error was wrongly displayed.

app: https://github.com/lblod/app-openproceshuis/pull/45