### PR TITLE
Add zoom buttons for diagrams

### DIFF
--- a/app/components/bpmn-viewer/bpmn-viewer.js
+++ b/app/components/bpmn-viewer/bpmn-viewer.js
@@ -20,13 +20,24 @@ export default class BpmnViewerModifier extends Modifier {
     registerDestructor(this, () => this.viewer?.destroy());
   }
 
-  async modify(container, _, { diagram, onBpmnLoaded, onSvgLoaded, onError }) {
+  async modify(
+    container,
+    _,
+    { diagram, onBpmnLoaded, onSvgLoaded, onError, registerApi },
+  ) {
     container.tabIndex = 0;
 
     if (!this.viewer) {
       this.viewer = new NavigatedViewer({ container });
       container.addEventListener('focus', () => this.enableZoomScroll());
       container.addEventListener('blur', () => this.disableZoomScroll());
+    }
+
+    if (registerApi) {
+      registerApi({
+        zoomIn: this.zoomIn.bind(this),
+        zoomOut: this.zoomOut.bind(this),
+      });
     }
 
     const fileId = diagram?.isBpmnFile && diagram.id;
@@ -61,4 +72,26 @@ export default class BpmnViewerModifier extends Modifier {
   disableZoomScroll() {
     this.viewer?.get('zoomScroll').toggle(false);
   }
+
+  //Zoom buttons
+  zoomFactor = 0.1;
+
+  zoomIn = () => {
+    const canvas = this.viewer?.get('canvas');
+    if (!canvas) {
+      return;
+    }
+
+    const currentZoom = canvas.zoom();
+
+    canvas.zoom(currentZoom + this.zoomFactor);
+  };
+
+  zoomOut = () => {
+    const canvas = this.viewer?.get('canvas');
+    if (!canvas) return;
+
+    const currentZoom = canvas.zoom();
+    canvas.zoom(currentZoom - this.zoomFactor);
+  };
 }

--- a/app/components/bpmn-viewer/bpmn-viewer.js
+++ b/app/components/bpmn-viewer/bpmn-viewer.js
@@ -7,6 +7,7 @@ import generateFileDownloadUrl from 'frontend-openproceshuis/utils/file-download
 export default class BpmnViewerModifier extends Modifier {
   viewer = null;
   lastFileId = null;
+  zoomStep = 0.2;
 
   downloadXml = restartableTask(async (fileId) => {
     const url = generateFileDownloadUrl(fileId);
@@ -73,9 +74,6 @@ export default class BpmnViewerModifier extends Modifier {
     this.viewer?.get('zoomScroll').toggle(false);
   }
 
-  //Zoom buttons
-  zoomFactor = 0.1;
-
   zoomIn = () => {
     const canvas = this.viewer?.get('canvas');
     if (!canvas) {
@@ -84,7 +82,7 @@ export default class BpmnViewerModifier extends Modifier {
 
     const currentZoom = canvas.zoom();
 
-    canvas.zoom(currentZoom + this.zoomFactor);
+    canvas.zoom(currentZoom + this.zoomStep);
   };
 
   zoomOut = () => {
@@ -92,6 +90,6 @@ export default class BpmnViewerModifier extends Modifier {
     if (!canvas) return;
 
     const currentZoom = canvas.zoom();
-    canvas.zoom(currentZoom - this.zoomFactor);
+    canvas.zoom(currentZoom - this.zoomStep);
   };
 }

--- a/app/components/bpmn-viewer/index.hbs
+++ b/app/components/bpmn-viewer/index.hbs
@@ -4,8 +4,8 @@
   </AuAlert>
 {{else}}
   <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
-    Klik en hou vast om diagram te bedienen. Gebruik ctrl en scrollwiel om in
-    en uit te zoomen. Klik elders om bediening uit te schakelen.
+    Klik en hou vast om diagram te bedienen. Gebruik ctrl en scrollwiel om in en
+    uit te zoomen. Klik elders om bediening uit te schakelen.
   </AuHelpText>
   <div
     class="bpmn-container au-u-margin-top-small"
@@ -14,6 +14,12 @@
       onBpmnLoaded=@onBpmnLoaded
       onSvgLoaded=@onSvgLoaded
       onError=this.setError
+      registerApi=this.registerModifierApi
     }}
-  ></div>
+  >
+  </div>
+  <AuButtonGroup class="au-u-flex au-u-flex--center au-u-margin-top-small">
+    <AuButton @skin="secondary" @icon="add" {{on "click" this.zoomIn}} />
+    <AuButton @skin="secondary" @icon="remove" {{on "click" this.zoomOut}} />
+  </AuButtonGroup>
 {{/if}}

--- a/app/components/bpmn-viewer/index.js
+++ b/app/components/bpmn-viewer/index.js
@@ -6,8 +6,21 @@ export default class BpmnViewerComponent extends Component {
   bpmnViewer = BpmnViewerModifier;
 
   @tracked hasError = false;
+  modifierApi = null;
 
   setError = (flag) => {
     this.hasError = flag;
+  };
+
+  registerModifierApi = (api) => {
+    this.modifierApi = api;
+  };
+
+  zoomIn = () => {
+    this.modifierApi?.zoomIn();
+  };
+
+  zoomOut = () => {
+    this.modifierApi?.zoomOut();
   };
 }

--- a/app/components/pdf-viewer/index.hbs
+++ b/app/components/pdf-viewer/index.hbs
@@ -4,8 +4,8 @@
   </AuAlert>
 {{else}}
   <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
-    Klik en hou vast om diagram te bedienen. Gebruik ctrl en scrollwiel om in
-    en uit te zoomen. Klik elders om bediening uit te schakelen.
+    Klik en hou vast om diagram te bedienen. Gebruik ctrl en scrollwiel om in en
+    uit te zoomen. Klik elders om bediening uit te schakelen.
   </AuHelpText>
   <div
     class="bpmn-container au-u-margin-top-small au-u-flex au-u-flex--center au-u-flex--vertical-center"
@@ -15,6 +15,7 @@
       onLoadingChange=this.setLoading
       onPageChange=this.setPage
       onTotalPages=this.setTotal
+      registerApi=this.registerModifierApi
     }}
   >
     {{#if this.isLoading}}
@@ -50,4 +51,8 @@
       </AuButtonGroup>
     {{/if}}
   </div>
+  <AuButtonGroup class="au-u-flex au-u-flex--center au-u-margin-top-small">
+    <AuButton @skin="secondary" @icon="add" {{on "click" this.zoomIn}} />
+    <AuButton @skin="secondary" @icon="remove" {{on "click" this.zoomOut}} />
+  </AuButtonGroup>
 {{/if}}

--- a/app/components/pdf-viewer/index.js
+++ b/app/components/pdf-viewer/index.js
@@ -10,6 +10,11 @@ export default class PdfViewerComponent extends Component {
   @tracked currentPage = 1;
   @tracked totalPages = 1;
   @tracked hasError = false;
+  modifierApi = null;
+
+  registerModifierApi = (api) => {
+    this.modifierApi = api;
+  };
 
   setLoading = (flag) => {
     this.isLoading = flag;
@@ -33,4 +38,12 @@ export default class PdfViewerComponent extends Component {
   goToNext() {
     if (this.currentPage < this.totalPages) this.setPage(this.currentPage + 1);
   }
+
+  zoomIn = () => {
+    this.modifierApi?.zoomIn();
+  };
+
+  zoomOut = () => {
+    this.modifierApi?.zoomOut();
+  };
 }

--- a/app/components/pdf-viewer/pdf-viewer.js
+++ b/app/components/pdf-viewer/pdf-viewer.js
@@ -58,6 +58,7 @@ export default class PdfViewerModifier extends Modifier {
       onPageChange,
       onTotalPages,
       onError,
+      registerApi,
     },
   ) {
     container.tabIndex = 0;
@@ -78,6 +79,13 @@ export default class PdfViewerModifier extends Modifier {
       window.addEventListener('mousemove', this.onMouseMove);
       window.addEventListener('mouseup', this.onMouseUp);
       this.canvas.addEventListener('wheel', this.onWheel, { passive: false });
+    }
+
+    if (registerApi) {
+      registerApi({
+        zoomIn: this.zoomIn.bind(this),
+        zoomOut: this.zoomOut.bind(this),
+      });
     }
 
     const fileId = diagram?.isVisioFile && diagram.id;
@@ -222,4 +230,22 @@ export default class PdfViewerModifier extends Modifier {
   _updateCanvasTransform() {
     this.canvas.style.transform = `translate(${this.offsetX}px, ${this.offsetY}px)`;
   }
+
+  zoomIn = async () => {
+    const newScale = Math.min(this.scale + this.zoomStep, this.maxScale);
+    if (newScale === this.scale) return;
+
+    this.scale = newScale;
+    await this._renderAtScale(newScale);
+    this._updateCanvasTransform();
+  };
+
+  zoomOut = async () => {
+    const newScale = Math.max(this.scale - this.zoomStep, this.minScale);
+    if (newScale === this.scale) return;
+
+    this.scale = newScale;
+    await this._renderAtScale(newScale);
+    this._updateCanvasTransform();
+  };
 }


### PR DESCRIPTION
OPH-521

This PR adds zoom buttons for process diagrams. This works on the bpmn viewer and the pdf viewer. 
This improvement was one I suggested since zooming in and out on laptops can sometimes be a bit finicky with trackpads. 
