### PR TITLE
Feature: Breadcrumbs

### DIFF
--- a/app/components/navigation-bar.hbs
+++ b/app/components/navigation-bar.hbs
@@ -1,23 +1,29 @@
-<AuToolbar @border="bottom" @skin="tint" class="au-c-navigation" as |Group|>
-  <Group>
-    <AuTabs @reversed={{this.reversed}} as |Tab|>
-      <Tab>
-        <AuLink @route="processes" @icon="sitemap">
-          Processen
+<AuToolbar @border="bottom" @size="small" @skin="tint">
+  <nav aria-label="breadcrumbs">
+    <ol
+      class="au-c-list-horizontal au-c-list-horizontal--breadcrumbs au-u-margin-left-tiny"
+    >
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="index" @icon="arrow-left" @iconAlignment="left">
+          Overzicht
         </AuLink>
-      </Tab>
-      {{#if this.currentSession.canEdit}}
-        <Tab>
-          <AuLink @route="my-local-government" @icon="users-four-of-four">
-            Mijn lokaal bestuur
-          </AuLink>
-        </Tab>
-        <Tab>
-          <AuLink @route="shared-processes" @icon="unordered-list">
-            Gedeelde processen
-          </AuLink>
-        </Tab>
-      {{/if}}
-    </AuTabs>
-  </Group>
+      </li>
+      {{#each (breadcrumbs) as |breadcrumb|}}
+        <li class="au-c-list-horizontal__item">
+          {{#if (is-last breadcrumb (breadcrumbs))}}
+            {{breadcrumb.title}}
+          {{else}}
+            <AuLink
+              @route={{breadcrumb.data.route}}
+              @model={{breadcrumb.data.model}}
+              @models={{breadcrumb.data.models}}
+            >
+              {{breadcrumb.title}}
+            </AuLink>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ol>
+  </nav>
+
 </AuToolbar>

--- a/app/components/navigation-bar.hbs
+++ b/app/components/navigation-bar.hbs
@@ -5,7 +5,7 @@
     >
       <li class="au-c-list-horizontal__item">
         <AuLink @route="index" @icon="arrow-left" @iconAlignment="left">
-          Overzicht
+          Overzicht modules
         </AuLink>
       </li>
       {{#each (breadcrumbs) as |breadcrumb|}}

--- a/app/components/page-header.hbs
+++ b/app/components/page-header.hbs
@@ -3,21 +3,6 @@
     <AuToolbar @border="bottom" @size="medium" @nowrap={{true}} as |Group|>
       <Group>
         <div>
-          {{#each (breadcrumbs) as |breadcrumb|}}
-            <p class="au-u-h-functional">
-              {{#if (not (is-last breadcrumb (breadcrumbs)))}}
-                <AuLink
-                  @icon="arrow-left"
-                  @skin="secondary"
-                  @route={{breadcrumb.data.route}}
-                  @model={{breadcrumb.data.model}}
-                  @models={{breadcrumb.data.models}}
-                >
-                  {{breadcrumb.title}}
-                </AuLink>
-              {{/if}}
-            </p>
-          {{/each}}
           <AuHeading>
             {{yield to="title"}}
           </AuHeading>

--- a/app/components/process-bar.hbs
+++ b/app/components/process-bar.hbs
@@ -1,0 +1,23 @@
+<AuToolbar @border="bottom" @skin="tint" class="au-c-navigation" as |Group|>
+  <Group>
+    <AuTabs @reversed={{this.reversed}} as |Tab|>
+      <Tab>
+        <AuLink @route="processes" @icon="sitemap">
+          Processen
+        </AuLink>
+      </Tab>
+      {{#if this.currentSession.canEdit}}
+        <Tab>
+          <AuLink @route="my-local-government" @icon="users-four-of-four">
+            Mijn lokaal bestuur
+          </AuLink>
+        </Tab>
+        <Tab>
+          <AuLink @route="shared-processes" @icon="unordered-list">
+            Gedeelde processen
+          </AuLink>
+        </Tab>
+      {{/if}}
+    </AuTabs>
+  </Group>
+</AuToolbar>

--- a/app/components/process-bar.js
+++ b/app/components/process-bar.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
-export default class NavigationBar extends Component {
+export default class ProcessBar extends Component {
   @service currentSession;
 }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -33,8 +33,4 @@ export default class ApplicationController extends Controller {
       this.environmentName && this.environmentName !== '{{ENVIRONMENT_NAME}}'
     );
   }
-
-  get showNavigation() {
-    return this.router.currentRouteName !== 'index';
-  }
 }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { getOwner } from '@ember/application';
+import { service } from '@ember/service';
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -8,6 +9,7 @@ const isLocalhost = Boolean(
 );
 
 export default class ApplicationController extends Controller {
+  @service router;
   get environmentName() {
     const thisEnvironmentValues = isLocalhost
       ? 'local'
@@ -30,5 +32,9 @@ export default class ApplicationController extends Controller {
     return (
       this.environmentName && this.environmentName !== '{{ENVIRONMENT_NAME}}'
     );
+  }
+
+  get showNavigation() {
+    return this.router.currentRouteName !== 'index';
   }
 }

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -50,17 +50,7 @@ export default class ProcessesProcessIndexController extends Controller {
   // Process
 
   get process() {
-    return this.model.loadProcessTaskInstance.isFinished
-      ? this.model.loadProcessTaskInstance.value
-      : this.model.loadedProcess;
-  }
-
-  get processIsLoading() {
-    return this.model.loadProcessTaskInstance.isRunning;
-  }
-
-  get processHasErrored() {
-    return this.model.loadProcessTaskInstance.isError;
+    return this.model.process;
   }
 
   get processUsedByUs() {
@@ -544,7 +534,7 @@ export default class ProcessesProcessIndexController extends Controller {
         number: 0,
         size: 1,
       },
-      'filter[processes][id]': this.model.processId,
+      'filter[processes][id]': this.model.process.id,
       'filter[:or:][extension]': ['bpmn', 'vsdx'],
       sort: '-created',
     };
@@ -590,7 +580,7 @@ export default class ProcessesProcessIndexController extends Controller {
         number: this.pageVersions,
         size: this.sizeVersions,
       },
-      'filter[processes][id]': this.model.processId,
+      'filter[processes][id]': this.model.process.id,
       'filter[:or:][extension]': ['bpmn', 'vsdx'],
       'filter[:not:status]': ENV.resourceStates.archived,
     };
@@ -628,7 +618,7 @@ export default class ProcessesProcessIndexController extends Controller {
         number: this.pageAttachments,
         size: this.sizeAttachments,
       },
-      'filter[processes][id]': this.model.processId,
+      'filter[processes][id]': this.model.process.id,
       'filter[:not:extension]': ['bpmn', 'vsdx'],
       'filter[:not:status]': ENV.resourceStates.archived,
     };

--- a/app/routes/processes/process.js
+++ b/app/routes/processes/process.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import ENV from 'frontend-openproceshuis/config/environment';
+
+export default class ProcessesProcessRoute extends Route {
+  @service store;
+
+  async model(params) {
+    const query = {
+      reload: true,
+      include:
+        'process-statistics,files,publisher,publisher.primary-site,publisher.primary-site.contacts,publisher.classification,ipdc-products,information-assets',
+      'filter[files][:not:status]': ENV.resourceStates.archived,
+    };
+    return await this.store.findRecord('process', params.id, query);
+  }
+}

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -1,47 +1,31 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { keepLatestTask } from 'ember-concurrency';
-import ENV from 'frontend-openproceshuis/config/environment';
 
 export default class ProcessesProcessIndexRoute extends Route {
-  @service store;
   @service plausible;
+  @service store;
 
   async model() {
-    const { id: processId } = this.paramsFor('processes.process');
-    return {
-      processId,
-      loadProcessTaskInstance: this.loadProcessTask.perform(),
-      loadedProcess: this.loadProcessTask.lastSuccesful?.value,
-    };
-  }
-
-  @keepLatestTask
-  *loadProcessTask() {
-    const { id: processId } = this.paramsFor('processes.process');
-    const query = {
-      reload: true,
-      include:
-        'process-statistics,files,publisher,publisher.primary-site,publisher.primary-site.contacts,publisher.classification,ipdc-products,information-assets',
-      'filter[files][:not:status]': ENV.resourceStates.archived,
-    };
-
-    const process = yield this.store.findRecord('process', processId, query);
+    const process = this.modelFor('processes.process');
     let stats = process.processStatistics;
+
     if (!stats) {
       stats = this.store.createRecord('process-statistic', {
         process,
       });
     }
+
     this.plausible.trackEvent('Raadpleeg proces', {
       'Proces-ID': process?.id,
       Procesnaam: process?.title,
       'Bestuur-ID': process?.publisher?.id,
       Bestuursnaam: process?.publisher?.name,
     });
+
     stats.processViews += 1;
-    yield stats.save();
-    return process;
+    await stats.save();
+
+    return { process };
   }
 
   setupController(controller) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -9,9 +9,6 @@
 <AuToaster />
 <AuApp>
   <AppHeader />
-  {{#if this.showNavigation}}
-    <ModuleNavigation />
-  {{/if}}
   <main id="main" class="au-c-main-container">
     <div
       class="au-c-main-container__content au-c-main-container__content--scroll au-u-flex au-u-flex--column"

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -7,9 +7,11 @@
 
 <AuModalContainer />
 <AuToaster />
-
 <AuApp>
   <AppHeader />
+  {{#if this.showNavigation}}
+    <ModuleNavigation />
+  {{/if}}
   <main id="main" class="au-c-main-container">
     <div
       class="au-c-main-container__content au-c-main-container__content--scroll au-u-flex au-u-flex--column"

--- a/app/templates/my-local-government.hbs
+++ b/app/templates/my-local-government.hbs
@@ -3,5 +3,6 @@
 
 <div class="au-c-body-container au-c-body-container--scroll">
   <NavigationBar />
+  <ProcessBar />
   {{outlet}}
 </div>

--- a/app/templates/processes.hbs
+++ b/app/templates/processes.hbs
@@ -3,5 +3,6 @@
 
 <div class="au-c-body-container au-c-body-container--scroll">
   <NavigationBar />
+  <ProcessBar />
   {{outlet}}
 </div>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -126,7 +126,7 @@
               {{/if}}
               <LinkTo
                 class="au-c-link"
-                @model={{process.id}}
+                @model={{process}}
                 @route="processes.process"
               >
                 {{process.title}}

--- a/app/templates/processes/process.hbs
+++ b/app/templates/processes/process.hbs
@@ -1,4 +1,3 @@
-{{page-title this.model.name}}
-
-{{breadcrumb this.model.name route="processes.process" models=this.model.id}}
+{{page-title this.model.title}}
+{{breadcrumb this.model.title route="processes.process" models=this.model.id}}
 {{outlet}}

--- a/app/templates/reporting.hbs
+++ b/app/templates/reporting.hbs
@@ -1,3 +1,7 @@
+{{page-title "Rapportering"}}
+{{breadcrumb "Rapportering" route="reporting"}}
+<NavigationBar />
+
 <PageHeader>
   <:title>Rapportering</:title>
   <:subtitle>

--- a/app/templates/shared-processes.hbs
+++ b/app/templates/shared-processes.hbs
@@ -3,5 +3,7 @@
 
 <div class="au-c-body-container au-c-body-container--scroll">
   <NavigationBar />
+  <ProcessBar />
+
   {{outlet}}
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.0.1",
         "ember-auto-import": "^2.6.3",
-        "ember-breadcrumb-trail": "^0.2.0",
+        "ember-breadcrumb-trail": "1.0.0",
         "ember-cli": "~4.12.1",
         "ember-cli-app-version": "^6.0.0",
         "ember-cli-babel": "^7.26.11",
@@ -11579,6 +11579,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/decorator-transforms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/decorator-transforms/-/decorator-transforms-1.2.1.tgz",
+      "integrity": "sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-decorators": "^7.23.3",
+        "babel-import-util": "^2.0.1"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -12438,262 +12448,14 @@
       "dev": true
     },
     "node_modules/ember-breadcrumb-trail": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ember-breadcrumb-trail/-/ember-breadcrumb-trail-0.2.0.tgz",
-      "integrity": "sha512-T/BDEtQwkRCUcdTZ1meoauXLiVPoZZB9yQXwYL0ItlDnWPRIefNkDhE30OpeGuJbOS5eVMCW8Cc21Qwd4lUnlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-breadcrumb-trail/-/ember-breadcrumb-trail-1.0.0.tgz",
+      "integrity": "sha512-Ujr4R83YuGMykEwij6nvZqJvA1wjgwY8Yhe3ZhqL+c01wmOjFQJUE1c4doJxtYWrPUfuMXkIwNFVLZuPOAwtBQ==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.3",
-        "ember-cli-htmlbars": "^5.7.1"
-      },
-      "engines": {
-        "node": ">= 12"
+        "@embroider/addon-shim": "^1.8.7",
+        "decorator-transforms": "^1.0.1"
       }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/editions/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-breadcrumb-trail/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/ember-cache-primitive-polyfill": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.0.1",
     "ember-auto-import": "^2.6.3",
-    "ember-breadcrumb-trail": "^0.2.0",
+    "ember-breadcrumb-trail": "1.0.0",
     "ember-cli": "~4.12.1",
     "ember-cli-app-version": "^6.0.0",
     "ember-cli-babel": "^7.26.11",


### PR DESCRIPTION
This PR adds a breadcrumb trail, which is especially useful for admins to navigate back and forth between the process and reporting views.

In the individual process fetch, I removed the task because I couldn’t figure out how to access the `loadedProcess`. I needed the entire model to display the correct breadcrumb for each process. I took some inspiration from OP, so my approach is based on how they handled it.