### PR TITLE
breaking-change: only use the adapter logic for file models

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,36 +1,3 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-export default class ApplicationAdapter extends JSONAPIAdapter {
-  buildURL(modelName, id, snapshot, requestType, query) {
-    // Query object containing
-    //   'paramKey': ['paramValueA', 'paramValueB']
-    // Should lead to URL containing query params
-    //   paramKey=paramValueA&paramKey=paramValueB
-    // Instead of
-    //   paramKey[]=paramValueA&paramKey[]=paramValueB
-
-    let url = super.buildURL(modelName, id, snapshot, requestType, query);
-
-    if (query) {
-      const customParams = [];
-
-      for (let key in query) {
-        if (Array.isArray(query[key])) {
-          query[key].forEach((item) => {
-            customParams.push(
-              `${encodeURIComponent(key)}=${encodeURIComponent(item)}`,
-            );
-          });
-          delete query[key];
-        }
-      }
-
-      if (customParams.length > 0) {
-        const customQueryString = customParams.join('&');
-        url += `?${customQueryString}`;
-      }
-    }
-
-    return url;
-  }
-}
+export default class ApplicationAdapter extends JSONAPIAdapter {}

--- a/app/adapters/file.js
+++ b/app/adapters/file.js
@@ -1,0 +1,31 @@
+import ApplicationAdapter from './application';
+
+export default class FileAdapter extends ApplicationAdapter {
+  buildURL(modelName, id, snapshot, requestType, query) {
+    // Query object containing
+    //   'paramKey': ['paramValueA', 'paramValueB']
+    // Should lead to URL containing query params
+    //   paramKey=paramValueA&paramKey=paramValueB
+    // Instead of
+    //   paramKey[]=paramValueA&paramKey[]=paramValueB
+    let url = super.buildURL(modelName, id, snapshot, requestType, query);
+    if (query) {
+      const customParams = [];
+      for (let key in query) {
+        if (Array.isArray(query[key])) {
+          query[key].forEach((item) => {
+            customParams.push(
+              `${encodeURIComponent(key)}=${encodeURIComponent(item)}`,
+            );
+          });
+          delete query[key];
+        }
+      }
+      if (customParams.length > 0) {
+        const customQueryString = customParams.join('&');
+        url += `?${customQueryString}`;
+      }
+    }
+    return url;
+  }
+}


### PR DESCRIPTION
## Description

Created this PR as it feels odd to me that we use the application adapter if we only differ from the JSON api standard when we fetch files.

## How to test

Everything should work the same as before