### PR TITLE
Correctly parse maintenanceEnabled from env

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -26,7 +26,7 @@ export default class ApplicationController extends Controller {
   }
 
   get maintenanceEnabled() {
-    return ENV.announce.maintenance.enabled === true;
+    return ENV.announce.maintenance.enabled === 'true';
   }
 
   get maintenanceMessage() {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -26,7 +26,7 @@ export default class ApplicationController extends Controller {
   }
 
   get maintenanceEnabled() {
-    return ENV.announce.maintenance.enabled;
+    return ENV.announce.maintenance.enabled === true;
   }
 
   get maintenanceMessage() {


### PR DESCRIPTION
Currently testing the environment banner on dev. The message gets updated correctly but the `maintenanceEnabled` flag was always read as true, so this PR fixes that.