### PR TITLE
Reset IPDC filter on filters reset

### DIFF
--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -105,6 +105,7 @@ export default class ProcessesIndexController extends Controller {
     this.sort = 'title';
     this.blueprint = false;
     this.selectedIpdcProducts = undefined;
+    this.ipdcProducts = undefined;
 
     // Triggers a refresh of the model
     this.page = null;


### PR DESCRIPTION
OPH-700

On the processes overview page, the IPDC filter didn't get cleared when the "Herstel alle filters" button was clicked. This has now been fixed.