### PR TITLE
Make 'relevant voor' only editable for uploader

### DIFF
--- a/app/components/process/details-card.hbs
+++ b/app/components/process/details-card.hbs
@@ -112,6 +112,7 @@
                 <Process::RelevantAdminUnitSelector
                   @selected={{@process.relevantAdministrativeUnits}}
                   @onChange={{this.setRelevantAdministrativeUnit}}
+                  @disabled={{not @canEdit}}
                 />
               </:content>
             </Item>

--- a/app/components/process/relevant-admin-unit-selector.hbs
+++ b/app/components/process/relevant-admin-unit-selector.hbs
@@ -6,6 +6,7 @@
     @selected={{@selected}}
     @onChange={{@onChange}}
     @triggerId={{@id}}
+    @disabled={{@disabled}}
     as |unit|
   >
     {{unit.label}}


### PR DESCRIPTION
OPH-643

Only uploaders should be able to edit the 'relevant voor' field.
Admins can edit this field by impersonating the uploader.

Test this by signing in as random user and try to edit the relevant voor field for a process uploaded by another user.
Test the same by using the impersonation service. The check should work as expected now.