### PR TITLE
Visualise Visio files in custom PDF viewer

### DIFF
--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -8,9 +8,9 @@ export default class BpmnViewerComponent extends Component {
   viewer = null;
 
   @action
-  async setupViewer(element) {
-    element.tabIndex = 0; // Make element focusable
-    this.viewer = new NavigatedViewer({ container: element });
+  async setupViewer(container) {
+    container.tabIndex = 0; // Make container focusable
+    this.viewer = new NavigatedViewer({ container: container });
 
     const bpmnFileId = this.args.diagram?.isBpmnFile
       ? this.args.diagram.id
@@ -24,11 +24,11 @@ export default class BpmnViewerComponent extends Component {
     this.viewer.get('canvas').zoom('fit-viewport');
     this.disableZoomScroll();
 
-    element.addEventListener('focus', () => {
+    container.addEventListener('focus', () => {
       this.enableZoomScroll();
     });
 
-    element.addEventListener('blur', () => {
+    container.addEventListener('blur', () => {
       this.disableZoomScroll();
     });
 

--- a/app/components/bpmn-viewer.js
+++ b/app/components/bpmn-viewer.js
@@ -9,7 +9,7 @@ export default class BpmnViewerComponent extends Component {
 
   @action
   async setupViewer(container) {
-    container.tabIndex = 0; // Make container focusable
+    container.tabIndex = 0;
     this.viewer = new NavigatedViewer({ container: container });
 
     const bpmnFileId = this.args.diagram?.isBpmnFile

--- a/app/components/pdf-viewer.hbs
+++ b/app/components/pdf-viewer.hbs
@@ -1,12 +1,4 @@
-<div
+<canvas
   class="bpmn-container au-u-margin-top-small"
   {{did-insert this.setupViewer}}
->
-  {{! template-lint-disable require-valid-alt-text }}
-  <object
-    data="{{this.pdfBlobUrl}}"
-    type="application/pdf"
-    width="100%"
-    height="100%"
-  />
-</div>
+></canvas>

--- a/app/components/pdf-viewer.hbs
+++ b/app/components/pdf-viewer.hbs
@@ -1,31 +1,35 @@
 <div
-  class="bpmn-container au-u-margin-top-small"
+  class="bpmn-container au-u-margin-top-small au-u-flex au-u-flex--center au-u-flex--vertical-center"
   {{did-insert this.setupViewer}}
 >
-  <AuButtonGroup
-    @inline="true"
-    class="pdf-navigation au-u-padding au-u-padding-small"
-  >
-    <AuButton
-      @icon="chevron-left"
-      @iconAlignment="left"
-      @hideText="true"
-      {{on "click" this.goToPreviousPage}}
+  {{#if this.isLoading}}
+    <AuLoader />
+  {{else}}
+    <AuButtonGroup
+      @inline="true"
+      class="pdf-navigation au-u-padding au-u-padding-small"
     >
-      Vorige
-    </AuButton>
-    <AuButton @skin="secondary" class="navigation-counter au-u-regular">
-      {{this.currentPage}}
-      /
-      {{this.totalPages}}
-    </AuButton>
-    <AuButton
-      @icon="chevron-right"
-      @iconAlignment="right"
-      @hideText="true"
-      {{on "click" this.goToNextPage}}
-    >
-      Volgende
-    </AuButton>
-  </AuButtonGroup>
+      <AuButton
+        @icon="chevron-left"
+        @iconAlignment="left"
+        @hideText="true"
+        {{on "click" this.goToPreviousPage}}
+      >
+        Vorige
+      </AuButton>
+      <AuButton @skin="secondary" class="navigation-counter au-u-regular">
+        {{this.currentPage}}
+        /
+        {{this.totalPages}}
+      </AuButton>
+      <AuButton
+        @icon="chevron-right"
+        @iconAlignment="right"
+        @hideText="true"
+        {{on "click" this.goToNextPage}}
+      >
+        Volgende
+      </AuButton>
+    </AuButtonGroup>
+  {{/if}}
 </div>

--- a/app/components/pdf-viewer.hbs
+++ b/app/components/pdf-viewer.hbs
@@ -1,4 +1,4 @@
-<canvas
+<div
   class="bpmn-container au-u-margin-top-small"
   {{did-insert this.setupViewer}}
-></canvas>
+></div>

--- a/app/components/pdf-viewer.hbs
+++ b/app/components/pdf-viewer.hbs
@@ -1,4 +1,31 @@
 <div
   class="bpmn-container au-u-margin-top-small"
   {{did-insert this.setupViewer}}
-></div>
+>
+  <AuButtonGroup
+    @inline="true"
+    class="pdf-navigation au-u-padding au-u-padding-small"
+  >
+    <AuButton
+      @icon="chevron-left"
+      @iconAlignment="left"
+      @hideText="true"
+      {{on "click" this.goToPreviousPage}}
+    >
+      Vorige
+    </AuButton>
+    <AuButton @skin="secondary" class="navigation-counter au-u-regular">
+      {{this.currentPage}}
+      /
+      {{this.totalPages}}
+    </AuButton>
+    <AuButton
+      @icon="chevron-right"
+      @iconAlignment="right"
+      @hideText="true"
+      {{on "click" this.goToNextPage}}
+    >
+      Volgende
+    </AuButton>
+  </AuButtonGroup>
+</div>

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -4,6 +4,13 @@ import pdfjsLib from 'pdfjs-dist/build/pdf';
 import { generateVisioConversionUrl } from 'frontend-openproceshuis/utils/file-download-url';
 
 export default class PdfViewerComponent extends Component {
+  isPanning = false;
+  startX = 0;
+  startY = 0;
+  lastX = 0;
+  lastY = 0;
+  canvas = null;
+
   constructor() {
     super(...arguments);
     pdfjsLib.GlobalWorkerOptions.workerSrc =
@@ -11,8 +18,19 @@ export default class PdfViewerComponent extends Component {
   }
 
   @action
-  async setupViewer(element) {
-    element.tabIndex = 0; // Make element focusable
+  async setupViewer(container) {
+    container.tabIndex = 0; // Make container focusable
+
+    container.style.position = 'relative';
+    container.style.overflow = 'hidden'; // Prevents scrolling outside
+    container.style.userSelect = 'none';
+
+    // Create canvas dynamically
+    this.canvas = document.createElement('canvas');
+    this.canvas.style.position = 'absolute';
+    this.canvas.style.left = '0px'; // Ensures top-left alignment
+    this.canvas.style.top = '0px';
+    container.appendChild(this.canvas);
 
     const visioFileId = this.args.diagram?.isVisioFile
       ? this.args.diagram.id
@@ -20,20 +38,63 @@ export default class PdfViewerComponent extends Component {
     if (!visioFileId) return;
 
     const url = generateVisioConversionUrl(visioFileId);
-
-    const loadingTask = pdfjsLib.getDocument(url);
-    const pdf = await loadingTask.promise;
-
+    const pdf = await pdfjsLib.getDocument(url).promise;
     const page = await pdf.getPage(1);
 
-    const scale = 1.5;
+    // Get original page dimensions
+    const originalViewport = page.getViewport({ scale: 1 });
+
+    // Calculate the best scale to fit the container
+    const containerWidth = container.clientWidth;
+    const containerHeight = container.clientHeight;
+    const scaleX = containerWidth / originalViewport.width;
+    const scaleY = containerHeight / originalViewport.height;
+    const scale = Math.min(scaleX, scaleY); // Maintain aspect ratio
+
     const viewport = page.getViewport({ scale });
 
-    element.width = viewport.width;
-    element.height = viewport.height;
-    const context = element.getContext('2d');
+    this.canvas.width = viewport.width;
+    this.canvas.height = viewport.height;
+    const context = this.canvas.getContext('2d');
 
     const renderContext = { canvasContext: context, viewport };
     await page.render(renderContext).promise;
+
+    // **Align canvas top-left and ensure no offset**
+    this.lastX = 0;
+    this.lastY = 0;
+    this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+
+    this.setupPanEvents(container);
+  }
+
+  @action
+  setupPanEvents(container) {
+    let startX, startY;
+
+    const onMouseDown = (event) => {
+      this.isPanning = true;
+      startX = event.clientX - this.lastX;
+      startY = event.clientY - this.lastY;
+    };
+
+    const onMouseMove = (event) => {
+      if (!this.isPanning) return;
+
+      // Calculate new position
+      this.lastX = event.clientX - startX;
+      this.lastY = event.clientY - startY;
+
+      this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+    };
+
+    const onMouseUp = () => {
+      this.isPanning = false;
+    };
+
+    container.addEventListener('mousedown', onMouseDown);
+    container.addEventListener('mousemove', onMouseMove);
+    container.addEventListener('mouseup', onMouseUp);
+    container.addEventListener('mouseleave', onMouseUp);
   }
 }

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -1,229 +1,181 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { restartableTask } from 'ember-concurrency';
 import pdfjsLib from 'pdfjs-dist/build/pdf';
 import { generateVisioConversionUrl } from 'frontend-openproceshuis/utils/file-download-url';
 
-export default class PdfViewerComponent extends Component {
-  // Pan state
-  isPanning = false;
-  startX = 0;
-  startY = 0;
-  lastX = 0;
-  lastY = 0;
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  '//cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
 
-  // Zoom state
+export default class PdfViewerComponent extends Component {
+  pdf = null;
+  page = null;
+  container = null;
+  canvas = null;
+
+  isPanning = false;
+  panStartX = 0;
+  panStartY = 0;
+  offsetX = 0;
+  offsetY = 0;
+
   scale = 1;
   minScale = 0.5;
   maxScale = 4;
   zoomStep = 0.2;
-
-  // PDF data
-  page = null;
-  pdfWidth = 0;
-  pdfHeight = 0;
-  container = null;
-  canvas = null;
-
-  constructor() {
-    super(...arguments);
-
-    // PDF.js worker
-    pdfjsLib.GlobalWorkerOptions.workerSrc =
-      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
-  }
+  zoomScrollEnabled = false;
 
   @action
   async setupViewer(container) {
+    container.tabIndex = 0;
     this.container = container;
-    container.tabIndex = 0; // Make container focusable
 
-    // Basic container styling
+    container.style.overflow = 'hidden';
     container.style.position = 'relative';
-    container.style.overflow = 'hidden'; // No scrollbars, we'll handle panning
     container.style.userSelect = 'none';
 
-    // Create a canvas element
     this.canvas = document.createElement('canvas');
     this.canvas.style.position = 'absolute';
     this.canvas.style.left = '0px';
     this.canvas.style.top = '0px';
     container.appendChild(this.canvas);
 
-    // If there's no visio file, exit
     const visioFileId = this.args.diagram?.isVisioFile
       ? this.args.diagram.id
       : undefined;
     if (!visioFileId) return;
 
-    // Fetch and parse the PDF
-    const url = generateVisioConversionUrl(visioFileId);
-    const pdf = await pdfjsLib.getDocument(url).promise;
-    this.page = await pdf.getPage(1);
+    await this.loadPdfTask.perform(visioFileId);
 
-    // Get the PDF's "natural" size (width, height) at scale=1
-    const viewportAtOne = this.page.getViewport({ scale: 1 });
-    this.pdfWidth = viewportAtOne.width;
-    this.pdfHeight = viewportAtOne.height;
+    this.disableZoomScroll();
 
-    // Calculate the initial scale to fill exactly one dimension
-    this.calculateInitialScale();
+    container.addEventListener('focus', () => {
+      this.enableZoomScroll();
+    });
 
-    // Render the PDF at the chosen initial scale
-    await this.renderPdf();
-
-    // Position the canvas so it's top-left aligned (no offset)
-    this.lastX = 0;
-    this.lastY = 0;
-    this.updateCanvasTransform();
-
-    // Set up mouse panning and wheel-based actions
-    this.setupPanEvents();
-    this.setupWheelEvents();
+    container.addEventListener('blur', () => {
+      this.disableZoomScroll();
+    });
   }
 
-  /**
-   * Compare aspect ratios of PDF vs. container
-   * to scale so that at least one dimension is 'filled' (width or height).
-   */
-  calculateInitialScale() {
+  @restartableTask
+  *loadPdfTask(fileId) {
+    const url = generateVisioConversionUrl(fileId);
+    this.pdf = yield pdfjsLib.getDocument(url).promise;
+    this.page = yield this.pdf.getPage(1);
+
+    this.fitPdfToContainer();
+  }
+
+  async fitPdfToContainer() {
+    const unscaledViewport = this.page.getViewport({ scale: 1 });
+    const pdfWidth = unscaledViewport.width;
+    const pdfHeight = unscaledViewport.height;
+
     const containerWidth = this.container.clientWidth;
     const containerHeight = this.container.clientHeight;
 
-    const pdfAspect = this.pdfWidth / this.pdfHeight;
-    const containerAspect = containerWidth / containerHeight;
+    const scaleX = containerWidth / pdfWidth;
+    const scaleY = containerHeight / pdfHeight;
+    this.scale = Math.min(scaleX, scaleY);
 
-    // If PDF is "wider" (aspect >= container's), fill container width.
-    // Otherwise, fill container height.
-    if (pdfAspect >= containerAspect) {
-      this.scale = containerWidth / this.pdfWidth;
-    } else {
-      this.scale = containerHeight / this.pdfHeight;
-    }
+    await this.renderPdfAtScale(this.scale);
+
+    this.offsetX = 0;
+    this.offsetY = 0;
+    this.updateCanvasTransform();
   }
 
-  /**
-   * Re-renders the PDF at the current `this.scale` onto the canvas.
-   * This ensures crisp quality at all zoom levels.
-   */
-  async renderPdf() {
-    // Resize the canvas to the new scaled size
-    const scaledWidth = this.pdfWidth * this.scale;
-    const scaledHeight = this.pdfHeight * this.scale;
-    this.canvas.width = scaledWidth;
-    this.canvas.height = scaledHeight;
+  async renderPdfAtScale(newScale) {
+    const viewport = this.page.getViewport({ scale: newScale });
+    this.canvas.width = viewport.width;
+    this.canvas.height = viewport.height;
 
     const context = this.canvas.getContext('2d');
-    const viewport = this.page.getViewport({ scale: this.scale });
-
     await this.page.render({
       canvasContext: context,
       viewport,
     }).promise;
   }
 
-  /**
-   * Update the canvas' CSS transform to reflect
-   * the current `this.lastX`, `this.lastY` for panning (no scale transform needed
-   * because the PDF is re-rendered at the new scale).
-   */
   updateCanvasTransform() {
-    this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+    this.canvas.style.transform = `translate(${this.offsetX}px, ${this.offsetY}px)`;
   }
 
-  /**
-   * Mouse-based panning (dragging with left-click).
-   */
-  setupPanEvents() {
-    let dragStartX, dragStartY;
-
-    const onMouseDown = (event) => {
-      this.isPanning = true;
-      // Record the offset between the mouse and the current translation
-      dragStartX = event.clientX - this.lastX;
-      dragStartY = event.clientY - this.lastY;
-    };
-
-    const onMouseMove = (event) => {
-      if (!this.isPanning) return;
-
-      this.lastX = event.clientX - dragStartX;
-      this.lastY = event.clientY - dragStartY;
-
-      this.updateCanvasTransform();
-    };
-
-    const onMouseUp = () => {
-      this.isPanning = false;
-    };
-
-    // Attach to container
-    this.container.addEventListener('mousedown', onMouseDown);
-    this.container.addEventListener('mousemove', onMouseMove);
-    this.container.addEventListener('mouseup', onMouseUp);
-    this.container.addEventListener('mouseleave', onMouseUp);
+  @action
+  enableZoomScroll() {
+    this.zoomScrollEnabled = true;
+    this.container.addEventListener('mousedown', this.onMouseDown);
+    this.container.addEventListener('mousemove', this.onMouseMove);
+    this.container.addEventListener('mouseup', this.onMouseUp);
+    this.container.addEventListener('mouseleave', this.onMouseUp);
+    this.container.addEventListener('wheel', this.onWheel, { passive: false });
   }
 
-  /**
-   * Wheel-based scrolling and zooming:
-   * - Ctrl+Scroll = zoom in/out (centered at cursor)
-   * - Shift+Scroll = pan left/right
-   * - Normal Scroll = pan up/down
-   */
-  setupWheelEvents() {
-    this.container.addEventListener('wheel', async (event) => {
-      event.preventDefault(); // Prevent browser scroll
-
-      if (event.ctrlKey) {
-        // Zoom in or out, centered at mouse
-        await this.handleZoom(event);
-      } else if (event.shiftKey) {
-        // Shift + Scroll => horizontal movement
-        this.lastX -= event.deltaY;
-        this.updateCanvasTransform();
-      } else {
-        // Normal scroll => vertical movement
-        this.lastY -= event.deltaY;
-        this.updateCanvasTransform();
-      }
+  @action
+  disableZoomScroll() {
+    this.zoomScrollEnabled = false;
+    this.container.removeEventListener('mousedown', this.onMouseDown);
+    this.container.removeEventListener('mousemove', this.onMouseMove);
+    this.container.removeEventListener('mouseup', this.onMouseUp);
+    this.container.removeEventListener('mouseleave', this.onMouseUp);
+    this.container.removeEventListener('wheel', this.onWheel, {
+      passive: false,
     });
   }
 
-  /**
-   * Zoom in or out, re-render PDF at the new scale,
-   * and keep the cursor in the same PDF location before/after zoom.
-   */
-  async handleZoom(event) {
-    // Decide zoom direction
-    const zoomDirection = event.deltaY > 0 ? -1 : 1;
-    const oldScale = this.scale;
-    let newScale = oldScale * (1 + zoomDirection * this.zoomStep);
+  onMouseDown = (event) => {
+    this.isPanning = true;
+    this.panStartX = event.clientX - this.offsetX;
+    this.panStartY = event.clientY - this.offsetY;
+  };
 
-    // Clamp the scale
-    newScale = Math.max(this.minScale, Math.min(this.maxScale, newScale));
-    if (newScale === oldScale) {
-      return; // No zoom change
+  onMouseMove = (event) => {
+    if (!this.isPanning) return;
+
+    this.offsetX = event.clientX - this.panStartX;
+    this.offsetY = event.clientY - this.panStartY;
+    this.updateCanvasTransform();
+  };
+
+  onMouseUp = () => {
+    this.isPanning = false;
+  };
+
+  onWheel = async (event) => {
+    if (!this.zoomScrollEnabled) return;
+    event.preventDefault();
+
+    if (event.ctrlKey) {
+      await this.zoomOnCursor(event);
+    } else if (event.shiftKey) {
+      this.offsetX -= event.deltaY;
+      this.updateCanvasTransform();
+    } else {
+      this.offsetY -= event.deltaY;
+      this.updateCanvasTransform();
     }
+  };
 
-    // **1) Figure out which PDF coordinate is under the cursor**
-    const containerRect = this.container.getBoundingClientRect();
-    // Convert mouse from container coordinates to unscaled PDF coordinates
-    const mouseXInPdfCoords =
-      (event.clientX - containerRect.left - this.lastX) / oldScale;
-    const mouseYInPdfCoords =
-      (event.clientY - containerRect.top - this.lastY) / oldScale;
+  async zoomOnCursor(event) {
+    const zoomOut = event.deltaY > 0;
+    const oldScale = this.scale;
+    let newScale = oldScale * (zoomOut ? 1 - this.zoomStep : 1 + this.zoomStep);
 
-    // **2) Update scale & re-render at that scale** (ensures crisp text)
+    newScale = Math.min(this.maxScale, Math.max(this.minScale, newScale));
+    if (newScale === oldScale) return;
+
+    const rect = this.container.getBoundingClientRect();
+    const mouseXRelative =
+      (event.clientX - rect.left - this.offsetX) / oldScale;
+    const mouseYRelative = (event.clientY - rect.top - this.offsetY) / oldScale;
+
     this.scale = newScale;
-    await this.renderPdf();
+    await this.renderPdfAtScale(this.scale);
 
-    // **3) Calculate new translation so (mouseXInPdfCoords, mouseYInPdfCoords)
-    //      remains under the cursor at (event.clientX, event.clientY).**
-    this.lastX =
-      event.clientX - containerRect.left - mouseXInPdfCoords * this.scale;
-    this.lastY =
-      event.clientY - containerRect.top - mouseYInPdfCoords * this.scale;
+    this.offsetX = event.clientX - rect.left - mouseXRelative * this.scale;
+    this.offsetY = event.clientY - rect.top - mouseYRelative * this.scale;
 
-    // **4) Update transform for panning**
     this.updateCanvasTransform();
   }
 }

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -66,6 +66,7 @@ export default class PdfViewerComponent extends Component {
     this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
 
     this.setupPanEvents(container);
+    this.setupScrollEvents(container);
   }
 
   @action
@@ -96,5 +97,22 @@ export default class PdfViewerComponent extends Component {
     container.addEventListener('mousemove', onMouseMove);
     container.addEventListener('mouseup', onMouseUp);
     container.addEventListener('mouseleave', onMouseUp);
+  }
+
+  @action
+  setupScrollEvents(container) {
+    container.addEventListener('wheel', (event) => {
+      event.preventDefault(); // Prevent page scrolling
+
+      if (event.shiftKey) {
+        // Shift + Scroll → Move Left/Right
+        this.lastX -= event.deltaY; // Reverse Y to move horizontally
+      } else {
+        // Normal Scroll → Move Up/Down
+        this.lastY -= event.deltaY;
+      }
+
+      this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+    });
   }
 }

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -1,30 +1,39 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { restartableTask } from 'ember-concurrency';
+import pdfjsLib from 'pdfjs-dist/build/pdf';
 import { generateVisioConversionUrl } from 'frontend-openproceshuis/utils/file-download-url';
 
 export default class PdfViewerComponent extends Component {
-  @tracked pdfBlobUrl = null;
+  constructor() {
+    super(...arguments);
+    pdfjsLib.GlobalWorkerOptions.workerSrc =
+      '//cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+  }
 
   @action
-  async setupViewer() {
+  async setupViewer(element) {
+    element.tabIndex = 0; // Make element focusable
+
     const visioFileId = this.args.diagram?.isVisioFile
       ? this.args.diagram.id
       : undefined;
     if (!visioFileId) return;
 
-    const blob = await this.downloadVisioAsPdf.perform(visioFileId);
-    if (!blob) return;
-
-    this.pdfBlobUrl = URL.createObjectURL(blob);
-  }
-
-  @restartableTask
-  *downloadVisioAsPdf(visioFileId) {
     const url = generateVisioConversionUrl(visioFileId);
-    const response = yield fetch(url);
-    if (!response.ok) throw Error(response.status);
-    return yield response.blob();
+
+    const loadingTask = pdfjsLib.getDocument(url);
+    const pdf = await loadingTask.promise;
+
+    const page = await pdf.getPage(1);
+
+    const scale = 1.5;
+    const viewport = page.getViewport({ scale });
+
+    element.width = viewport.width;
+    element.height = viewport.height;
+    const context = element.getContext('2d');
+
+    const renderContext = { canvasContext: context, viewport };
+    await page.render(renderContext).promise;
   }
 }

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -14,6 +14,7 @@ export default class PdfViewerComponent extends Component {
   container = null;
   canvas = null;
   currentRenderTask = null;
+  @tracked isLoading = true;
 
   @tracked currentPage = 1;
   @tracked totalPages = 1;
@@ -52,6 +53,11 @@ export default class PdfViewerComponent extends Component {
     if (!visioFileId) return;
 
     await this.loadPdfTask.perform(visioFileId);
+    console.log('loading pdf done');
+
+    await this.fitPdfToContainer();
+    console.log('fitting pdf done');
+    this.isLoading = false;
 
     this.disableZoomScroll();
 
@@ -71,8 +77,6 @@ export default class PdfViewerComponent extends Component {
 
     this.currentPage = 1;
     this.page = yield this.pdf.getPage(this.currentPage);
-
-    yield this.fitPdfToContainer();
   }
 
   async fitPdfToContainer() {

--- a/app/components/pdf-viewer.js
+++ b/app/components/pdf-viewer.js
@@ -4,115 +4,226 @@ import pdfjsLib from 'pdfjs-dist/build/pdf';
 import { generateVisioConversionUrl } from 'frontend-openproceshuis/utils/file-download-url';
 
 export default class PdfViewerComponent extends Component {
+  // Pan state
   isPanning = false;
   startX = 0;
   startY = 0;
   lastX = 0;
   lastY = 0;
+
+  // Zoom state
+  scale = 1;
+  minScale = 0.5;
+  maxScale = 4;
+  zoomStep = 0.2;
+
+  // PDF data
+  page = null;
+  pdfWidth = 0;
+  pdfHeight = 0;
+  container = null;
   canvas = null;
 
   constructor() {
     super(...arguments);
+
+    // PDF.js worker
     pdfjsLib.GlobalWorkerOptions.workerSrc =
       '//cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
   }
 
   @action
   async setupViewer(container) {
+    this.container = container;
     container.tabIndex = 0; // Make container focusable
 
+    // Basic container styling
     container.style.position = 'relative';
-    container.style.overflow = 'hidden'; // Prevents scrolling outside
+    container.style.overflow = 'hidden'; // No scrollbars, we'll handle panning
     container.style.userSelect = 'none';
 
-    // Create canvas dynamically
+    // Create a canvas element
     this.canvas = document.createElement('canvas');
     this.canvas.style.position = 'absolute';
-    this.canvas.style.left = '0px'; // Ensures top-left alignment
+    this.canvas.style.left = '0px';
     this.canvas.style.top = '0px';
     container.appendChild(this.canvas);
 
+    // If there's no visio file, exit
     const visioFileId = this.args.diagram?.isVisioFile
       ? this.args.diagram.id
       : undefined;
     if (!visioFileId) return;
 
+    // Fetch and parse the PDF
     const url = generateVisioConversionUrl(visioFileId);
     const pdf = await pdfjsLib.getDocument(url).promise;
-    const page = await pdf.getPage(1);
+    this.page = await pdf.getPage(1);
 
-    // Get original page dimensions
-    const originalViewport = page.getViewport({ scale: 1 });
+    // Get the PDF's "natural" size (width, height) at scale=1
+    const viewportAtOne = this.page.getViewport({ scale: 1 });
+    this.pdfWidth = viewportAtOne.width;
+    this.pdfHeight = viewportAtOne.height;
 
-    // Calculate the best scale to fit the container
-    const containerWidth = container.clientWidth;
-    const containerHeight = container.clientHeight;
-    const scaleX = containerWidth / originalViewport.width;
-    const scaleY = containerHeight / originalViewport.height;
-    const scale = Math.min(scaleX, scaleY); // Maintain aspect ratio
+    // Calculate the initial scale to fill exactly one dimension
+    this.calculateInitialScale();
 
-    const viewport = page.getViewport({ scale });
+    // Render the PDF at the chosen initial scale
+    await this.renderPdf();
 
-    this.canvas.width = viewport.width;
-    this.canvas.height = viewport.height;
-    const context = this.canvas.getContext('2d');
-
-    const renderContext = { canvasContext: context, viewport };
-    await page.render(renderContext).promise;
-
-    // **Align canvas top-left and ensure no offset**
+    // Position the canvas so it's top-left aligned (no offset)
     this.lastX = 0;
     this.lastY = 0;
-    this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+    this.updateCanvasTransform();
 
-    this.setupPanEvents(container);
-    this.setupScrollEvents(container);
+    // Set up mouse panning and wheel-based actions
+    this.setupPanEvents();
+    this.setupWheelEvents();
   }
 
-  @action
-  setupPanEvents(container) {
-    let startX, startY;
+  /**
+   * Compare aspect ratios of PDF vs. container
+   * to scale so that at least one dimension is 'filled' (width or height).
+   */
+  calculateInitialScale() {
+    const containerWidth = this.container.clientWidth;
+    const containerHeight = this.container.clientHeight;
+
+    const pdfAspect = this.pdfWidth / this.pdfHeight;
+    const containerAspect = containerWidth / containerHeight;
+
+    // If PDF is "wider" (aspect >= container's), fill container width.
+    // Otherwise, fill container height.
+    if (pdfAspect >= containerAspect) {
+      this.scale = containerWidth / this.pdfWidth;
+    } else {
+      this.scale = containerHeight / this.pdfHeight;
+    }
+  }
+
+  /**
+   * Re-renders the PDF at the current `this.scale` onto the canvas.
+   * This ensures crisp quality at all zoom levels.
+   */
+  async renderPdf() {
+    // Resize the canvas to the new scaled size
+    const scaledWidth = this.pdfWidth * this.scale;
+    const scaledHeight = this.pdfHeight * this.scale;
+    this.canvas.width = scaledWidth;
+    this.canvas.height = scaledHeight;
+
+    const context = this.canvas.getContext('2d');
+    const viewport = this.page.getViewport({ scale: this.scale });
+
+    await this.page.render({
+      canvasContext: context,
+      viewport,
+    }).promise;
+  }
+
+  /**
+   * Update the canvas' CSS transform to reflect
+   * the current `this.lastX`, `this.lastY` for panning (no scale transform needed
+   * because the PDF is re-rendered at the new scale).
+   */
+  updateCanvasTransform() {
+    this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+  }
+
+  /**
+   * Mouse-based panning (dragging with left-click).
+   */
+  setupPanEvents() {
+    let dragStartX, dragStartY;
 
     const onMouseDown = (event) => {
       this.isPanning = true;
-      startX = event.clientX - this.lastX;
-      startY = event.clientY - this.lastY;
+      // Record the offset between the mouse and the current translation
+      dragStartX = event.clientX - this.lastX;
+      dragStartY = event.clientY - this.lastY;
     };
 
     const onMouseMove = (event) => {
       if (!this.isPanning) return;
 
-      // Calculate new position
-      this.lastX = event.clientX - startX;
-      this.lastY = event.clientY - startY;
+      this.lastX = event.clientX - dragStartX;
+      this.lastY = event.clientY - dragStartY;
 
-      this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
+      this.updateCanvasTransform();
     };
 
     const onMouseUp = () => {
       this.isPanning = false;
     };
 
-    container.addEventListener('mousedown', onMouseDown);
-    container.addEventListener('mousemove', onMouseMove);
-    container.addEventListener('mouseup', onMouseUp);
-    container.addEventListener('mouseleave', onMouseUp);
+    // Attach to container
+    this.container.addEventListener('mousedown', onMouseDown);
+    this.container.addEventListener('mousemove', onMouseMove);
+    this.container.addEventListener('mouseup', onMouseUp);
+    this.container.addEventListener('mouseleave', onMouseUp);
   }
 
-  @action
-  setupScrollEvents(container) {
-    container.addEventListener('wheel', (event) => {
-      event.preventDefault(); // Prevent page scrolling
+  /**
+   * Wheel-based scrolling and zooming:
+   * - Ctrl+Scroll = zoom in/out (centered at cursor)
+   * - Shift+Scroll = pan left/right
+   * - Normal Scroll = pan up/down
+   */
+  setupWheelEvents() {
+    this.container.addEventListener('wheel', async (event) => {
+      event.preventDefault(); // Prevent browser scroll
 
-      if (event.shiftKey) {
-        // Shift + Scroll → Move Left/Right
-        this.lastX -= event.deltaY; // Reverse Y to move horizontally
+      if (event.ctrlKey) {
+        // Zoom in or out, centered at mouse
+        await this.handleZoom(event);
+      } else if (event.shiftKey) {
+        // Shift + Scroll => horizontal movement
+        this.lastX -= event.deltaY;
+        this.updateCanvasTransform();
       } else {
-        // Normal Scroll → Move Up/Down
+        // Normal scroll => vertical movement
         this.lastY -= event.deltaY;
+        this.updateCanvasTransform();
       }
-
-      this.canvas.style.transform = `translate(${this.lastX}px, ${this.lastY}px)`;
     });
+  }
+
+  /**
+   * Zoom in or out, re-render PDF at the new scale,
+   * and keep the cursor in the same PDF location before/after zoom.
+   */
+  async handleZoom(event) {
+    // Decide zoom direction
+    const zoomDirection = event.deltaY > 0 ? -1 : 1;
+    const oldScale = this.scale;
+    let newScale = oldScale * (1 + zoomDirection * this.zoomStep);
+
+    // Clamp the scale
+    newScale = Math.max(this.minScale, Math.min(this.maxScale, newScale));
+    if (newScale === oldScale) {
+      return; // No zoom change
+    }
+
+    // **1) Figure out which PDF coordinate is under the cursor**
+    const containerRect = this.container.getBoundingClientRect();
+    // Convert mouse from container coordinates to unscaled PDF coordinates
+    const mouseXInPdfCoords =
+      (event.clientX - containerRect.left - this.lastX) / oldScale;
+    const mouseYInPdfCoords =
+      (event.clientY - containerRect.top - this.lastY) / oldScale;
+
+    // **2) Update scale & re-render at that scale** (ensures crisp text)
+    this.scale = newScale;
+    await this.renderPdf();
+
+    // **3) Calculate new translation so (mouseXInPdfCoords, mouseYInPdfCoords)
+    //      remains under the cursor at (event.clientX, event.clientY).**
+    this.lastX =
+      event.clientX - containerRect.left - mouseXInPdfCoords * this.scale;
+    this.lastY =
+      event.clientY - containerRect.top - mouseYInPdfCoords * this.scale;
+
+    // **4) Update transform for panning**
+    this.updateCanvasTransform();
   }
 }

--- a/app/styles/components/_bpmn-viewer.scss
+++ b/app/styles/components/_bpmn-viewer.scss
@@ -16,3 +16,15 @@
 .bjs-powered-by {
   display: none;
 }
+
+.pdf-navigation {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  z-index: 10;
+
+  .navigation-counter {
+    text-decoration: none !important;
+    cursor: default;
+  }
+}

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -252,13 +252,17 @@
             Er ging iets mis bij het ophalen van het diagram. Probeer later
             opnieuw.
           </AuAlert>
-        {{else if this.latestDiagram}}
+        {{else if
+          (and
+            this.latestDiagram
+            (or this.latestDiagram.isBpmnFile this.latestDiagram.isVisioFile)
+          )
+        }}
+          <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
+            Klik en hou vast om diagram te bedienen. Gebruik ctrl en scrollwiel
+            om in en uit te zoomen. Klik elders om bediening uit te schakelen.
+          </AuHelpText>
           {{#if this.latestDiagram.isBpmnFile}}
-            <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
-              Klik en hou vast om diagram te bedienen. Gebruik ctrl en
-              scrollwiel om in en uit te zoomen. Klik elders om bediening uit te
-              schakelen.
-            </AuHelpText>
             <BpmnViewer
               @diagram={{this.latestDiagram}}
               @onBpmnLoaded={{this.setLatestDiagramAsBpmn}}
@@ -266,11 +270,6 @@
             />
           {{else if this.latestDiagram.isVisioFile}}
             <PdfViewer @diagram={{this.latestDiagram}} />
-          {{else}}
-            <AuAlert @title="Mislukt" @skin="warning" @icon="alert-triangle">
-              Visualisatie mislukt
-              {{! TODO: improve }}
-            </AuAlert>
           {{/if}}
           <DataCard class="au-u-margin-top-small">
             <:header></:header>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,23 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
+    autoImport: {
+      webpack: {
+        module: {
+          rules: [
+            {
+              test: /pdf.js/,
+              use: {
+                loader: 'babel-loader',
+                options: {
+                  presets: [['@babel/preset-env', { targets: 'defaults' }]],
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "husky": "^4.3.8",
         "lint-staged": "^11.2.3",
         "loader.js": "^4.7.0",
+        "pdfjs-dist": "3.11.174",
         "prettier": "^2.8.7",
         "qunit": "^2.19.4",
         "qunit-dom": "^2.0.0",
@@ -3807,6 +3808,170 @@
       },
       "engines": {
         "node": "12.* || >= 14"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -9461,6 +9626,22 @@
         }
       ]
     },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -11593,6 +11774,16 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -28442,6 +28633,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/path2d-polyfill": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
+      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -28456,6 +28657,19 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "path2d-polyfill": "^2.0.1"
       }
     },
     "node_modules/performance-now": {
@@ -31035,6 +31249,65 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-get/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-get/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/simple-html-tokenizer": {
       "version": "0.5.11",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "husky": "^4.3.8",
     "lint-staged": "^11.2.3",
     "loader.js": "^4.7.0",
+    "pdfjs-dist": "3.11.174",
     "prettier": "^2.8.7",
     "qunit": "^2.19.4",
     "qunit-dom": "^2.0.0",


### PR DESCRIPTION
OPH-482

Instead of the browser's default, a custom PDF viewer is used to display Visio files. Its look and feel mirror the BPMN viewer as closely as possible. Buttons for navigated between pages are also introduced.

For quick testing:

```
ember serve --proxy "https://dev.openproceshuis.lblod.info"
```

and visit a process with a Visio file, e.g.

```
http://localhost:4200/processen/679398D9C6E009ADB3495B8F
```