### PR TITLE
Remove format column from attachments table

### DIFF
--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -624,11 +624,7 @@ export default class ProcessesProcessIndexController extends Controller {
         ? this.sortAttachments.substring(1)
         : this.sortAttachments;
 
-      if (
-        sortValue === 'name' ||
-        sortValue === 'extension' ||
-        sortValue === 'format'
-      )
+      if (sortValue === 'name' || sortValue === 'extension')
         sortValue = `:no-case:${sortValue}`;
       if (isDescending) sortValue = `-${sortValue}`;
 

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -537,11 +537,6 @@
                 @label="Extensie"
               />
               <AuDataTableThSortable
-                @field="format"
-                @currentSorting={{this.sortAttachments}}
-                @label="Formaat"
-              />
-              <AuDataTableThSortable
                 @field="created"
                 @currentSorting={{this.sortAttachments}}
                 @label="Toegevoegd op"
@@ -564,7 +559,6 @@
                 <td>{{attachment.name}}</td>
                 <td>{{file-size-format attachment.size}}</td>
                 <td>{{attachment.extension}}</td>
-                <td>{{attachment.format}}</td>
                 <td>{{date-format attachment.created true}}</td>
                 <td>
                   <AuButton


### PR DESCRIPTION
OPH-488

The attachments table on the process details page no longer shows the format column.