### PR TITLE
Feature: Relevant administrative units as extra metadata

### DIFF
--- a/app/components/process-select-by-classification.hbs
+++ b/app/components/process-select-by-classification.hbs
@@ -1,7 +1,6 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
-  <PowerSelect
+  <PowerSelectMultiple
     {{did-insert this.loadProcessClassificationsTask.perform}}
-    @allowClear={{true}}
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @options={{this.classifications}}
@@ -11,5 +10,5 @@
     as |classification|
   >
     {{classification.label}}
-  </PowerSelect>
+  </PowerSelectMultiple>
 </div>

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -27,7 +27,6 @@ export default class ProcessSelectByClassificationComponent extends Component {
 
     const classificationIds = new Set();
     activeProcesses.forEach((process) => {
-      classificationIds.add(process.publisher?.classification.id);
       process.relevantAdministrativeUnits.forEach((unit) => {
         classificationIds.add(unit.id);
       });

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -27,7 +27,7 @@ export default class ProcessSelectByClassificationComponent extends Component {
 
     const classificationIds = new Set();
     activeProcesses.forEach((process) => {
-      classificationIds.add(process.publisher.classification.id);
+      classificationIds.add(process.publisher?.classification.id);
       process.relevantAdministrativeUnits.forEach((unit) => {
         classificationIds.add(unit.id);
       });

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -23,6 +23,7 @@ export default class ProcessSelectByClassificationComponent extends Component {
     const activeProcesses = yield this.store.query('process', {
       'filter[:not:status]': ENV.resourceStates.archived,
       include: 'relevant-administrative-units',
+      page: { number: 0, size: 1000 },
     });
 
     const classificationIds = new Set();

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -23,7 +23,7 @@ export default class ProcessSelectByClassificationComponent extends Component {
     const activeProcesses = yield this.store.query('process', {
       'filter[:not:status]': ENV.resourceStates.archived,
       include: 'relevant-administrative-units',
-      page: { number: 0, size: 1000 },
+      page: { number: 0, size: 1000 }, //TODO: if OPH grows we should keep the size of this page in mind to prevent performance issues
     });
 
     const classificationIds = new Set();

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -27,13 +27,16 @@ export default class ProcessSelectByClassificationComponent extends Component {
     );
     this.classifications = result;
 
-    const selectedClassificationLabel =
-      this.router.currentRoute.queryParams.classification;
-    if (selectedClassificationLabel) {
-      const selectedClassification = this.classifications.find(
-        (classification) => classification.label === selectedClassificationLabel
+    const classificationsParam =
+      this.router.currentRoute.queryParams.classifications;
+    if (classificationsParam) {
+      const classificationLabels = classificationsParam.split(',');
+      const selectedClassifications = this.classifications.filter(
+        (classification) => classificationLabels.includes(classification.label)
       );
-      this.args.onChange(selectedClassification);
+      if (selectedClassifications.length > 0) {
+        this.args.onChange(selectedClassifications);
+      }
     }
   }
 }

--- a/app/components/process-select-by-classification.js
+++ b/app/components/process-select-by-classification.js
@@ -19,14 +19,7 @@ export default class ProcessSelectByClassificationComponent extends Component {
       sort: ':no-case:label',
     };
 
-    if (this.args.publisher) {
-      query['filter[:or:][processes][publisher][id]'] = this.args.publisher;
-      query['filter[:or:][processes][users][id]'] = this.args.publisher;
-      query['filter[:or:][groups][:has:processes]'] = true;
-    } else {
-      query['filter[:or:][groups][:has:processes]'] = true;
-      query['filter[:or:][:has:processes]'] = true;
-    }
+    query['filter[:has:processes]'] = true;
 
     const result = yield this.store.query(
       'administrative-unit-classification-code',

--- a/app/components/process-select-by-group.hbs
+++ b/app/components/process-select-by-group.hbs
@@ -9,7 +9,7 @@
     @search={{perform this.loadGroupsTask}}
     @selected={{@selected}}
     @onChange={{@onChange}}
-    @classification={{@classification}}
+    @classifications={{@classifications}}
     @triggerId={{@id}}
     as |group|
   >

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -15,20 +15,15 @@ export default class ProcessSelectByGroupComponent extends Component {
       page: {
         size: 50,
       },
-      'filter[:has:processes]': true,
       filter: {
         name: searchParams,
+        ':has:processes': true,
       },
       sort: ':no-case:name',
     };
 
     if (this.args.classification)
       query['filter[classification][:exact:label]'] = this.args.classification;
-
-    if (this.args.publisher) {
-      query['filter[:or:][processes][publisher][id]'] = this.args.publisher;
-      query['filter[:or:][processes][users][id]'] = this.args.publisher;
-    }
 
     const result = yield this.store.query('group', query);
 

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -36,7 +36,7 @@ export default class ProcessSelectByGroupComponent extends Component {
 
     const groupQuery = {
       page: {
-        size: 50,
+        size: 1000,
       },
       'filter[id]': Array.from(groupIds).join(','),
       sort: ':no-case:name',

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -25,6 +25,11 @@ export default class ProcessSelectByGroupComponent extends Component {
     if (this.args.classification)
       query['filter[classification][:exact:label]'] = this.args.classification;
 
+    if (this.args.publisher) {
+      query['filter[:or:][processes][publisher][id]'] = this.args.publisher;
+      query['filter[:or:][processes][users][id]'] = this.args.publisher;
+    }
+
     const result = yield this.store.query('group', query);
 
     if (result) return [...new Set(result.map((r) => r.name))];

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -15,7 +15,7 @@ export default class ProcessSelectByGroupComponent extends Component {
     const processQuery = {
       'filter[:not:status]': ENV.resourceStates.archived,
       include: 'publisher,relevant-administrative-units',
-      page: { number: 0, size: 1000 },
+      page: { number: 0, size: 1000 }, //TODO: if OPH grows we should keep the size of this query in mind to prevent performance issues
     };
 
     if (this.args.classifications) {

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -34,9 +34,6 @@ export default class ProcessSelectByGroupComponent extends Component {
       }
     });
 
-    if (groupIds.size === 0) return [];
-
-    // Query matching groups
     const groupQuery = {
       page: {
         size: 50,

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
+import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessSelectByGroupComponent extends Component {
   @service store;
@@ -11,22 +12,85 @@ export default class ProcessSelectByGroupComponent extends Component {
 
     yield timeout(200);
 
+    let classificationIds;
+    if (this.args.classifications) {
+      // Handle if classifications is already an array of IDs
+      if (Array.isArray(this.args.classifications)) {
+        classificationIds = this.args.classifications;
+      }
+      // Handle if classifications is a comma-separated string (from URL)
+      else if (typeof this.args.classifications === 'string') {
+        classificationIds = this.args.classifications.split(',');
+      }
+      // Handle if classifications is a single classification object
+      else if (this.args.classifications.id) {
+        classificationIds = [this.args.classifications.id];
+      }
+    }
+
+    // First query: get processes where publisher has these classifications
+    const publisherProcessQuery = {
+      'filter[:not:status]': ENV.resourceStates.archived,
+      include: 'publisher,relevant-administrative-units',
+    };
+
+    if (classificationIds && classificationIds.length > 0) {
+      publisherProcessQuery['filter[publisher][classification][:id:]'] =
+        classificationIds.join(',');
+    }
+
+    // Second query: get processes where relevantAdministrativeUnits have these classifications
+    const adminUnitProcessQuery = {
+      'filter[:not:status]': ENV.resourceStates.archived,
+      include: 'publisher,relevant-administrative-units',
+    };
+
+    if (classificationIds && classificationIds.length > 0) {
+      adminUnitProcessQuery['filter[relevant-administrative-units][:id:]'] =
+        classificationIds.join(',');
+    }
+
+    // Execute both queries
+    const [publisherProcesses, adminUnitProcesses] = yield Promise.all([
+      this.store.query('process', publisherProcessQuery),
+      this.store.query('process', adminUnitProcessQuery),
+    ]);
+
+    // Combine the results and extract unique publisher IDs
+    const groupIds = new Set();
+
+    // Add publishers from processes with matching publisher classifications
+    publisherProcesses.forEach((process) => {
+      if (process.publisher) {
+        groupIds.add(process.publisher.id);
+      }
+    });
+
+    // Add publishers from processes with matching relevantAdministrativeUnits
+    adminUnitProcesses.forEach((process) => {
+      if (process.publisher) {
+        groupIds.add(process.publisher.id);
+      }
+    });
+
+    // If no groups found, return early
+    if (groupIds.size === 0) return [];
+
+    // Now query groups with these IDs
     const query = {
       page: {
         size: 50,
       },
-      filter: {
-        name: searchParams,
-        ':has:processes': true,
-      },
+      'filter[id]': Array.from(groupIds).join(','),
       sort: ':no-case:name',
     };
 
-    if (this.args.classification)
-      query['filter[classification][:exact:label]'] = this.args.classification;
+    // Add name search filter if provided
+    if (searchParams) {
+      query['filter[name]'] = searchParams;
+    }
 
     const result = yield this.store.query('group', query);
-
     if (result) return [...new Set(result.map((r) => r.name))];
   }
 }

--- a/app/components/process-select-by-group.js
+++ b/app/components/process-select-by-group.js
@@ -15,6 +15,7 @@ export default class ProcessSelectByGroupComponent extends Component {
     const processQuery = {
       'filter[:not:status]': ENV.resourceStates.archived,
       include: 'publisher,relevant-administrative-units',
+      page: { number: 0, size: 1000 },
     };
 
     if (this.args.classifications) {

--- a/app/components/process-select-by-title.js
+++ b/app/components/process-select-by-title.js
@@ -19,8 +19,10 @@ export default class ProcessSelectByTitleComponent extends Component {
       },
     };
 
-    if (this.args.publisher)
-      query['filter[publisher][id]'] = this.args.publisher;
+    if (this.args.publisher) {
+      query['filter[:or:][publisher][id]'] = this.args.publisher;
+      query['filter[:or:][users][id]'] = this.args.publisher;
+    }
 
     const result = yield this.store.query('process', query);
 

--- a/app/components/process/relevant-admin-unit-selector.hbs
+++ b/app/components/process/relevant-admin-unit-selector.hbs
@@ -1,0 +1,14 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelectMultiple
+    {{did-insert this.loadProcessClassificationsTask.perform}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @options={{this.relevantAdministrativeUnits}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
+    @triggerId={{@id}}
+    as |classification|
+  >
+    {{classification.label}}
+  </PowerSelectMultiple>
+</div>

--- a/app/components/process/relevant-admin-unit-selector.js
+++ b/app/components/process/relevant-admin-unit-selector.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { restartableTask } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+
+export default class RelevantAdminUnitSelector extends Component {
+  @service router;
+  @service store;
+
+  @tracked relevantAdministrativeUnits = [];
+
+  @restartableTask
+  *loadProcessClassificationsTask() {
+    const query = {
+      page: {
+        number: 0,
+        size: 20,
+      },
+      sort: ':no-case:label',
+    };
+
+    const result = yield this.store.query(
+      'administrative-unit-classification-code',
+      query
+    );
+    this.relevantAdministrativeUnits = result;
+  }
+}

--- a/app/controllers/my-local-government/index.js
+++ b/app/controllers/my-local-government/index.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 
 export default class MyLocalGovernmentIndexController extends Controller {
   queryParams = [
@@ -21,6 +22,7 @@ export default class MyLocalGovernmentIndexController extends Controller {
   @tracked selectedClassification = '';
   @tracked group = '';
   @tracked blueprint = false;
+  @service currentSession;
 
   get processes() {
     return this.model.loadProcessesTaskInstance.isFinished

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -19,7 +19,7 @@ export default class ProcessesIndexController extends Controller {
   @tracked sort = 'title';
   @tracked title = '';
   @tracked classifications = undefined;
-  @tracked selectedClassifications = [];
+  @tracked selectedClassifications = undefined;
   @tracked group = '';
   @tracked blueprint = false;
   @service currentSession;
@@ -55,11 +55,15 @@ export default class ProcessesIndexController extends Controller {
   setClassifications(selection) {
     this.page = null;
     this.selectedClassifications = selection;
-    this.classifications = selection
-      .map((classification) => {
-        return classification.id;
-      })
-      .join(',');
+    if (selection.length === 0) {
+      this.classifications = undefined;
+    } else {
+      this.classifications = selection
+        .map((classification) => {
+          return classification.id;
+        })
+        .join(',');
+    }
   }
 
   @action
@@ -83,7 +87,7 @@ export default class ProcessesIndexController extends Controller {
   resetFilters() {
     this.title = '';
     this.classifications = undefined;
-    this.selectedClassifications = [];
+    this.selectedClassifications = undefined;
     this.group = '';
     this.page = 0;
     this.sort = 'title';

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -57,7 +57,6 @@ export default class ProcessesIndexController extends Controller {
     this.selectedClassifications = selection;
     this.classifications = selection
       .map((classification) => {
-        console.log('classification', classification);
         return classification.id;
       })
       .join(',');

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -18,7 +18,7 @@ export default class ProcessesIndexController extends Controller {
   size = 20;
   @tracked sort = 'title';
   @tracked title = '';
-  @tracked classifications = '';
+  @tracked classifications = undefined;
   @tracked selectedClassifications = [];
   @tracked group = '';
   @tracked blueprint = false;
@@ -82,8 +82,8 @@ export default class ProcessesIndexController extends Controller {
   @action
   resetFilters() {
     this.title = '';
-    this.classification = '';
-    this.selectedClassification = '';
+    this.classifications = undefined;
+    this.selectedClassifications = [];
     this.group = '';
     this.page = 0;
     this.sort = 'title';

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -9,7 +9,7 @@ export default class ProcessesIndexController extends Controller {
     'size',
     'sort',
     'title',
-    'classification',
+    'classifications',
     'group',
     'blueprint',
   ];
@@ -18,8 +18,8 @@ export default class ProcessesIndexController extends Controller {
   size = 20;
   @tracked sort = 'title';
   @tracked title = '';
-  @tracked classification = '';
-  @tracked selectedClassification = '';
+  @tracked classifications = '';
+  @tracked selectedClassifications = [];
   @tracked group = '';
   @tracked blueprint = false;
   @service currentSession;
@@ -52,10 +52,15 @@ export default class ProcessesIndexController extends Controller {
   }
 
   @action
-  setClassification(selection) {
+  setClassifications(selection) {
     this.page = null;
-    this.selectedClassification = selection;
-    this.classification = selection?.label;
+    this.selectedClassifications = selection;
+    this.classifications = selection
+      .map((classification) => {
+        console.log('classification', classification);
+        return classification.id;
+      })
+      .join(',');
   }
 
   @action

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -45,6 +45,7 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked draftIpdcProducts = undefined;
   @tracked processUserChanged = undefined;
   @tracked originalUsers = undefined;
+  @tracked relevantAdministrativeUnitsChanged = false;
 
   // Process
 
@@ -391,6 +392,7 @@ export default class ProcessesProcessIndexController extends Controller {
     this.process?.rollbackAttributes();
     this.draftIpdcProducts = this.process?.ipdcProducts;
     this.linkedBlueprintsChanged = false;
+    this.relevantAdministrativeUnitsChanged = false;
 
     // Restore original users state when canceling form
     if (this.processUserChanged && this.originalUsers) {
@@ -434,12 +436,20 @@ export default class ProcessesProcessIndexController extends Controller {
     this.validateForm();
   }
 
+  @action
+  setRelevantAdministrativeUnit(selection) {
+    this.process.relevantAdministrativeUnits = selection;
+    this.relevantAdministrativeUnitsChanged = true;
+    this.validateForm();
+  }
+
   validateForm() {
     this.formIsValid =
       this.process?.validate() &&
       (this.process?.hasDirtyAttributes ||
         this.linkedBlueprintsChanged ||
         this.processUserChanged ||
+        this.relevantAdministrativeUnitsChanged ||
         this.draftIpdcProducts?.length < this.process?.ipdcProducts?.length ||
         this.draftIpdcProducts?.some((product) => product.isDraft));
   }

--- a/app/controllers/shared-processes/index.js
+++ b/app/controllers/shared-processes/index.js
@@ -105,7 +105,7 @@ export default class SharedProcessesIndexController extends Controller {
   @task
   *createProcess(diagramId) {
     const diagram = yield this.store.findRecord('file', diagramId);
-    const defaultRelUnit = yield this.currentSession.group.classification;
+    const defaultRelevantUnit = yield this.currentSession.group.classification;
     const created = new Date();
     const process = this.store.createRecord('process', {
       title: removeFileNameExtension(diagram.name, diagram.extension),
@@ -113,7 +113,7 @@ export default class SharedProcessesIndexController extends Controller {
       modified: created,
       publisher: this.currentSession.group,
       files: [diagram],
-      relevantAdministrativeUnits: [defaultRelUnit],
+      relevantAdministrativeUnits: [defaultRelevantUnit],
     });
     yield process.save();
     this.newProcessId = process.id;

--- a/app/controllers/shared-processes/index.js
+++ b/app/controllers/shared-processes/index.js
@@ -113,6 +113,7 @@ export default class SharedProcessesIndexController extends Controller {
       modified: created,
       publisher: this.currentSession.group,
       files: [diagram],
+      relevantAdministrativeUnits: [this.currentSession.group.classification],
     });
     yield process.save();
     this.newProcessId = process.id;

--- a/app/controllers/shared-processes/index.js
+++ b/app/controllers/shared-processes/index.js
@@ -105,7 +105,7 @@ export default class SharedProcessesIndexController extends Controller {
   @task
   *createProcess(diagramId) {
     const diagram = yield this.store.findRecord('file', diagramId);
-
+    const defaultRelUnit = yield this.currentSession.group.classification;
     const created = new Date();
     const process = this.store.createRecord('process', {
       title: removeFileNameExtension(diagram.name, diagram.extension),
@@ -113,7 +113,7 @@ export default class SharedProcessesIndexController extends Controller {
       modified: created,
       publisher: this.currentSession.group,
       files: [diagram],
-      relevantAdministrativeUnits: [this.currentSession.group.classification],
+      relevantAdministrativeUnits: [defaultRelUnit],
     });
     yield process.save();
     this.newProcessId = process.id;

--- a/app/models/administrative-unit-classification-code.js
+++ b/app/models/administrative-unit-classification-code.js
@@ -1,5 +1,7 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class AdministrativeUnitClassificationCodeModel extends Model {
   @attr('string') label;
+  @hasMany('process', { inverse: 'relevantAdministrativeUnits', async: false })
+  processes;
 }

--- a/app/models/administrative-unit-classification-code.js
+++ b/app/models/administrative-unit-classification-code.js
@@ -2,6 +2,6 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class AdministrativeUnitClassificationCodeModel extends Model {
   @attr('string') label;
-  @hasMany('process', { inverse: 'relevantAdministrativeUnits', async: false })
+  @hasMany('process', { inverse: 'relevantAdministrativeUnits', async: true })
   processes;
 }

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -39,7 +39,7 @@ export default class ProcessModel extends Model {
   users;
   @hasMany('administrative-unit-classification-code', {
     inverse: 'processes',
-    async: false,
+    async: true,
   })
   relevantAdministrativeUnits;
 

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -39,7 +39,7 @@ export default class ProcessModel extends Model {
   users;
   @hasMany('administrative-unit-classification-code', {
     inverse: 'processes',
-    async: true,
+    async: false,
   })
   relevantAdministrativeUnits;
 

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -38,7 +38,7 @@ export default class ProcessModel extends Model {
   @hasMany('group', { inverse: null, async: false })
   users;
   @hasMany('administrative-unit-classification-code', {
-    inverse: null,
+    inverse: 'processes',
     async: false,
   })
   relevantAdministrativeUnits;

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -37,6 +37,11 @@ export default class ProcessModel extends Model {
   linkedBlueprints;
   @hasMany('group', { inverse: null, async: false })
   users;
+  @hasMany('administrative-unit-classification-code', {
+    inverse: null,
+    async: false,
+  })
+  relevantAdministrativeUnits;
 
   validations = {
     title: {

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -30,7 +30,7 @@ export default class ProcessesIndexRoute extends Route {
         size: params.size,
       },
       include:
-        'publisher,users,publisher.primary-site,publisher.primary-site.contacts,publisher.classification',
+        'publisher,users,publisher.primary-site,publisher.primary-site.contacts,publisher.classification,relevant-administrative-units',
     };
 
     if (params.sort) {

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -10,7 +10,7 @@ export default class ProcessesIndexRoute extends Route {
     page: { refreshModel: true },
     sort: { refreshModel: true },
     title: { refreshModel: true, replace: true },
-    classification: { refreshModel: true, replace: true },
+    classifications: { refreshModel: true, replace: true },
     group: { refreshModel: true, replace: true },
     blueprint: { refreshModel: true },
   };
@@ -53,9 +53,9 @@ export default class ProcessesIndexRoute extends Route {
       query['filter[:or:][description]'] = params.title;
     }
 
-    if (params.classification)
-      query['filter[publisher][classification][:exact:label]'] =
-        params.classification;
+    if (params.classifications) {
+      query['filter[publisher][classification][:id:]'] = params.classifications;
+    }
 
     if (params.group) query['filter[publisher][:exact:name]'] = params.group;
 

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -54,7 +54,10 @@ export default class ProcessesIndexRoute extends Route {
     }
 
     if (params.classifications) {
-      query['filter[publisher][classification][:id:]'] = params.classifications;
+      query['filter[:or:][publisher][classification][:id:]'] =
+        params.classifications;
+      query['filter[:or:][relevant-administrative-units][:id:]'] =
+        params.classifications;
     }
 
     if (params.group) query['filter[publisher][:exact:name]'] = params.group;

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -54,9 +54,7 @@ export default class ProcessesIndexRoute extends Route {
     }
 
     if (params.classifications) {
-      query['filter[:or:][publisher][classification][:id:]'] =
-        params.classifications;
-      query['filter[:or:][relevant-administrative-units][:id:]'] =
+      query['filter[relevant-administrative-units][:id:]'] =
         params.classifications;
     }
 

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -40,7 +40,6 @@ export default class CurrentSessionService extends Service {
         include: 'classification',
         reload: true,
       });
-      console.log('this.group', this.group);
       this.title = `${this.user.firstName} ${this.user.familyName} - ${this.group.name}`;
     }
   }

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -36,8 +36,11 @@ export default class CurrentSessionService extends Service {
       this.user = this.account.user;
 
       let groupId = sessionData?.group?.data?.id;
-      this.group = await this.store.findRecord('group', groupId);
-
+      this.group = await this.store.findRecord('group', groupId, {
+        include: 'classification',
+        reload: true,
+      });
+      console.log('this.group', this.group);
       this.title = `${this.user.firstName} ${this.user.familyName} - ${this.group.name}`;
     }
   }

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -21,6 +21,7 @@
               @id="filter-title"
               @selected={{this.title}}
               @onChange={{this.setTitle}}
+              @publisher={{this.currentSession.group.id}}
               class="grow"
             />
           </div>
@@ -30,6 +31,7 @@
               @id="filter-classification"
               @selected={{this.selectedClassification}}
               @onChange={{this.setClassification}}
+              @publisher={{this.currentSession.group.id}}
               class="grow"
             />
           </div>
@@ -91,7 +93,7 @@
           <AuDataTableThSortable
             @field="classification"
             @currentSorting={{this.sort}}
-            @label="Type bestuur"
+            @label="Relevant voor type bestuur"
           />
           <AuDataTableThSortable
             @field="organization"
@@ -129,7 +131,14 @@
               </LinkTo>
             </td>
             <td>{{or (truncate process.description 150 true) "/"}}</td>
-            <td>{{process.publisher.classification.label}}</td>
+            <td>
+              <ul>
+                <li>{{process.publisher.classification.label}}</li>
+                {{#each process.relevantAdministrativeUnits as |adminUnit|}}
+                  <li>{{adminUnit.label}}</li>
+                {{/each}}
+              </ul>
+            </td>
             <td>{{process.publisher.name}}</td>
             <td>{{date-format process.modified}}</td>
 

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -7,41 +7,12 @@
           class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
         >
           <h1 class="au-u-h3 au-u-medium">Filters</h1>
-          <div class="au-u-flex au-u-flex--between au-u-flex--vertical-center">
-            <AuLabel for="filter-blueprint">Blauwdruk</AuLabel>
-            <AuCheckbox
-              id="filter-blueprint"
-              @checked={{this.isBlueprint}}
-              @onChange={{this.toggleBlueprintFilter}}
-            />
-          </div>
           <div>
             <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
             <ProcessSelectByTitle
               @id="filter-title"
               @selected={{this.title}}
               @onChange={{this.setTitle}}
-              @publisher={{this.currentSession.group.id}}
-              class="grow"
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-classification">Type bestuur</AuLabel>
-            <ProcessSelectByClassification
-              @id="filter-classification"
-              @selected={{this.selectedClassification}}
-              @onChange={{this.setClassification}}
-              @publisher={{this.currentSession.group.id}}
-              class="grow"
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-group">Naam bestuur</AuLabel>
-            <ProcessSelectByGroup
-              @id="filter-group"
-              @selected={{this.group}}
-              @onChange={{this.setGroup}}
-              @classification={{this.classification}}
               @publisher={{this.currentSession.group.id}}
               class="grow"
             />

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -65,7 +65,7 @@
           <AuDataTableThSortable
             @field="classification"
             @currentSorting={{this.sort}}
-            @label="Relevant voor type bestuur"
+            @label="Relevant voor"
           />
           <AuDataTableThSortable
             @field="organization"

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -42,6 +42,7 @@
               @selected={{this.group}}
               @onChange={{this.setGroup}}
               @classification={{this.classification}}
+              @publisher={{this.currentSession.group.id}}
               class="grow"
             />
           </div>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -28,8 +28,8 @@
             <AuLabel for="filter-classification">Type bestuur</AuLabel>
             <ProcessSelectByClassification
               @id="filter-classification"
-              @selected={{this.selectedClassification}}
-              @onChange={{this.setClassification}}
+              @selected={{this.selectedClassifications}}
+              @onChange={{this.setClassifications}}
               class="grow"
             />
           </div>
@@ -100,7 +100,7 @@
           <AuDataTableThSortable
             @field="classification"
             @currentSorting={{this.sort}}
-            @label="Type bestuur"
+            @label="Relevant voor type bestuur"
           />
           <AuDataTableThSortable
             @field="organization"

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -39,7 +39,7 @@
               @id="filter-group"
               @selected={{this.group}}
               @onChange={{this.setGroup}}
-              @classification={{this.classification}}
+              @classifications={{this.classifications}}
               class="grow"
             />
           </div>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -143,7 +143,6 @@
             </td>
 
             <td><ul>
-                <li>{{process.publisher.classification.label}}</li>
                 {{#each
                   process.relevantAdministrativeUnits
                   as |relevantAdministrativeUnit|

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -25,7 +25,7 @@
             />
           </div>
           <div>
-            <AuLabel for="filter-classification">Type bestuur</AuLabel>
+            <AuLabel for="filter-classification">Relevant voor</AuLabel>
             <ProcessSelectByClassification
               @id="filter-classification"
               @selected={{this.selectedClassifications}}
@@ -100,7 +100,7 @@
           <AuDataTableThSortable
             @field="classification"
             @currentSorting={{this.sort}}
-            @label="Relevant voor type bestuur"
+            @label="Relevant voor"
           />
           <AuDataTableThSortable
             @field="organization"

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -140,7 +140,11 @@
               {{/if}}
             </td>
 
-            <td>{{process.publisher.classification.label}}</td>
+            <td>{{#each
+                process.relevantAdministrativeUnits
+                as |relevantAdministrativeUnit|
+              }}<ul><li>{{relevantAdministrativeUnit.label}}</li></ul>
+              {{/each}}</td>
             <td>{{process.publisher.name}}</td>
           </c.body>
         {{/if}}

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -118,19 +118,21 @@
           </TableMessage>
         {{else}}
           <c.body as |process|>
-            <td
-              class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
-            >
-              {{#if process.isBlueprint}}
-                <CustomIcon @icon={{"blueprint"}} @size="large" />
-              {{/if}}
-              <LinkTo
-                class="au-c-link"
-                @model={{process.id}}
-                @route="processes.process"
+            <td>
+              <div
+                class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
               >
-                {{process.title}}
-              </LinkTo>
+                {{#if process.isBlueprint}}
+                  <CustomIcon @icon={{"blueprint"}} @size="large" />
+                {{/if}}
+                <LinkTo
+                  class="au-c-link"
+                  @model={{process.id}}
+                  @route="processes.process"
+                >
+                  {{process.title}}
+                </LinkTo>
+              </div>
             </td>
             <td>{{or (truncate process.description 150 true) "/"}}</td>
             <td>{{date-format process.modified}}</td>
@@ -140,11 +142,13 @@
               {{/if}}
             </td>
 
-            <td>{{#each
-                process.relevantAdministrativeUnits
-                as |relevantAdministrativeUnit|
-              }}<ul><li>{{relevantAdministrativeUnit.label}}</li></ul>
-              {{/each}}</td>
+            <td><ul>
+                <li>{{process.publisher.classification.label}}</li>
+                {{#each
+                  process.relevantAdministrativeUnits
+                  as |relevantAdministrativeUnit|
+                }}<li>{{relevantAdministrativeUnit.label}}</li>
+                {{/each}}</ul></td>
             <td>{{process.publisher.name}}</td>
           </c.body>
         {{/if}}

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -117,6 +117,15 @@
                 </:content>
               </Item>
               <Item>
+                <:label>Relevant voor type bestuur</:label>
+                <:content>
+                  <Process::RelevantAdminUnitSelector
+                    @selected={{this.process.relevantAdministrativeUnits}}
+                    @onChange={{this.setRelevantAdministrativeUnit}}
+                  />
+                </:content>
+              </Item>
+              <Item>
                 <:label>Emailadres bestuur</:label>
                 <:content>
                   {{or
@@ -218,6 +227,19 @@
               <:label>Type bestuur</:label>
               <:content>
                 {{this.process.publisher.classification.label}}
+              </:content>
+            </Item>
+            <Item>
+              <:label>Relevant voor type bestuur</:label>
+              <:content>
+                {{#each
+                  this.process.relevantAdministrativeUnits
+                  as |relevantAdministrativeUnit|
+                }}
+                  <ul><li>
+                      {{relevantAdministrativeUnit.label}}
+                    </li></ul>
+                {{/each}}
               </:content>
             </Item>
             <Item>

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -117,7 +117,7 @@
                 </:content>
               </Item>
               <Item>
-                <:label>Relevant voor type bestuur</:label>
+                <:label>Relevant voor</:label>
                 <:content>
                   <Process::RelevantAdminUnitSelector
                     @selected={{this.process.relevantAdministrativeUnits}}
@@ -230,7 +230,7 @@
               </:content>
             </Item>
             <Item>
-              <:label>Relevant voor type bestuur</:label>
+              <:label>Relevant voor</:label>
               <:content>
                 {{#each
                   this.process.relevantAdministrativeUnits


### PR DESCRIPTION
# OPH-469

## Overview
- Modified classification and group filters
- Added component to assign relevant administrative units to a process
- Changed the 'type bestuur' column to 'relevant voor type bestuur'
- Removed classification, blueprint and group filter from local government view (discussed with Stefanie)

### Description
This new feature allows users to link relevant administrative units to a process. A dropdown fetches all administrative units, and you can now select which ones the process applies to.
In the process overview, we've renamed the ‘Type bestuur’ column to ‘Relevant voor type bestuur’. Previously, this column only showed the classification of the publisher. Now it defaults to the publisher's classification and appends the classifications of any relevant administrative units, if present.
I also updated the classification filter and group filter. Since processes can now have multiple classifications, the group filter will dynamically adjust its results based on the selected classification(s).

### Uncertainty
We're now passing classification IDs as query params. To support multi-select and real-time model updates, I found filtering on id was the only approach that worked reliably with mu-cl-resources. This unfortunately sacrifices a bit of user-friendliness (e.g. using labels), but it’s the only stable solution for now.
If we want to support more complex queries like filtering over multiple classifications and relationships, we might need to consider switching to mu-search.

### To the reviewer
Please give it a critical look. I’m open to ideas if there’s a better way to handle these queries without switching away from mu-cl-resources. If not, this setup should hold for now.