### PR TITLE
Don't show disabled download options

### DIFF
--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -591,22 +591,22 @@
           BPMN
           <span class="au-u-para-tiny au-u-regular">(.bpmn)</span>
         </AuButton>
-        <AuButton
-          @skin="secondary"
-          @disabled={{not this.latestDiagramAsSvg}}
-          {{on "click" (perform this.downloadLatestDiagram "png")}}
-        >
-          Afbeelding
-          <span class="au-u-para-tiny au-u-regular">(.png)</span>
-        </AuButton>
-        <AuButton
-          @skin="secondary"
-          @disabled={{not this.latestDiagramAsSvg}}
-          {{on "click" (perform this.downloadLatestDiagram "svg")}}
-        >
-          Vectorafbeelding
-          <span class="au-u-para-tiny au-u-regular">(.svg)</span>
-        </AuButton>
+        {{#if this.latestDiagramAsSvg}}
+          <AuButton
+            @skin="secondary"
+            {{on "click" (perform this.downloadLatestDiagram "png")}}
+          >
+            Afbeelding
+            <span class="au-u-para-tiny au-u-regular">(.png)</span>
+          </AuButton>
+          <AuButton
+            @skin="secondary"
+            {{on "click" (perform this.downloadLatestDiagram "svg")}}
+          >
+            Vectorafbeelding
+            <span class="au-u-para-tiny au-u-regular">(.svg)</span>
+          </AuButton>
+        {{/if}}
         <AuButton
           @skin="secondary"
           {{on "click" (perform this.downloadLatestDiagram "pdf")}}


### PR DESCRIPTION
OPH-533

Instead of disabling download options that won't work, simply hide them.

Before:
![image](https://github.com/user-attachments/assets/a62f19cb-cf05-4ef8-acd5-1cd70ebcd8ac)

After:
![image](https://github.com/user-attachments/assets/6750a179-4ae4-4ccd-9884-a8fc0a700f27)
