### PR TITLE
Feature: Announce downtime

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -26,18 +26,10 @@ export default class ApplicationController extends Controller {
   }
 
   get maintenanceEnabled() {
-    console.log(
-      'ENV.announce.maintenance.enabled',
-      ENV.announce.maintenance.enabled,
-    );
     return ENV.announce.maintenance.enabled;
   }
 
   get maintenanceMessage() {
-    console.log(
-      'ENV.announce.maintenance.message',
-      ENV.announce.maintenance.message,
-    );
     return ENV.announce.maintenance.message;
   }
 }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -26,10 +26,18 @@ export default class ApplicationController extends Controller {
   }
 
   get maintenanceEnabled() {
+    console.log(
+      'ENV.announce.maintenance.enabled',
+      ENV.announce.maintenance.enabled,
+    );
     return ENV.announce.maintenance.enabled;
   }
 
   get maintenanceMessage() {
+    console.log(
+      'ENV.announce.maintenance.message',
+      ENV.announce.maintenance.message,
+    );
     return ENV.announce.maintenance.message;
   }
 }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
-import { getOwner } from '@ember/application';
 import { service } from '@ember/service';
+import ENV from 'frontend-openproceshuis/config/environment';
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -10,27 +10,26 @@ const isLocalhost = Boolean(
 
 export default class ApplicationController extends Controller {
   @service router;
-  get environmentName() {
-    const thisEnvironmentValues = isLocalhost
-      ? 'local'
-      : getOwner(this).resolveRegistration('config:environment')
-          .environmentName;
 
-    return thisEnvironmentValues;
+  get environmentName() {
+    return isLocalhost ? 'local' : ENV.environmentName;
   }
 
   get environmentTitle() {
-    const thisEnvironmentValues = isLocalhost
-      ? 'lokalomgeving'
-      : getOwner(this).resolveRegistration('config:environment')
-          .environmentTitle;
-
-    return thisEnvironmentValues;
+    return isLocalhost ? 'lokalomgeving' : ENV.environmentTitle;
   }
 
   get showEnvironment() {
     return (
       this.environmentName && this.environmentName !== '{{ENVIRONMENT_NAME}}'
     );
+  }
+
+  get maintenanceEnabled() {
+    return ENV.announce.maintenance.enabled;
+  }
+
+  get maintenanceMessage() {
+    return ENV.announce.maintenance.message;
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,6 +15,15 @@
       id="content"
       tabindex="-1"
     >
+      {{#if this.maintenanceEnabled}}
+        <AuAlert
+          @skin="warning"
+          @icon="alert-triangle"
+          class="au-u-margin-bottom-none au-c-env-announcement"
+        >
+          <p>{{this.maintenanceMessage}}</p>
+        </AuAlert>
+      {{/if}}
       {{outlet}}
     </div>
   </main>

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,13 @@ module.exports = function (environment) {
       // when it is created
     },
 
+    announce: {
+      maintenance: {
+        enabled: '{{ANNOUNCE_MAINTENANCE_ENABLED}}',
+        message: '{{ANNOUNCE_MAINTENANCE_MESSAGE}}',
+      },
+    },
+
     appName: 'Open Proces Huis',
 
     ovoCodes: {


### PR DESCRIPTION
OPH-570

This PR will include the possibility to add a banner when downtime is scheduled.

On the `docker-compose.override.yml` of the server, add the following:

```yml
environment:
  EMBER_ANNOUNCE_MAINTENANCE_ENABLED: "true"
  EMBER_ANNOUNCE_MAINTENANCE_MESSAGE: "Open Proces Huis zal tussen 20:00 en 21:00 tijdelijk onbeschikbaar zijn wegens onderhoud. Onze excuses voor het ongemak."
```