### PR TITLE
Hide edit buttons when not authorized to edit

### DIFF
--- a/app/components/process/inventory-process-card.hbs
+++ b/app/components/process/inventory-process-card.hbs
@@ -67,13 +67,13 @@
       Link met procesinventaris
     </:title>
     <:header>
-      {{#unless this.currentSession.readOnly}}
+      {{#if @canEdit}}
         <AuButton
           @skin="naked"
           @icon="pencil"
           {{on "click" this.toggleEdit}}
         >Wijzig</AuButton>
-      {{/unless}}
+      {{/if}}
     </:header>
     <:card as |Card|>
       <Card.Columns>

--- a/app/templates/inventory/index.hbs
+++ b/app/templates/inventory/index.hbs
@@ -78,27 +78,30 @@
                 <span
                   class="inventory-process-number"
                 >{{conceptualProcess.number}}</span>
-                <AuButtonGroup
-                  @inline={{true}}
-                  class="inventory-row-button-group"
-                >
-                  <AuButton
-                    @icon="pencil"
-                    @skin="naked"
-                    @size="large"
-                    {{on
-                      "click"
-                      (fn this.editInventoryProcess conceptualProcess)
-                    }}
-                  />
-                  <AuButton
-                    @icon="bin"
-                    @skin="naked"
-                    @size="large"
-                    @alert={{true}}
-                    {{on "click" (fn this.openDeleteModal conceptualProcess)}}
-                  />
-                </AuButtonGroup>
+                {{#if this.currentSession.isAdmin}}
+
+                  <AuButtonGroup
+                    @inline={{true}}
+                    class="inventory-row-button-group"
+                  >
+                    <AuButton
+                      @icon="pencil"
+                      @skin="naked"
+                      @size="large"
+                      {{on
+                        "click"
+                        (fn this.editInventoryProcess conceptualProcess)
+                      }}
+                    />
+                    <AuButton
+                      @icon="bin"
+                      @skin="naked"
+                      @size="large"
+                      @alert={{true}}
+                      {{on "click" (fn this.openDeleteModal conceptualProcess)}}
+                    />
+                  </AuButtonGroup>
+                {{/if}}
               </div>
             </td>
           </c.body>


### PR DESCRIPTION
Noticed a little mistake when testing the new features on dev. Currently everyone can see the edit/delete buttons. 
If user is not admin ofcourse our auth config is going to block the requests, but i removed the buttons. Also every user that had edit access was able to link to an inventory process. I changed it so it's only the uploader who can set the link