### PR TITLE
Feature/oph 671 hyperlinks to relevant bronnen

### DIFF
--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -28,7 +28,7 @@
   </:subheader>
 
   <:card>
-    <Process::RelevantLinks @canEdit={{@canEdit}} @processId={{@process.id}} />
+    <Process::RelevantLinks @canEdit={{@canEdit}} @process={{@process}} />
     <AuDataTable
       @content={{this.attachments}}
       @isLoading={{this.attachmentsAreLoading}}

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -28,6 +28,7 @@
   </:subheader>
 
   <:card>
+    <Process::RelevantLinks @canEdit={{@canEdit}} @processId={{@process.id}} />
     <AuDataTable
       @content={{this.attachments}}
       @isLoading={{this.attachmentsAreLoading}}

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -1,0 +1,61 @@
+{{#unless (eq this.relevantLinks.length 0)}}
+  <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
+    {{#each this.relevantLinks as |link|}}
+      <Item>
+        <AuLinkExternal
+          href={{link.href}}
+          @icon="external-link"
+          @iconAlignment="right"
+          @newTab={{true}}
+        >
+          {{link.label}}
+        </AuLinkExternal>
+      </Item>
+    {{/each}}
+    {{#if @canEdit}}
+      <Item>
+        <AuButton
+          @icon="plus"
+          @skin="naked"
+          {{on "click" (fn (mut this.isAddModalOpen) true)}}
+        >
+          Voeg een link toe
+        </AuButton>
+      </Item>
+    {{/if}}
+  </AuList>
+{{/unless}}
+
+<AuModal
+  @modalOpen={{this.isAddModalOpen}}
+  @closeModal={{fn (mut this.isAddModalOpen) false}}
+>
+  <:title>Voeg link toe</:title>
+  <:body>
+    <p class="au-u-margin-bottom">Voeg een link toe die relevant is aan dit
+      proces.</p>
+    <AuLabel @error={{not this.inputIsValid}} for="relevant-link">
+      Link
+    </AuLabel>
+    <AuInput
+      @error={{not this.inputIsValid}}
+      @width="block"
+      value={{this.linkValue}}
+      id="relevant-link"
+      {{on "keyup" this.updateLinkValue}}
+    />
+  </:body>
+  <:footer>
+    <AuButtonGroup class="au-u-flex--end">
+      <AuButton
+        @skin="secondary"
+        {{on "click" (fn (mut this.isAddModalOpen) false)}}
+      >Annuleer</AuButton>
+      <AuButton
+        @icon="plus"
+        @disabled={{not this.canSaveChanges}}
+        {{on "click" this.addLink}}
+      >Voeg toe</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -1,18 +1,18 @@
-{{#unless (eq this.relevantLinks.length 0)}}
-  <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
-    {{#each this.relevantLinks as |link|}}
-      <Item>
-        <div
-          class="au-u-padding-left show-element-on-hover au-u-flex au-u-flex--between"
+<AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
+  {{#each this.relevantLinks as |link|}}
+    <Item>
+      <div
+        class="au-u-padding-left show-element-on-hover au-u-flex au-u-flex--between"
+      >
+        <AuLinkExternal
+          href={{link.href}}
+          @icon="external-link"
+          @iconAlignment="right"
+          @newTab={{true}}
         >
-          <AuLinkExternal
-            href={{link.href}}
-            @icon="external-link"
-            @iconAlignment="right"
-            @newTab={{true}}
-          >
-            {{link.displayLabel}}
-          </AuLinkExternal>
+          {{link.displayLabel}}
+        </AuLinkExternal>
+        {{#if @canEdit}}
           <AuButtonGroup
             @inline={{true}}
             class="show-element-on-hover--element"
@@ -31,23 +31,23 @@
               {{on "click" (fn this.openDeleteModal link)}}
             />
           </AuButtonGroup>
-        </div>
-      </Item>
-    {{/each}}
-    {{#if @canEdit}}
-      <Item class="au-u-padding-left-small">
-        <AuButton
-          @icon="plus"
-          @iconAlignment="right"
-          @skin="naked"
-          {{on "click" this.openAddModal}}
-        >
-          Voeg een link toe
-        </AuButton>
-      </Item>
-    {{/if}}
-  </AuList>
-{{/unless}}
+        {{/if}}
+      </div>
+    </Item>
+  {{/each}}
+  {{#if @canEdit}}
+    <Item class="au-u-padding-left-small">
+      <AuButton
+        @icon="plus"
+        @iconAlignment="right"
+        @skin="naked"
+        {{on "click" this.openAddModal}}
+      >
+        Voeg een link toe
+      </AuButton>
+    </Item>
+  {{/if}}
+</AuList>
 
 <AuModal
   @modalOpen={{this.isAddModalOpen}}

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -56,7 +56,9 @@
   <:title>Voeg link toe</:title>
   <:body>
     <p>Voeg een link toe die relevant is aan dit proces. De bijhorende label
-      wordt gebruikt om de links te tonen in de lijst.</p>
+      wordt gebruikt om de links te tonen in de lijst. Laat je deze leeg dan
+      wordt er de link getoont.
+    </p>
     <div class="au-u-margin-top">
       <AuLabel @error={{not this.isLabelValid}} for="relevant-link-label">
         Label

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -157,7 +157,8 @@
   <:title>Voeg link toe</:title>
   <:body>
     <p>Bent u zeker dat u de link
-      <a href={{this.updateLink.href}}> {{this.updateLink.displayLabel}}</a>
+      <a href={{this.updateLinkModel.href}}>
+        {{this.updateLinkModel.displayLabel}}</a>
       wilt verwijderen?</p>
   </:body>
   <:footer>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -21,7 +21,7 @@
               @icon="pencil"
               @skin="naked"
               @size="large"
-              {{!-- {{on "click" this.editInventoryProcess}} --}}
+              {{on "click" (fn this.openEditModal link)}}
             />
             <AuButton
               @icon="bin"
@@ -36,7 +36,12 @@
     {{/each}}
     {{#if @canEdit}}
       <Item class="au-u-padding-left-small">
-        <AuButton @skin="naked" {{on "click" this.openAddModal}}>
+        <AuButton
+          @icon="plus"
+          @iconAlignment="right"
+          @skin="naked"
+          {{on "click" this.openAddModal}}
+        >
           Voeg een link toe
         </AuButton>
       </Item>
@@ -74,6 +79,39 @@
         @disabled={{not this.canSaveChanges}}
         {{on "click" this.addLink}}
       >Voeg toe</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>
+
+<AuModal
+  @modalOpen={{this.isEditModalOpen}}
+  @closeModal={{fn (mut this.isEditModalOpen) false}}
+>
+  <:title>Pas link aan</:title>
+  <:body>
+    <p class="au-u-margin-bottom">Pas de link aan naar een aangepast waarde.</p>
+    <AuLabel @error={{not this.inputIsValid}} for="editrelevant-link">
+      Link
+    </AuLabel>
+    <AuInput
+      @error={{not this.inputIsValid}}
+      @width="block"
+      value={{this.linkValue}}
+      id="edit-relevant-link"
+      {{on "keyup" this.updateLinkValue}}
+    />
+  </:body>
+  <:footer>
+    <AuButtonGroup class="au-u-flex--end">
+      <AuButton
+        @skin="secondary"
+        {{on "click" (fn (mut this.isEditModalOpen) false)}}
+      >Annuleer</AuButton>
+      <AuButton
+        @icon="pencil"
+        @disabled={{not this.canUpdateChanges}}
+        {{on "click" this.updateLink}}
+      >Update</AuButton>
     </AuButtonGroup>
   </:footer>
 </AuModal>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -2,7 +2,9 @@
   <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
     {{#each this.relevantLinks as |link|}}
       <Item>
-        <div class="au-u-padding-left show-element-on-hover au-u-flex au-u-flex--between">
+        <div
+          class="au-u-padding-left show-element-on-hover au-u-flex au-u-flex--between"
+        >
           <AuLinkExternal
             href={{link.href}}
             @icon="external-link"
@@ -26,7 +28,7 @@
               @skin="naked"
               @size="large"
               @alert={{true}}
-              {{!-- {{on "click" this.openDeleteModal}} --}}
+              {{on "click" (fn this.openDeleteModal link)}}
             />
           </AuButtonGroup>
         </div>
@@ -34,10 +36,7 @@
     {{/each}}
     {{#if @canEdit}}
       <Item class="au-u-padding-left-small">
-        <AuButton
-          @skin="naked"
-          {{on "click" this.openAddModal}}
-        >
+        <AuButton @skin="naked" {{on "click" this.openAddModal}}>
           Voeg een link toe
         </AuButton>
       </Item>
@@ -75,6 +74,31 @@
         @disabled={{not this.canSaveChanges}}
         {{on "click" this.addLink}}
       >Voeg toe</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>
+
+<AuModal
+  @modalOpen={{this.isDeleteModalOpen}}
+  @closeModal={{fn (mut this.isDeleteModalOpen) false}}
+>
+  <:title>Voeg link toe</:title>
+  <:body>
+    <p>Bent u zeker dat u de link
+      <a href={{this.updateLink.href}}> {{this.updateLink.displayLabel}}</a>
+      wilt verwijderen?</p>
+  </:body>
+  <:footer>
+    <AuButtonGroup class="au-u-flex--end">
+      <AuButton
+        @skin="secondary"
+        {{on "click" (fn (mut this.isDeleteModalOpen) false)}}
+      >Annuleer</AuButton>
+      <AuButton
+        @icon="trash"
+        @alert={{true}}
+        {{on "click" this.deleteLink}}
+      >Verwijder</AuButton>
     </AuButtonGroup>
   </:footer>
 </AuModal>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -1,29 +1,28 @@
 {{#unless (eq this.relevantLinks.length 0)}}
-  <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
-    {{#each this.relevantLinks as |link|}}
-      <Item>
-        <AuLinkExternal
-          href={{link.href}}
-          @icon="external-link"
-          @iconAlignment="right"
-          @newTab={{true}}
-        >
-          {{link.label}}
-        </AuLinkExternal>
-      </Item>
-    {{/each}}
-    {{#if @canEdit}}
-      <Item>
-        <AuButton
-          @icon="plus"
-          @skin="naked"
-          {{on "click" (fn (mut this.isAddModalOpen) true)}}
-        >
-          Voeg een link toe
-        </AuButton>
-      </Item>
-    {{/if}}
-  </AuList>
+    <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
+      {{#each this.relevantLinks as |link|}}
+        <Item class="au-u-padding-left">
+          <AuLinkExternal
+            href={{link.href}}
+            @icon="external-link"
+            @iconAlignment="right"
+            @newTab={{true}}
+          >
+            {{link.displayLabel}}
+          </AuLinkExternal>
+        </Item>
+      {{/each}}
+      {{#if @canEdit}}
+        <Item class="au-u-padding-left-small">
+          <AuButton
+            @skin="naked"
+            {{on "click" (fn (mut this.isAddModalOpen) true)}}
+          >
+            Voeg een link toe
+          </AuButton>
+        </Item>
+      {{/if}}
+    </AuList>
 {{/unless}}
 
 <AuModal

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -55,9 +55,8 @@
 >
   <:title>Voeg link toe</:title>
   <:body>
-    <p>Voeg een link toe die relevant is aan dit proces. De bijhorende label
-      wordt gebruikt om de links te tonen in de lijst. Laat je deze leeg dan
-      wordt er de link getoont.
+    <p>Voeg een link toe die relevant is voor dit proces. Kies een label voor
+      meer context. Laat je deze leeg, dan wordt de link getoond.
     </p>
     <div class="au-u-margin-top">
       <AuLabel @error={{not this.isLabelValid}} for="relevant-link-label">
@@ -154,12 +153,10 @@
   @modalOpen={{this.isDeleteModalOpen}}
   @closeModal={{fn (mut this.isDeleteModalOpen) false}}
 >
-  <:title>Voeg link toe</:title>
+  <:title>Verwijder link</:title>
   <:body>
-    <p>Bent u zeker dat u de link
-      <a href={{this.updateLinkModel.href}}>
-        {{this.updateLinkModel.displayLabel}}</a>
-      wilt verwijderen?</p>
+    <p>Ben je zeker dat je de link "{{this.updateLinkModel.displayLabel}}" wil
+      verwijderen?</p>
   </:body>
   <:footer>
     <AuButtonGroup class="au-u-flex--end">

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -1,7 +1,8 @@
 {{#unless (eq this.relevantLinks.length 0)}}
-    <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
-      {{#each this.relevantLinks as |link|}}
-        <Item class="au-u-padding-left">
+  <AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
+    {{#each this.relevantLinks as |link|}}
+      <Item>
+        <div class="au-u-padding-left show-element-on-hover au-u-flex au-u-flex--between">
           <AuLinkExternal
             href={{link.href}}
             @icon="external-link"
@@ -10,19 +11,38 @@
           >
             {{link.displayLabel}}
           </AuLinkExternal>
-        </Item>
-      {{/each}}
-      {{#if @canEdit}}
-        <Item class="au-u-padding-left-small">
-          <AuButton
-            @skin="naked"
-            {{on "click" (fn (mut this.isAddModalOpen) true)}}
+          <AuButtonGroup
+            @inline={{true}}
+            class="show-element-on-hover--element"
           >
-            Voeg een link toe
-          </AuButton>
-        </Item>
-      {{/if}}
-    </AuList>
+            <AuButton
+              @icon="pencil"
+              @skin="naked"
+              @size="large"
+              {{!-- {{on "click" this.editInventoryProcess}} --}}
+            />
+            <AuButton
+              @icon="bin"
+              @skin="naked"
+              @size="large"
+              @alert={{true}}
+              {{!-- {{on "click" this.openDeleteModal}} --}}
+            />
+          </AuButtonGroup>
+        </div>
+      </Item>
+    {{/each}}
+    {{#if @canEdit}}
+      <Item class="au-u-padding-left-small">
+        <AuButton
+          @skin="naked"
+          {{on "click" this.openAddModal}}
+        >
+          Voeg een link toe
+        </AuButton>
+      </Item>
+    {{/if}}
+  </AuList>
 {{/unless}}
 
 <AuModal

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -55,18 +55,36 @@
 >
   <:title>Voeg link toe</:title>
   <:body>
-    <p class="au-u-margin-bottom">Voeg een link toe die relevant is aan dit
-      proces.</p>
-    <AuLabel @error={{not this.inputIsValid}} for="relevant-link">
-      Link
-    </AuLabel>
-    <AuInput
-      @error={{not this.inputIsValid}}
-      @width="block"
-      value={{this.linkValue}}
-      id="relevant-link"
-      {{on "keyup" this.updateLinkValue}}
-    />
+    <p>Voeg een link toe die relevant is aan dit proces. De bijhorende label
+      wordt gebruikt om de links te tonen in de lijst.</p>
+    <div class="au-u-margin-top">
+      <AuLabel @error={{not this.isLabelValid}} for="relevant-link-label">
+        Label
+      </AuLabel>
+      <AuInput
+        @error={{not this.isLabelValid}}
+        @width="block"
+        value={{this.labelValue}}
+        id="relevant-link-label"
+        {{on "keyup" this.updateLabelValue}}
+      />
+    </div>
+    <div class="au-u-margin-top">
+      <AuLabel
+        @required={{true}}
+        @error={{not this.isLinkValid}}
+        for="relevant-link"
+      >
+        Link
+      </AuLabel>
+      <AuInput
+        @error={{not this.isLinkValid}}
+        @width="block"
+        value={{this.linkValue}}
+        id="relevant-link"
+        {{on "keyup" this.updateLinkValue}}
+      />
+    </div>
   </:body>
   <:footer>
     <AuButtonGroup class="au-u-flex--end">
@@ -89,17 +107,31 @@
 >
   <:title>Pas link aan</:title>
   <:body>
-    <p class="au-u-margin-bottom">Pas de link aan naar een aangepast waarde.</p>
-    <AuLabel @error={{not this.inputIsValid}} for="editrelevant-link">
-      Link
-    </AuLabel>
-    <AuInput
-      @error={{not this.inputIsValid}}
-      @width="block"
-      value={{this.linkValue}}
-      id="edit-relevant-link"
-      {{on "keyup" this.updateLinkValue}}
-    />
+    <p>Pas de link aan naar een aangepast waarde.</p>
+    <div class="au-u-margin-top">
+      <AuLabel @error={{not this.isLabelValid}} for="edit-relevant-link-label">
+        Label
+      </AuLabel>
+      <AuInput
+        @error={{not this.isLabelValid}}
+        @width="block"
+        value={{this.labelValue}}
+        id="edit-relevant-link-label"
+        {{on "keyup" this.updateLabelValue}}
+      />
+    </div>
+    <div class="au-u-margin-bottom">
+      <AuLabel @error={{not this.isLinkValid}} for="editrelevant-link">
+        Link
+      </AuLabel>
+      <AuInput
+        @error={{not this.isLinkValid}}
+        @width="block"
+        value={{this.linkValue}}
+        id="edit-relevant-link"
+        {{on "keyup" this.updateLinkValue}}
+      />
+    </div>
   </:body>
   <:footer>
     <AuButtonGroup class="au-u-flex--end">

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -15,28 +15,46 @@ export default class ProcessRelevantLinks extends Component {
   @tracked isDeleteModalOpen = false;
 
   @tracked updateLinkModel;
+  @tracked labelValue;
   @tracked linkValue;
 
   get relevantLinks() {
     return this.args.process?.links ?? [];
   }
 
-  get inputIsValid() {
+  get isLinkValid() {
     return isEmptyOrUrl(this.linkValue);
+  }
+
+  get isLabelValid() {
+    return !this.labelValue || this.labelValue.trim() != '';
   }
 
   get canSaveChanges() {
     if (!this.linkValue) {
       return false;
     }
-    return this.inputIsValid;
+    return this.isLinkValid;
   }
 
   get canUpdateChanges() {
     if (!this.linkValue) {
       return false;
     }
-    return this.inputIsValid && this.updateLinkModel?.href !== this.linkValue;
+    return this.isLinkValid && this.updateLinkModel?.href !== this.linkValue;
+  }
+
+  get cleanLabel() {
+    return this.labelValue?.trim();
+  }
+
+  get cleanLink() {
+    return this.linkValue?.trim();
+  }
+
+  @action
+  updateLabelValue(event) {
+    this.labelValue = event.target?.value;
   }
 
   @action
@@ -65,10 +83,9 @@ export default class ProcessRelevantLinks extends Component {
 
   @action
   async addLink() {
-    const cleanLink = this.linkValue.trim();
     const linkModel = this.store.createRecord('link', {
-      label: null,
-      href: cleanLink,
+      label: this.cleanLabel,
+      href: this.cleanLink,
     });
     const links = await this.args.process.links;
     if (links.find((l) => l.href === linkModel.href)) {
@@ -119,7 +136,8 @@ export default class ProcessRelevantLinks extends Component {
 
   @action
   async updateLink() {
-    this.updateLinkModel.href = this.linkValue;
+    this.updateLinkModel.label = this.cleanLabel;
+    this.updateLinkModel.href = this.cleanLink;
     try {
       await this.updateLinkModel.save();
       this.toaster.success('De link werd succesvol aangepast', undefined, {

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+import { isEmptyOrUrl } from '../../utils/custom-validators';
+
+export default class ProcessRelevantLinks extends Component {
+  @tracked isAddModalOpen = false;
+  @tracked linkValue;
+
+  get inputIsValid() {
+    return isEmptyOrUrl(this.linkValue);
+  }
+
+  get canSaveChanges() {
+    if (!this.linkValue) {
+      return false;
+    }
+    return this.inputIsValid;
+  }
+
+  get relevantLinks() {
+    return [];
+  }
+
+  @action
+  updateLinkValue(event) {
+    this.linkValue = event.target?.value;
+  }
+
+  @action
+  addLink() {
+    const cleanLink = this.linkValue.trim();
+    alert('Add link TODO => ' + cleanLink);
+  }
+}

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -41,7 +41,7 @@ export default class ProcessRelevantLinks extends Component {
     if (!this.linkValue) {
       return false;
     }
-    return this.isLinkValid && this.updateLinkModel?.href !== this.linkValue;
+    return this.isLinkValid && this.isInputDivergingFromStartValue;
   }
 
   get cleanLabel() {
@@ -50,6 +50,20 @@ export default class ProcessRelevantLinks extends Component {
 
   get cleanLink() {
     return this.linkValue?.trim();
+  }
+
+  get isInputDivergingFromStartValue() {
+    if (!this.updateLinkModel) {
+      return false;
+    }
+    if (this.cleanLabel != this.updateLinkModel.label) {
+      return true;
+    }
+    if (this.cleanLink != this.updateLinkModel.href) {
+      return true;
+    }
+
+    return false;
   }
 
   @action
@@ -65,6 +79,7 @@ export default class ProcessRelevantLinks extends Component {
   @action
   openAddModal() {
     this.isAddModalOpen = true;
+    this.labelValue = null;
     this.linkValue = null;
   }
 
@@ -78,6 +93,7 @@ export default class ProcessRelevantLinks extends Component {
   openEditModal(link) {
     this.isEditModalOpen = true;
     this.updateLinkModel = link;
+    this.labelValue = link.label;
     this.linkValue = link.href;
   }
 

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -136,6 +136,8 @@ export default class ProcessRelevantLinks extends Component {
   async deleteLink() {
     try {
       await this.updateLinkModel.destroyRecord();
+      this.isDeleteModalOpen = false;
+      this.updateLinkModel = null;
       this.toaster.success('Link succesvol verwijderd', undefined, {
         timeOut: 5000,
       });

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -11,9 +11,10 @@ export default class ProcessRelevantLinks extends Component {
   @service toaster;
 
   @tracked isAddModalOpen = false;
+  @tracked isEditModalOpen = false;
   @tracked isDeleteModalOpen = false;
 
-  @tracked editLinkModel;
+  @tracked updateLinkModel;
   @tracked linkValue;
 
   get relevantLinks() {
@@ -31,6 +32,13 @@ export default class ProcessRelevantLinks extends Component {
     return this.inputIsValid;
   }
 
+  get canUpdateChanges() {
+    if (!this.linkValue) {
+      return false;
+    }
+    return this.inputIsValid && this.updateLinkModel?.href !== this.linkValue;
+  }
+
   @action
   updateLinkValue(event) {
     this.linkValue = event.target?.value;
@@ -45,7 +53,14 @@ export default class ProcessRelevantLinks extends Component {
   @action
   openDeleteModal(link) {
     this.isDeleteModalOpen = true;
-    this.editLinkModel = link;
+    this.updateLinkModel = link;
+  }
+
+  @action
+  openEditModal(link) {
+    this.isEditModalOpen = true;
+    this.updateLinkModel = link;
+    this.linkValue = link.href;
   }
 
   @action
@@ -87,13 +102,35 @@ export default class ProcessRelevantLinks extends Component {
   @action
   async deleteLink() {
     try {
-      await this.editLinkModel.destroyRecord();
+      await this.updateLinkModel.destroyRecord();
       this.toaster.success('Link succesvol verwijderd', undefined, {
         timeOut: 5000,
       });
     } catch (error) {
       this.toaster.error(
         'Er liep iets mis bij het verwijderen van de link',
+        undefined,
+        {
+          timeOut: 5000,
+        },
+      );
+    }
+  }
+
+  @action
+  async updateLink() {
+    this.updateLinkModel.href = this.linkValue;
+    try {
+      await this.updateLinkModel.save();
+      this.toaster.success('De link werd succesvol aangepast', undefined, {
+        timeOut: 5000,
+      });
+      this.isEditModalOpen = false;
+      this.updateLinkModel = null;
+      this.linkValue = null;
+    } catch (error) {
+      this.toaster.error(
+        'Er liep iets mis bij het aanpassen van de link',
         undefined,
         {
           timeOut: 5000,

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -11,6 +11,9 @@ export default class ProcessRelevantLinks extends Component {
   @service toaster;
 
   @tracked isAddModalOpen = false;
+  @tracked isDeleteModalOpen = false;
+
+  @tracked editLinkModel;
   @tracked linkValue;
 
   get relevantLinks() {
@@ -37,6 +40,12 @@ export default class ProcessRelevantLinks extends Component {
   openAddModal() {
     this.isAddModalOpen = true;
     this.linkValue = null;
+  }
+
+  @action
+  openDeleteModal(link) {
+    this.isDeleteModalOpen = true;
+    this.editLinkModel = link;
   }
 
   @action
@@ -67,6 +76,24 @@ export default class ProcessRelevantLinks extends Component {
     } catch (error) {
       this.toaster.error(
         'Er liep iets mis bij het toevoegen van de link',
+        undefined,
+        {
+          timeOut: 5000,
+        },
+      );
+    }
+  }
+
+  @action
+  async deleteLink() {
+    try {
+      await this.editLinkModel.destroyRecord();
+      this.toaster.success('Link succesvol verwijderd', undefined, {
+        timeOut: 5000,
+      });
+    } catch (error) {
+      this.toaster.error(
+        'Er liep iets mis bij het verwijderen van de link',
         undefined,
         {
           timeOut: 5000,

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -105,7 +105,7 @@ export default class ProcessRelevantLinks extends Component {
     });
     const links = await this.args.process.links;
     if (links.find((l) => l.href === linkModel.href)) {
-      this.toaster.error('Deze link heeft u al toegevoegd', undefined, {
+      this.toaster.error('Deze link werd al toegevoegd.', undefined, {
         timeOut: 5000,
       });
       linkModel.deleteRecord();

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -2,12 +2,19 @@ import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 
 import { isEmptyOrUrl } from '../../utils/custom-validators';
 
 export default class ProcessRelevantLinks extends Component {
+  @service store;
+
   @tracked isAddModalOpen = false;
   @tracked linkValue;
+
+  get relevantLinks() {
+    return this.args.process?.links ?? [];
+  }
 
   get inputIsValid() {
     return isEmptyOrUrl(this.linkValue);
@@ -20,18 +27,30 @@ export default class ProcessRelevantLinks extends Component {
     return this.inputIsValid;
   }
 
-  get relevantLinks() {
-    return [];
-  }
-
   @action
   updateLinkValue(event) {
     this.linkValue = event.target?.value;
   }
 
   @action
-  addLink() {
+  async addLink() {
     const cleanLink = this.linkValue.trim();
-    alert('Add link TODO => ' + cleanLink);
+    const link = this.store.createRecord('link', {
+      label: null,
+      href: this.linkValue,
+    });
+    const links = await this.args.process.links;
+    links.push(cleanLink);
+
+    if (links.find((l) => l.href === link.href)) {
+      this.toaster.error('Deze link heeft u al toegevoegd', undefined, {
+        timeOut: 5000,
+      });
+      link.deleteRecord();
+      return;
+    }
+
+    await link.save();
+    await this.args.process.save();
   }
 }

--- a/app/models/link.js
+++ b/app/models/link.js
@@ -1,15 +1,8 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 export default class LinkModel extends Model {
   @attr('string') label;
   @attr('string') href;
-
-  @belongsTo('process', {
-    async: false,
-    inverse: 'links',
-    polymorphic: true,
-  })
-  process;
 
   get displayLabel() {
     if (!this.label) {

--- a/app/models/link.js
+++ b/app/models/link.js
@@ -1,0 +1,20 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class LinkModel extends Model {
+  @attr('string') label;
+  @attr('string') href;
+
+  @belongsTo('process', {
+    async: false,
+    inverse: 'links',
+    polymorphic: true,
+  })
+  process;
+
+  get displayLabel() {
+    if (!this.label) {
+      return this.href;
+    }
+    return this.label;
+  }
+}

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -41,6 +41,11 @@ export default class ProcessModel extends Model {
     polymorphic: true,
   })
   ipdcProducts;
+  @hasMany('link', {
+    inverse: 'process',
+    async: true,
+  })
+  links;
   @hasMany('information-asset', { inverse: null, async: false })
   informationAssets;
   @hasMany('process', { inverse: 'linkedBlueprints', async: true })

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -42,7 +42,7 @@ export default class ProcessModel extends Model {
   })
   ipdcProducts;
   @hasMany('link', {
-    inverse: 'process',
+    inverse: null,
     async: true,
   })
   links;

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -128,3 +128,13 @@
 tr:hover .inventory-row-button-group .au-c-button {
   visibility: visible;
 }
+
+.show-element-on-hover--element {
+  visibility: hidden;
+}
+
+.show-element-on-hover:hover {
+  .show-element-on-hover--element {
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
## Description

We want to keep related links to a process on the process. The user can add/remove/update the related links on the process detail page.

## How to test

1. Open a process that you can edit
2. You should be able to do crud actions on the links of the process
3. Login as someone else and view that process again. These links you added should be visible but not editable

## Links to other PR's

- https://github.com/lblod/app-openproceshuis/pull/88

## Attachments

**Initial state**
<img width="1756" height="547" alt="image" src="https://github.com/user-attachments/assets/8c072a8a-83cf-441a-bb25-82737c3b28b1" />

**Added links**
<img width="1768" height="685" alt="image" src="https://github.com/user-attachments/assets/7dbf5a5f-c3c9-498e-a4bb-f68322311678" />


** Readonly for other organizations**
<img width="1753" height="558" alt="image" src="https://github.com/user-attachments/assets/c2de030c-aa6f-46c6-84a8-545f9b6d5bd8" />

