### PR TITLE
OPH-472: Move gedeelde processen button

### DIFF
--- a/app/components/navigation-bar.hbs
+++ b/app/components/navigation-bar.hbs
@@ -6,13 +6,13 @@
           Processen
         </AuLink>
       </Tab>
+      {{#if this.currentSession.canEdit}}
+        <Tab>
+          <AuLink @route="shared-processes" @icon="upload">
+            Gedeelde processen
+          </AuLink>
+        </Tab>
+      {{/if}}
     </AuTabs>
   </Group>
-  {{#if this.currentSession.canEdit}}
-    <Group>
-      <AuLink @route="shared-processes" @skin="button-secondary">
-        Gedeelde processen
-      </AuLink>
-    </Group>
-  {{/if}}
 </AuToolbar>

--- a/app/components/navigation-bar.hbs
+++ b/app/components/navigation-bar.hbs
@@ -8,7 +8,7 @@
       </Tab>
       {{#if this.currentSession.canEdit}}
         <Tab>
-          <AuLink @route="shared-processes" @icon="upload">
+          <AuLink @route="shared-processes" @icon="unordered-list">
             Gedeelde processen
           </AuLink>
         </Tab>


### PR DESCRIPTION
# Overview
This PR implements a simple UI change where we will use a tab to display shared processes, instead of a button.
This looks cleaner and will improve visibility and user experience.

**Link to jira ticket**
https://binnenland.atlassian.net/browse/OPH-472

![image](https://github.com/user-attachments/assets/35c84857-3a4a-463e-90bb-d45e464a6e4a)
