### PR TITLE
Improve error message on Visio to BPMN failure

### DIFF
--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -209,12 +209,12 @@ export default class ProcessesProcessIndexController extends Controller {
         const mailto =
           'mailto:loketlokaalbestuur@vlaanderen.be' +
           `?subject=${encodeURIComponent(
-            'Open Proces Huis conversieprobleem'
+            'Visio kan niet downloaden als BPMN'
           )}` +
           `?body=${encodeURIComponent(`\n\n${window.location.href}\n`)}`;
-        const linkHtml = `<a href="${mailto}">loketlokaalbestuur@vlaanderen.be</a>`;
+        const linkHtml = `<a href="${mailto}">Stuur ons een mailtje</a>`;
         message = htmlSafe(
-          `Dit Visio-bestand kon helaas niet worden omgezet naar BPMN. Stuur ons een e-mail via ${linkHtml} zodat we de applicatie verder kunnen verbeteren.`
+          `Dit visio-bestand kan niet worden gedownload als BPMN. ${linkHtml} met het proces waarover het gaat en een korte beschrijving van wat niet lukt. Dan kunnen we nagaan wat fout gaat en Open Proces Huis verder verbeteren.`
         );
       }
 

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask, enqueueTask, keepLatestTask } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import FileSaver from 'file-saver';
 import ENV from 'frontend-openproceshuis/config/environment';
 import removeFileNameExtension from 'frontend-openproceshuis/utils/file-extension-remover';
@@ -203,9 +204,14 @@ export default class ProcessesProcessIndexController extends Controller {
       FileSaver.saveAs(blob, fileName);
     } catch {
       let message = 'Bestand kon niet worden opgehaald';
-      if (this.latestDiagram.isVisioFile && targetExtension === 'bpmn')
-        message =
-          'Het is helaas niet gelukt om dit Visio-bestand om te zetten naar BPMN. Stuur ons gerust een e-mail via loketlokaalbestuur@vlaanderen.be zodat we de applicatie verder kunnen verbeteren.';
+
+      if (this.latestDiagram.isVisioFile && targetExtension === 'bpmn') {
+        const linkHtml =
+          '<a href="mailto:loketlokaalbestuur@vlaanderen.be">loketlokaalbestuur@vlaanderen.be</a>';
+        message = htmlSafe(
+          `Dit Visio-bestand kon helaas niet worden omgezet naar BPMN. Stuur ons een e-mail via ${linkHtml} zodat we de applicatie verder kunnen verbeteren.`
+        );
+      }
 
       this.toaster.error(message, 'Fout');
       return;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -206,8 +206,13 @@ export default class ProcessesProcessIndexController extends Controller {
       let message = 'Bestand kon niet worden opgehaald';
 
       if (this.latestDiagram.isVisioFile && targetExtension === 'bpmn') {
-        const linkHtml =
-          '<a href="mailto:loketlokaalbestuur@vlaanderen.be">loketlokaalbestuur@vlaanderen.be</a>';
+        const mailto =
+          'mailto:loketlokaalbestuur@vlaanderen.be' +
+          `?subject=${encodeURIComponent(
+            'Open Proces Huis conversieprobleem'
+          )}` +
+          `?body=${encodeURIComponent(window.location.href)}`;
+        const linkHtml = `<a href="${mailto}">loketlokaalbestuur@vlaanderen.be</a>`;
         message = htmlSafe(
           `Dit Visio-bestand kon helaas niet worden omgezet naar BPMN. Stuur ons een e-mail via ${linkHtml} zodat we de applicatie verder kunnen verbeteren.`
         );

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -202,7 +202,12 @@ export default class ProcessesProcessIndexController extends Controller {
 
       FileSaver.saveAs(blob, fileName);
     } catch {
-      this.toaster.error('Bestand kon niet worden opgehaald', 'Fout');
+      let message = 'Bestand kon niet worden opgehaald';
+      if (this.latestDiagram.isVisioFile && targetExtension === 'bpmn')
+        message =
+          'Het is helaas niet gelukt om dit Visio-bestand om te zetten naar BPMN. Stuur ons gerust een e-mail via loketlokaalbestuur@vlaanderen.be zodat we de applicatie verder kunnen verbeteren.';
+
+      this.toaster.error(message, 'Fout');
       return;
     }
 

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -211,7 +211,7 @@ export default class ProcessesProcessIndexController extends Controller {
           `?subject=${encodeURIComponent(
             'Open Proces Huis conversieprobleem'
           )}` +
-          `?body=${encodeURIComponent(window.location.href)}`;
+          `?body=${encodeURIComponent(`\n\n${window.location.href}\n`)}`;
         const linkHtml = `<a href="${mailto}">loketlokaalbestuur@vlaanderen.be</a>`;
         message = htmlSafe(
           `Dit Visio-bestand kon helaas niet worden omgezet naar BPMN. Stuur ons een e-mail via ${linkHtml} zodat we de applicatie verder kunnen verbeteren.`


### PR DESCRIPTION
OPH-557

When the conversion from Visio to BPMN fails, a more specific message is shown. Most importantly, it provides an email address so users can immediately notice the OPH team. When clicking the email address, the process's URL is filled in by default in the email body.