### PR TITLE
OPH-456: Finetune 'filter on group'

### DIFF
--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -22,9 +22,8 @@ export default class ProcessSelectByGroupComponent extends Component {
       sort: ':no-case:name',
     };
 
-    if (this.args.classification) {
+    if (this.args.classification)
       query['filter[classification][:exact:label]'] = this.args.classification;
-    }
 
     const result = yield this.store.query('group', query);
 

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -15,14 +15,16 @@ export default class ProcessSelectByGroupComponent extends Component {
       page: {
         size: 50,
       },
+      'filter[:has:processes]': true,
       filter: {
         name: searchParams,
       },
       sort: ':no-case:name',
     };
 
-    if (this.args.classification)
+    if (this.args.classification) {
       query['filter[classification][:exact:label]'] = this.args.classification;
+    }
 
     const result = yield this.store.query('group', query);
 


### PR DESCRIPTION
This PR adds a condition to the 'filter on group' filter, where it will check if the group you are searching for (naam bestuur) has a registered process. If this is not the case, the group you're searching for will not show in the search resutlts.

**Link to Jira ticket**
https://binnenland.atlassian.net/browse/OPH-456

### How to test/reproduce:
Go to the process overview and test the filter functionality.
1. Try filtering by 'type bestuur'
2. Search by 'naam bestuur'

You will see that the results will only show the groups that have the specified type AND have a process registered in the app.