### PR TITLE
fix login page and show shared processes in my local government view

### DIFF
--- a/app/routes/my-local-government/index.js
+++ b/app/routes/my-local-government/index.js
@@ -32,11 +32,6 @@ export default class MyLocalGovernmentIndexRoute extends Route {
       },
       include:
         'publisher,users,publisher.primary-site,publisher.primary-site.contacts,publisher.classification',
-      filter: {
-        users: {
-          id: this.currentSession.group.id,
-        },
-      },
     };
 
     if (params.sort) {
@@ -69,6 +64,8 @@ export default class MyLocalGovernmentIndexRoute extends Route {
       query['filter[is-blueprint]'] = params.blueprint;
     }
 
+    query['filter[:or:][users][id]'] = this.currentSession.group.id;
+    query['filter[:or:][publisher][id]'] = this.currentSession.group.id;
     query['filter[:not:status]'] = ENV.resourceStates.archived;
 
     return yield this.store.query('process', query);

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -11,15 +11,12 @@
       lokale beheerder (ICT).
     </AuAlert>
   {{/if}}
-
   <AuBodyContainer class="au-u-background-gray-100">
     <section class="c-home">
       <div class="au-o-flow">
         <AuContent>
-          <AuHeading @level="1" @skin="2">
-            Welkom bij Open Proces Huis, jouw centrale bron voor het ontdekken
-            en delen van processen.
-          </AuHeading>
+          <AuHeading @level="1" @skin="2">Welkom bij Open Proces Huis, jouw
+            centrale bron voor het ontdekken en delen van processen.</AuHeading>
           <div class="c-home__visual">
             <img
               src="/assets/images/homepage-visual.svg"
@@ -28,15 +25,13 @@
               {{!template-lint-disable require-valid-alt-text}}
             />
           </div>
-          <p>
-            Raadpleeg, doorzoek en upload processen als originele BPMN- of
+          <p>Raadpleeg, doorzoek en upload processen als originele BPMN- of
             Visiobestanden naar het Open Proces Huis, de centrale bron voor
-            lokale besturen in Vlaanderen om processen te ontdekken en te delen.
-          </p>
+            lokale besturen in Vlaanderen om processen te ontdekken en te delen.</p>
         </AuContent>
         <div class="au-c-home__form au-o-flow">
           <div class="au-o-grid au-o-grid--small">
-            {{#if this.currentSession.isAdmin}}
+            {{#if (or this.currentSession.canEdit this.currentSession.isAdmin)}}
               <div class="au-o-grid__item au-u-1-2@medium">
                 <AuCard @flex={{true}} as |c|>
                   <c.header
@@ -44,10 +39,9 @@
                     @badgeIcon="sitemap"
                     @badgeSize="small"
                   >
-                    <AuHeading
-                      @level="2"
-                      @skin="4"
-                    >Processenbibliotheek</AuHeading>
+                    <AuHeading @level="2" @skin="4">
+                      Processenbibliotheek
+                    </AuHeading>
                   </c.header>
                   <c.content>
                     <AuList @divider={{true}} as |Item|>
@@ -68,7 +62,9 @@
                     @badgeIcon="upload"
                     @badgeSize="small"
                   >
-                    <AuHeading @level="2" @skin="4">Deel jouw processen</AuHeading>
+                    <AuHeading @level="2" @skin="4">
+                      Deel jouw processen
+                    </AuHeading>
                   </c.header>
                   <c.content>
                     <AuList @divider={{true}} as |Item|>
@@ -84,88 +80,45 @@
                   </c.footer>
                 </AuCard>
               </div>
-              <div class="au-o-grid__item au-u-1-2@medium">
-                <AuCard @flex={{true}} as |c|>
-                  <c.header
-                    @badgeSkin="brand"
-                    @badgeIcon="upload"
-                    @badgeSize="small"
-                  >
-                    <AuHeading @level="2" @skin="4">Administratie</AuHeading>
-                  </c.header>
-                  <c.content>
-                    <AuList @divider={{true}} as |Item|>
-                      <Item>Raadpleeg rapporten</Item>
-                      <Item>Bevraag de databank</Item>
-                    </AuList>
-                  </c.content>
-                  <c.footer>
-                    <div class="au-u-h-functional au-o-flow au-o-flow--small">
-                      <AuLink
-                        @skin="button"
-                        @route="reporting"
-                      >Rapportering</AuLink>
-                      <AuLink
-                        @skin="button-secondary"
-                        @route="sparql"
-                      >SPARQL</AuLink>
-                    </div>
-                  </c.footer>
-                </AuCard>
-              </div>
-            {{else if this.currentSession.canEdit}}
-              <div class="au-o-grid__item au-u-1-2@medium">
-                <AuCard @flex={{true}} as |c|>
-                  <c.header
-                    @badgeSkin="brand"
-                    @badgeIcon="sitemap"
-                    @badgeSize="small"
-                  >
-                    <AuHeading
-                      @level="2"
-                      @skin="4"
-                    >Processenbibliotheek</AuHeading>
-                  </c.header>
-                  <c.content>
-                    <AuList @divider={{true}} as |Item|>
-                      <Item>Raadpleeg processen</Item>
-                    </AuList>
-                  </c.content>
-                  <c.footer>
-                    <div class="au-u-h-functional au-o-flow au-o-flow--small">
-                      <AuLink @skin="button" @route="processes">Toon Processen</AuLink>
-                    </div>
-                  </c.footer>
-                </AuCard>
-              </div>
-              <div class="au-o-grid__item au-u-1-2@medium">
-                <AuCard @flex={{true}} as |c|>
-                  <c.header
-                    @badgeSkin="brand"
-                    @badgeIcon="upload"
-                    @badgeSize="small"
-                  >
-                    <AuHeading @level="2" @skin="4">Deel jouw processen</AuHeading>
-                  </c.header>
-                  <c.content>
-                    <AuList @divider={{true}} as |Item|>
-                      <Item>Upload processen</Item>
-                      <Item>Beheer gedeelde processen</Item>
-                    </AuList>
-                  </c.content>
-                  <c.footer>
-                    <div class="au-u-h-functional au-o-flow au-o-flow--small">
-                      <AuLink @skin="button" @route="shared-processes">Deel jouw
-                        processen</AuLink>
-                    </div>
-                  </c.footer>
-                </AuCard>
-              </div>
+              {{#if this.currentSession.isAdmin}}
+                <div class="au-o-grid__item au-u-1-2@medium">
+                  <AuCard @flex={{true}} as |c|>
+                    <c.header
+                      @badgeSkin="brand"
+                      @badgeIcon="upload"
+                      @badgeSize="small"
+                    >
+                      <AuHeading @level="2" @skin="4">
+                        Administratie
+                      </AuHeading>
+                    </c.header>
+                    <c.content>
+                      <AuList @divider={{true}} as |Item|>
+                        <Item>Raadpleeg rapporten</Item>
+                        <Item>Bevraag de databank</Item>
+                      </AuList>
+                    </c.content>
+                    <c.footer>
+                      <div class="au-u-h-functional au-o-flow au-o-flow--small">
+                        <AuLink
+                          @skin="button"
+                          @route="reporting"
+                        >Rapportering</AuLink>
+                        <AuLink
+                          @skin="button-secondary"
+                          @route="sparql"
+                        >SPARQL</AuLink>
+                      </div>
+                    </c.footer>
+                  </AuCard>
+                </div>
+              {{/if}}
             {{else}}
               <div class="au-o-grid__item au-u-1-2@medium">
                 <AuLink @skin="button" @route="auth.login">Log in</AuLink>
               </div>
             {{/if}}
+
           </div>
           <p class="au-u-text-center">
             <AuLinkExternal

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -11,12 +11,15 @@
       lokale beheerder (ICT).
     </AuAlert>
   {{/if}}
+
   <AuBodyContainer class="au-u-background-gray-100">
     <section class="c-home">
       <div class="au-o-flow">
         <AuContent>
-          <AuHeading @level="1" @skin="2">Welkom bij Open Proces Huis, jouw
-            centrale bron voor het ontdekken en delen van processen.</AuHeading>
+          <AuHeading @level="1" @skin="2">
+            Welkom bij Open Proces Huis, jouw centrale bron voor het ontdekken
+            en delen van processen.
+          </AuHeading>
           <div class="c-home__visual">
             <img
               src="/assets/images/homepage-visual.svg"
@@ -25,13 +28,15 @@
               {{!template-lint-disable require-valid-alt-text}}
             />
           </div>
-          <p>Raadpleeg, doorzoek en upload processen als originele BPMN- of
+          <p>
+            Raadpleeg, doorzoek en upload processen als originele BPMN- of
             Visiobestanden naar het Open Proces Huis, de centrale bron voor
-            lokale besturen in Vlaanderen om processen te ontdekken en te delen.</p>
+            lokale besturen in Vlaanderen om processen te ontdekken en te delen.
+          </p>
         </AuContent>
         <div class="au-c-home__form au-o-flow">
           <div class="au-o-grid au-o-grid--small">
-            {{#if this.currentSession.canEdit}}
+            {{#if this.currentSession.isAdmin}}
               <div class="au-o-grid__item au-u-1-2@medium">
                 <AuCard @flex={{true}} as |c|>
                   <c.header
@@ -39,9 +44,10 @@
                     @badgeIcon="sitemap"
                     @badgeSize="small"
                   >
-                    <AuHeading @level="2" @skin="4">
-                      Processenbibliotheek
-                    </AuHeading>
+                    <AuHeading
+                      @level="2"
+                      @skin="4"
+                    >Processenbibliotheek</AuHeading>
                   </c.header>
                   <c.content>
                     <AuList @divider={{true}} as |Item|>
@@ -62,9 +68,7 @@
                     @badgeIcon="upload"
                     @badgeSize="small"
                   >
-                    <AuHeading @level="2" @skin="4">
-                      Deel jouw processen
-                    </AuHeading>
+                    <AuHeading @level="2" @skin="4">Deel jouw processen</AuHeading>
                   </c.header>
                   <c.content>
                     <AuList @divider={{true}} as |Item|>
@@ -80,45 +84,88 @@
                   </c.footer>
                 </AuCard>
               </div>
-              {{#if this.currentSession.isAdmin}}
-                <div class="au-o-grid__item au-u-1-2@medium">
-                  <AuCard @flex={{true}} as |c|>
-                    <c.header
-                      @badgeSkin="brand"
-                      @badgeIcon="upload"
-                      @badgeSize="small"
-                    >
-                      <AuHeading @level="2" @skin="4">
-                        Administratie
-                      </AuHeading>
-                    </c.header>
-                    <c.content>
-                      <AuList @divider={{true}} as |Item|>
-                        <Item>Raadpleeg rapporten</Item>
-                        <Item>Bevraag de databank</Item>
-                      </AuList>
-                    </c.content>
-                    <c.footer>
-                      <div class="au-u-h-functional au-o-flow au-o-flow--small">
-                        <AuLink
-                          @skin="button"
-                          @route="reporting"
-                        >Rapportering</AuLink>
-                        <AuLink
-                          @skin="button-secondary"
-                          @route="sparql"
-                        >SPARQL</AuLink>
-                      </div>
-                    </c.footer>
-                  </AuCard>
-                </div>
-              {{/if}}
+              <div class="au-o-grid__item au-u-1-2@medium">
+                <AuCard @flex={{true}} as |c|>
+                  <c.header
+                    @badgeSkin="brand"
+                    @badgeIcon="upload"
+                    @badgeSize="small"
+                  >
+                    <AuHeading @level="2" @skin="4">Administratie</AuHeading>
+                  </c.header>
+                  <c.content>
+                    <AuList @divider={{true}} as |Item|>
+                      <Item>Raadpleeg rapporten</Item>
+                      <Item>Bevraag de databank</Item>
+                    </AuList>
+                  </c.content>
+                  <c.footer>
+                    <div class="au-u-h-functional au-o-flow au-o-flow--small">
+                      <AuLink
+                        @skin="button"
+                        @route="reporting"
+                      >Rapportering</AuLink>
+                      <AuLink
+                        @skin="button-secondary"
+                        @route="sparql"
+                      >SPARQL</AuLink>
+                    </div>
+                  </c.footer>
+                </AuCard>
+              </div>
+            {{else if this.currentSession.canEdit}}
+              <div class="au-o-grid__item au-u-1-2@medium">
+                <AuCard @flex={{true}} as |c|>
+                  <c.header
+                    @badgeSkin="brand"
+                    @badgeIcon="sitemap"
+                    @badgeSize="small"
+                  >
+                    <AuHeading
+                      @level="2"
+                      @skin="4"
+                    >Processenbibliotheek</AuHeading>
+                  </c.header>
+                  <c.content>
+                    <AuList @divider={{true}} as |Item|>
+                      <Item>Raadpleeg processen</Item>
+                    </AuList>
+                  </c.content>
+                  <c.footer>
+                    <div class="au-u-h-functional au-o-flow au-o-flow--small">
+                      <AuLink @skin="button" @route="processes">Toon Processen</AuLink>
+                    </div>
+                  </c.footer>
+                </AuCard>
+              </div>
+              <div class="au-o-grid__item au-u-1-2@medium">
+                <AuCard @flex={{true}} as |c|>
+                  <c.header
+                    @badgeSkin="brand"
+                    @badgeIcon="upload"
+                    @badgeSize="small"
+                  >
+                    <AuHeading @level="2" @skin="4">Deel jouw processen</AuHeading>
+                  </c.header>
+                  <c.content>
+                    <AuList @divider={{true}} as |Item|>
+                      <Item>Upload processen</Item>
+                      <Item>Beheer gedeelde processen</Item>
+                    </AuList>
+                  </c.content>
+                  <c.footer>
+                    <div class="au-u-h-functional au-o-flow au-o-flow--small">
+                      <AuLink @skin="button" @route="shared-processes">Deel jouw
+                        processen</AuLink>
+                    </div>
+                  </c.footer>
+                </AuCard>
+              </div>
             {{else}}
               <div class="au-o-grid__item au-u-1-2@medium">
                 <AuLink @skin="button" @route="auth.login">Log in</AuLink>
               </div>
             {{/if}}
-
           </div>
           <p class="au-u-text-center">
             <AuLinkExternal


### PR DESCRIPTION
The local government view needed to also include the processes that were uploaded by the current group.
This PR also fixes a bug where the admins got to see the login page instead of the correct module cards.