### PR TITLE
Display Visio files as PDF

### DIFF
--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -12,7 +12,9 @@ export default class BpmnViewerComponent extends Component {
     element.tabIndex = 0; // Make element focusable
     this.viewer = new NavigatedViewer({ container: element });
 
-    const latestBpmnFileId = this.args.diagram?.bpmnFile?.id;
+    const latestBpmnFileId = this.args.diagram?.isBpmnFile
+      ? this.args.diagram.id
+      : undefined;
     if (!latestBpmnFileId) return;
 
     const bpmnXml = await this.downloadBpmnFile.perform(latestBpmnFileId);

--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -12,12 +12,12 @@ export default class BpmnViewerComponent extends Component {
     element.tabIndex = 0; // Make element focusable
     this.viewer = new NavigatedViewer({ container: element });
 
-    const latestBpmnFileId = this.args.diagram?.isBpmnFile
+    const bpmnFileId = this.args.diagram?.isBpmnFile
       ? this.args.diagram.id
       : undefined;
-    if (!latestBpmnFileId) return;
+    if (!bpmnFileId) return;
 
-    const bpmnXml = await this.downloadBpmnFile.perform(latestBpmnFileId);
+    const bpmnXml = await this.downloadBpmnFile.perform(bpmnFileId);
     if (!bpmnXml) return;
 
     await this.viewer.importXML(bpmnXml);

--- a/app/components/pdf-viewer.hbs
+++ b/app/components/pdf-viewer.hbs
@@ -1,10 +1,12 @@
-<object
-  data="{{this.pdfUrl}}"
-  type="application/pdf"
-  width="100%"
-  height="100%"
+<div
+  class="bpmn-container au-u-margin-top-small"
+  {{did-insert this.setupViewer}}
 >
-  <AuAlert @title="Visualisatie mislukt" @skin="warning" @icon="alert-triangle">
-    Er ging iets mis bij het weergeven van het diagram.
-  </AuAlert>
-</object>
+  {{! template-lint-disable require-valid-alt-text }}
+  <object
+    data="{{this.pdfBlobUrl}}"
+    type="application/pdf"
+    width="100%"
+    height="100%"
+  />
+</div>

--- a/app/components/pdf-viewer.hbs
+++ b/app/components/pdf-viewer.hbs
@@ -1,0 +1,10 @@
+<object
+  data="{{this.pdfUrl}}"
+  type="application/pdf"
+  width="100%"
+  height="100%"
+>
+  <AuAlert @title="Visualisatie mislukt" @skin="warning" @icon="alert-triangle">
+    Er ging iets mis bij het weergeven van het diagram.
+  </AuAlert>
+</object>

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
+import { generateVisioConversionUrl } from 'frontend-openproceshuis/utils/file-download-url';
 
 export default class PdfViewerComponent extends Component {
   @tracked pdfBlobUrl = null;
@@ -21,7 +22,7 @@ export default class PdfViewerComponent extends Component {
 
   @restartableTask
   *downloadVisioAsPdf(visioFileId) {
-    const url = `/visio/convert?id=${visioFileId}&target=pdf`;
+    const url = generateVisioConversionUrl(visioFileId);
     const response = yield fetch(url);
     if (!response.ok) throw Error(response.status);
     return yield response.blob();

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -1,6 +1,29 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { restartableTask } from 'ember-concurrency';
+
 export default class PdfViewerComponent extends Component {
-  get pdfUrl() {
-    return 'https://pdfobject.com/pdf/sample.pdf';
+  @tracked pdfBlobUrl = null;
+
+  @action
+  async setupViewer() {
+    const visioFileId = this.args.diagram?.isVisioFile
+      ? this.args.diagram.id
+      : undefined;
+    if (!visioFileId) return;
+
+    const blob = await this.downloadVisioAsPdf.perform(visioFileId);
+    if (!blob) return;
+
+    this.pdfBlobUrl = URL.createObjectURL(blob);
+  }
+
+  @restartableTask
+  *downloadVisioAsPdf(visioFileId) {
+    const url = `/visio/convert?id=${visioFileId}&target=pdf`;
+    const response = yield fetch(url);
+    if (!response.ok) throw Error(response.status);
+    return yield response.blob();
   }
 }

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+export default class PdfViewerComponent extends Component {
+  get pdfUrl() {
+    return 'https://pdfobject.com/pdf/sample.pdf';
+  }
+}

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -424,7 +424,6 @@ export default class ProcessesProcessIndexController extends Controller {
         number: 0,
         size: 1,
       },
-      include: 'bpmn-files',
       'filter[processes][id]': this.model.processId,
       'filter[:or:][extension]': ['bpmn', 'vsdx'],
       sort: '-created',
@@ -450,7 +449,6 @@ export default class ProcessesProcessIndexController extends Controller {
     try {
       this.latestDiagram = yield this.store.findRecord('file', fileId, {
         reload: true,
-        include: 'bpmn-files',
       });
     } catch {
       this.latestDiagramHasErrored = true;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -14,7 +14,9 @@ import {
   convertSvgToPdf,
   convertSvgToPng,
 } from 'frontend-openproceshuis/utils/svg-convertors';
-import generateFileDownloadUrl from 'frontend-openproceshuis/utils/file-download-url';
+import generateFileDownloadUrl, {
+  generateVisioConversionUrl,
+} from 'frontend-openproceshuis/utils/file-download-url';
 
 export default class ProcessesProcessIndexController extends Controller {
   queryParams = [
@@ -142,18 +144,30 @@ export default class ProcessesProcessIndexController extends Controller {
 
   @dropTask
   *downloadLatestDiagram(targetExtension) {
+    console.log('latest diagram:', this.latestDiagram);
+    console.log('target extension:', targetExtension);
     if (!this.latestDiagram) return;
 
     let blob = undefined;
-    if (targetExtension === 'vsdx' && this.latestDiagram?.isVisioFile) {
+    if (targetExtension === 'vsdx' && this.latestDiagram.isVisioFile) {
       const url = generateFileDownloadUrl(this.latestDiagram.id);
       const response = yield fetch(url);
       if (!response.ok) throw Error(response.status);
       blob = yield response.blob();
-    } else if (targetExtension === 'bpmn' && this.latestDiagramAsBpmn) {
-      blob = new Blob([this.latestDiagramAsBpmn], {
-        type: 'application/xml;charset=utf-8',
-      });
+    } else if (targetExtension === 'bpmn') {
+      if (this.latestDiagramAsBpmn) {
+        blob = new Blob([this.latestDiagramAsBpmn], {
+          type: 'application/xml;charset=utf-8',
+        });
+      } else if (this.latestDiagram.isVisioFile) {
+        const url = generateVisioConversionUrl(
+          this.latestDiagram.id,
+          targetExtension
+        );
+        const response = yield fetch(url);
+        if (!response.ok) throw Error(response.status);
+        blob = yield response.blob();
+      }
     } else if (targetExtension === 'svg' && this.latestDiagramAsSvg) {
       blob = new Blob([this.latestDiagramAsSvg], {
         type: 'image/svg+xml;charset=utf-8',

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -172,8 +172,18 @@ export default class ProcessesProcessIndexController extends Controller {
       blob = new Blob([this.latestDiagramAsSvg], {
         type: 'image/svg+xml;charset=utf-8',
       });
-    } else if (targetExtension === 'pdf' && this.latestDiagramAsSvg) {
-      blob = yield convertSvgToPdf(this.latestDiagramAsSvg);
+    } else if (targetExtension === 'pdf') {
+      if (this.latestDiagramAsSvg) {
+        blob = yield convertSvgToPdf(this.latestDiagramAsSvg);
+      } else if (this.latestDiagram.isVisioFile) {
+        const url = generateVisioConversionUrl(
+          this.latestDiagram.id,
+          targetExtension
+        );
+        const response = yield fetch(url);
+        if (!response.ok) throw Error(response.status);
+        blob = yield response.blob();
+      }
     } else if (targetExtension === 'png' && this.latestDiagramAsSvg) {
       blob = yield convertSvgToPng(this.latestDiagramAsSvg);
     }

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -1,4 +1,4 @@
-import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class FileModel extends Model {
@@ -10,18 +10,10 @@ export default class FileModel extends Model {
   @attr('iso-date') modified;
   @attr('string') status;
   @hasMany('process', { inverse: 'files', async: false }) processes;
-  @belongsTo('file', { inverse: 'bpmnFiles', async: false }) vsdxFile;
-  @hasMany('file', { inverse: 'vsdxFile', async: false }) bpmnFiles;
 
   get process() {
     if (!this.processes || this.processes.length === 0) return null;
     return this.processes[0];
-  }
-
-  get bpmnFile() {
-    if (this.isBpmnFile) return this;
-    if (!this.bpmnFiles || this.bpmnFiles.length === 0) return null;
-    return this.bpmnFiles[0];
   }
 
   get isArchived() {

--- a/app/styles/components/_bpmn-viewer.scss
+++ b/app/styles/components/_bpmn-viewer.scss
@@ -1,6 +1,7 @@
 .bpmn-container {
   flex: none;
   height: 500px;
+  width: 100%;
   border: 1px solid var(--au-gray-200);
   border-radius: $au-radius;
   overflow: hidden;

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -265,10 +265,7 @@
               @onSvgLoaded={{this.setLatestDiagramAsSvg}}
             />
           {{else if this.latestDiagram.isVisioFile}}
-            <AuAlert @title="Visio" @skin="warning" @icon="alert-triangle">
-              Visio bestand
-              {{! TODO: improve }}
-            </AuAlert>
+            <PdfViewer @diagram={{this.latestDiagram}} />
           {{else}}
             <AuAlert @title="Mislukt" @skin="warning" @icon="alert-triangle">
               Visualisatie mislukt

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -253,16 +253,7 @@
             opnieuw.
           </AuAlert>
         {{else if this.latestDiagram}}
-          {{#if this.latestDiagram.bpmnFile}}
-            {{#if this.latestDiagram.isVisioFile}}
-              <AuHelpText @skin="secondary" class="au-u-margin-bottom-small">
-                Dit diagram is origineel gemaakt in Visio. Open Proces Huis kan
-                geen Visiobestanden tonen, het toont enkel een
-                <span class="au-u-italic">.bpmn</span>-versie. Let op: die kan
-                verschillen van het originele Visiobestand. Je kan het originele
-                Visiobestand downloaden om te bekijken in de Visiotoepassing.
-              </AuHelpText>
-            {{/if}}
+          {{#if this.latestDiagram.isBpmnFile}}
             <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
               Klik en hou vast om diagram te bedienen. Gebruik ctrl en
               scrollwiel om in en uit te zoomen. Klik elders om bediening uit te
@@ -273,18 +264,15 @@
               @onBpmnLoaded={{this.setLatestDiagramAsBpmn}}
               @onSvgLoaded={{this.setLatestDiagramAsSvg}}
             />
+          {{else if this.latestDiagram.isVisioFile}}
+            <AuAlert @title="Visio" @skin="warning" @icon="alert-triangle">
+              Visio bestand
+              {{! TODO: improve }}
+            </AuAlert>
           {{else}}
-            <AuAlert
-              @title="Visualisatie mislukt"
-              @skin="warning"
-              @icon="alert-triangle"
-            >
-              {{#if this.latestDiagram.isVisioFile}}
-                <span>Het Visiobestand kon niet worden omgezet naar BPMN,
-                  bijgevolg kan Open Proces Huis het diagram niet weergeven.</span>
-              {{else}}
-                <span>Er ging iets mis bij het weergeven van het diagram.</span>
-              {{/if}}
+            <AuAlert @title="Mislukt" @skin="warning" @icon="alert-triangle">
+              Visualisatie mislukt
+              {{! TODO: improve }}
             </AuAlert>
           {{/if}}
           <DataCard class="au-u-margin-top-small">
@@ -602,10 +590,6 @@
         {{/if}}
         <AuButton
           @skin={{if this.latestDiagram.isBpmnFile "primary" "secondary"}}
-          @disabled={{and
-            this.latestDiagram.isVisioFile
-            (not this.latestDiagram.bpmnFile)
-          }}
           {{on "click" (perform this.downloadLatestDiagram "bpmn")}}
         >
           BPMN
@@ -613,10 +597,6 @@
         </AuButton>
         <AuButton
           @skin="secondary"
-          @disabled={{and
-            this.latestDiagram.isVisioFile
-            (not this.latestDiagram.bpmnFile)
-          }}
           {{on "click" (perform this.downloadLatestDiagram "png")}}
         >
           Afbeelding
@@ -624,10 +604,6 @@
         </AuButton>
         <AuButton
           @skin="secondary"
-          @disabled={{and
-            this.latestDiagram.isVisioFile
-            (not this.latestDiagram.bpmnFile)
-          }}
           {{on "click" (perform this.downloadLatestDiagram "svg")}}
         >
           Vectorafbeelding
@@ -635,10 +611,6 @@
         </AuButton>
         <AuButton
           @skin="secondary"
-          @disabled={{and
-            this.latestDiagram.isVisioFile
-            (not this.latestDiagram.bpmnFile)
-          }}
           {{on "click" (perform this.downloadLatestDiagram "pdf")}}
         >
           PDF

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -594,6 +594,7 @@
         </AuButton>
         <AuButton
           @skin="secondary"
+          @disabled={{not this.latestDiagramAsSvg}}
           {{on "click" (perform this.downloadLatestDiagram "png")}}
         >
           Afbeelding
@@ -601,6 +602,7 @@
         </AuButton>
         <AuButton
           @skin="secondary"
+          @disabled={{not this.latestDiagramAsSvg}}
           {{on "click" (perform this.downloadLatestDiagram "svg")}}
         >
           Vectorafbeelding

--- a/app/utils/file-download-url.js
+++ b/app/utils/file-download-url.js
@@ -2,3 +2,11 @@ export default function generateFileDownloadUrl(fileId) {
   if (!fileId) return null;
   return `/files/${fileId}/download`;
 }
+
+export function generateVisioConversionUrl(
+  visioFileId,
+  targetExtension = 'pdf'
+) {
+  if (!visioFileId) return null;
+  return `/visio/convert?id=${visioFileId}&target=${targetExtension}`;
+}


### PR DESCRIPTION
OPH-421

Corresponding PRs:
- App: https://github.com/lblod/app-openproceshuis/pull/47
- Visio service: https://github.com/lblod/openproceshuis-visio-service/pull/2

Since converting Visio 1-to-1 to BPMN is virtually impossible, Visio files are now converted to PDF and displayed as such. The converted BPMN can still be downloaded as part of the download options.

Currently, the brower's default PDF viewer is being used, but in a future PR this should become a custom one to fit better in the app design-wise, as well not display a UUID as filename.

Also, another future PR should again make it possible to download Visio as PNG or SVG.