### PR TITLE
added filter param to ignore archived processes

### DIFF
--- a/app/components/process/blueprint-card/blueprint-multiple-select.js
+++ b/app/components/process/blueprint-card/blueprint-multiple-select.js
@@ -1,16 +1,18 @@
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
+import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessIcrCardBlueprintMultipleSelectComponent extends Component {
   @service store;
 
   @task
   *loadBlueprintProcessesTask(params) {
-    const query = {
+    let query = {
+      title: params,
       filter: {
         'is-blueprint': true,
-        title: params,
+        ':not:status': ENV.resourceStates.archived,
       },
     };
 


### PR DESCRIPTION
This is a little bugfix where the link-to-blueprint dropdown was also showing archived processes.