### PR TITLE
oph-711 | Add filters to inventory page

### DIFF
--- a/app/components/inventory/select-category.hbs
+++ b/app/components/inventory/select-category.hbs
@@ -1,5 +1,7 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
+    @searchEnabled={{true}}
+    @searchField="label"
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @options={{this.categories.value}}

--- a/app/components/inventory/select-category.hbs
+++ b/app/components/inventory/select-category.hbs
@@ -1,0 +1,14 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelect
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @options={{this.categories.value}}
+    @selected={{this.selectedCategory.value}}
+    @onChange={{this.onChange}}
+    @allowClear={{true}}
+    @triggerId={{@id}}
+    as |category|
+  >
+    {{category.label}}
+  </PowerSelect>
+</div>

--- a/app/components/inventory/select-category.hbs
+++ b/app/components/inventory/select-category.hbs
@@ -1,6 +1,5 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
-    @disabled={{@disabled}}
     @searchEnabled={{true}}
     @searchField="label"
     @loadingMessage="Aan het laden..."

--- a/app/components/inventory/select-category.hbs
+++ b/app/components/inventory/select-category.hbs
@@ -1,5 +1,6 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
+    @disabled={{@disabled}}
     @searchEnabled={{true}}
     @searchField="label"
     @loadingMessage="Aan het laden..."

--- a/app/components/inventory/select-category.js
+++ b/app/components/inventory/select-category.js
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+
+import { restartableTask } from 'ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
+import ENV from 'frontend-openproceshuis/config/environment';
+
+export default class InventorySelectCategory extends Component {
+  @service router;
+  @service store;
+
+  loadCategoriesTask = restartableTask(async () => {
+    const query = {
+      sort: ':no-case:label',
+      filter: {
+        scheme: ENV.conceptSchemes.processCategories,
+        ':not:status': ENV.resourceStates.archived,
+      },
+    };
+
+    return await this.store.query('process-category', query);
+  });
+
+  categories = trackedTask(this, this.loadCategoriesTask);
+
+  loadSelectedCategory = restartableTask(async () => {
+    if (!this.args.selected) return null;
+    return await this.store.findRecord('process-category', this.args.selected);
+  });
+
+  selectedCategory = trackedTask(this, this.loadSelectedCategory, () => [
+    this.args.selected,
+  ]);
+
+  @action
+  onChange(category) {
+    this.args.onChange(category?.id);
+  }
+}

--- a/app/components/inventory/select-category.js
+++ b/app/components/inventory/select-category.js
@@ -36,6 +36,9 @@ export default class InventorySelectCategory extends Component {
 
   @action
   onChange(category) {
-    this.args.onChange(category?.id);
+    this.args.onChange?.({
+      filterKey: 'category',
+      value: category?.id,
+    });
   }
 }

--- a/app/components/inventory/select-domain.hbs
+++ b/app/components/inventory/select-domain.hbs
@@ -1,0 +1,16 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelect
+    @searchEnabled={{true}}
+    @searchField="label"
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @options={{this.domains.value}}
+    @selected={{this.selectedDomain.value}}
+    @onChange={{this.onChange}}
+    @allowClear={{true}}
+    @triggerId={{@id}}
+    as |domain|
+  >
+    {{domain.label}}
+  </PowerSelect>
+</div>

--- a/app/components/inventory/select-domain.hbs
+++ b/app/components/inventory/select-domain.hbs
@@ -1,6 +1,5 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
-    @disabled={{@disabled}}
     @searchEnabled={{true}}
     @searchField="label"
     @loadingMessage="Aan het laden..."

--- a/app/components/inventory/select-domain.hbs
+++ b/app/components/inventory/select-domain.hbs
@@ -1,5 +1,6 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
+    @disabled={{@disabled}}
     @searchEnabled={{true}}
     @searchField="label"
     @loadingMessage="Aan het laden..."

--- a/app/components/inventory/select-domain.js
+++ b/app/components/inventory/select-domain.js
@@ -1,0 +1,51 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+
+import { restartableTask } from 'ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
+
+import ENV from 'frontend-openproceshuis/config/environment';
+
+export default class InventorySelectDomain extends Component {
+  @service router;
+  @service store;
+
+  loadDomainsTask = restartableTask(async () => {
+    const query = {
+      page: {
+        size: 100,
+      },
+      sort: ':no-case:label',
+      filter: {
+        scheme: ENV.conceptSchemes.processDomains,
+        ':not:status': ENV.resourceStates.archived,
+      },
+    };
+
+    if (this.args.category)
+      query['filter[process-categories][id]'] = this.args.category;
+
+    return await this.store.query('process-domain', query);
+  });
+
+  domains = trackedTask(this, this.loadDomainsTask, () => [this.args.category]);
+
+  loadSelectedDomain = restartableTask(async () => {
+    if (!this.args.selected) return null;
+    return await this.store.findRecord('process-domain', this.args.selected);
+  });
+
+  selectedDomain = trackedTask(this, this.loadSelectedDomain, () => [
+    this.args.selected,
+  ]);
+
+  @action
+  onChange(domain) {
+    this.args.onChange?.({
+      filterKey: 'domain',
+      value: domain?.id,
+    });
+  }
+}

--- a/app/components/inventory/select-group.hbs
+++ b/app/components/inventory/select-group.hbs
@@ -1,0 +1,16 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelect
+    @searchEnabled={{true}}
+    @searchField="label"
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @options={{this.groups.value}}
+    @selected={{this.selectedGroup.value}}
+    @onChange={{this.onChange}}
+    @allowClear={{true}}
+    @triggerId={{@id}}
+    as |group|
+  >
+    {{group.label}}
+  </PowerSelect>
+</div>

--- a/app/components/inventory/select-group.hbs
+++ b/app/components/inventory/select-group.hbs
@@ -1,6 +1,5 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
-    @disabled={{@disabled}}
     @searchEnabled={{true}}
     @searchField="label"
     @loadingMessage="Aan het laden..."

--- a/app/components/inventory/select-group.hbs
+++ b/app/components/inventory/select-group.hbs
@@ -1,5 +1,6 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelect
+    @disabled={{@disabled}}
     @searchEnabled={{true}}
     @searchField="label"
     @loadingMessage="Aan het laden..."

--- a/app/components/inventory/select-group.js
+++ b/app/components/inventory/select-group.js
@@ -1,0 +1,58 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+
+import { restartableTask } from 'ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
+
+import ENV from 'frontend-openproceshuis/config/environment';
+
+export default class InventorySelectGroup extends Component {
+  @service router;
+  @service store;
+
+  loadGroupsTask = restartableTask(async () => {
+    const query = {
+      page: {
+        size: 500,
+      },
+      sort: ':no-case:label',
+      filter: {
+        scheme: ENV.conceptSchemes.processGroups,
+        ':not:status': ENV.resourceStates.archived,
+      },
+    };
+
+    if (this.args.category)
+      query['filter[process-domains][process-categories][id]'] =
+        this.args.category;
+
+    if (this.args.domain)
+      query['filter[process-domains][id]'] = this.args.domain;
+
+    return await this.store.query('process-group', query);
+  });
+
+  groups = trackedTask(this, this.loadGroupsTask, () => [
+    this.args.category,
+    this.args.domain,
+  ]);
+
+  loadSelectedGroup = restartableTask(async () => {
+    if (!this.args.selected) return null;
+    return await this.store.findRecord('process-group', this.args.selected);
+  });
+
+  selectedGroup = trackedTask(this, this.loadSelectedGroup, () => [
+    this.args.selected,
+  ]);
+
+  @action
+  onChange(group) {
+    this.args.onChange?.({
+      filterKey: 'group',
+      value: group?.id,
+    });
+  }
+}

--- a/app/components/inventory/select-number.hbs
+++ b/app/components/inventory/select-number.hbs
@@ -1,0 +1,9 @@
+<AuInput
+  @width="block"
+  @id={{@id}}
+  value={{@selected}}
+  type="number"
+  min="0"
+  class="grow"
+  {{on "input" (perform this.onChange)}}
+/>

--- a/app/components/inventory/select-number.js
+++ b/app/components/inventory/select-number.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+export default class InventorySelectNumber extends Component {
+  @service router;
+  @service store;
+
+  onChange = restartableTask(async (event) => {
+    await timeout(250);
+    this.args.onChange?.({
+      filterKey: 'processNumber',
+      value: event.target?.value?.trim(),
+    });
+  });
+}

--- a/app/components/inventory/select-title.hbs
+++ b/app/components/inventory/select-title.hbs
@@ -1,0 +1,19 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelect
+    @allowClear={{true}}
+    @searchEnabled={{true}}
+    @searchField="title"
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @search={{perform this.loadConceptualProcessesTask}}
+    @onOpen={{perform this.loadConceptualProcessesTask}}
+    @options={{this.options}}
+    @selected={{@selected}}
+    @onChange={{this.onChange}}
+    @triggerId={{@id}}
+    as |title|
+  >
+    {{title}}
+  </PowerSelect>
+</div>

--- a/app/components/inventory/select-title.js
+++ b/app/components/inventory/select-title.js
@@ -1,0 +1,58 @@
+import Component from '@glimmer/component';
+
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+import { restartableTask, timeout } from 'ember-concurrency';
+
+import ENV from 'frontend-openproceshuis/config/environment';
+
+export default class InventorySelectTitle extends Component {
+  @service store;
+
+  @tracked options = A([]);
+
+  @restartableTask
+  *loadConceptualProcessesTask(searchParams = '') {
+    yield timeout(200);
+
+    const query = {
+      filter: {
+        ':not:status': ENV.resourceStates.archived,
+      },
+    };
+    this.options.clear();
+    if (
+      searchParams &&
+      typeof searchParams === 'string' &&
+      searchParams?.trim() !== ''
+    ) {
+      query['filter']['title'] = searchParams;
+      this.options.pushObject(searchParams);
+    }
+    if (this.args.category)
+      query['filter[process-groups][process-domains][process-categories][id]'] =
+        this.args.category;
+
+    if (this.args.domain)
+      query['filter[process-groups][process-domains][id]'] = this.args.domain;
+
+    if (this.args.group) query['filter[process-groups][id]'] = this.args.group;
+
+    const result = yield this.store.query('conceptual-process', query);
+
+    if (result) {
+      this.options.pushObjects([...new Set(result.map((r) => r.title))]);
+    }
+  }
+
+  @action
+  onChange(title) {
+    this.args.onChange?.({
+      filterKey: 'processTitle',
+      value: title,
+    });
+  }
+}

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -12,7 +12,6 @@
           @selected={{@params.category}}
           @onChange={{this.onFilterUpdated}}
           class="grow"
-          @disabled={{@params.domain}}
         />
       </div>
       <div>
@@ -23,7 +22,6 @@
           @onChange={{this.onFilterUpdated}}
           @category={{@params.category}}
           class="grow"
-          @disabled={{@params.group}}
         />
       </div>
       <div>

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -1,0 +1,29 @@
+<div class="au-c-sidebar">
+  <div class="au-c-sidebar__content">
+    <form
+      {{on "reset" this.resetFilters}}
+      class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
+    >
+      <h1 class="au-u-h3 au-u-medium">Filters</h1>
+      <div>
+        <AuLabel for="filter-category">Categorie</AuLabel>
+        <Inventory::SelectCategory
+          @id="filter-category"
+          @selected={{@params.category}}
+          @onChange={{this.onFilterUpdated}}
+          class="grow"
+        />
+      </div>
+      <div class="au-u-flex au-u-flex--end">
+        <AuButton
+          @icon="cross"
+          @skin="link"
+          type="reset"
+          class="au-u-padding-none au-u-medium"
+        >
+          Herstel alle filters
+        </AuButton>
+      </div>
+    </form>
+  </div>
+</div>

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -24,6 +24,17 @@
           class="grow"
         />
       </div>
+      <div>
+        <AuLabel for="filter-group">Procesgroep</AuLabel>
+        <Inventory::SelectGroup
+          @id="filter-group"
+          @selected={{@params.group}}
+          @onChange={{this.onFilterUpdated}}
+          @category={{@params.category}}
+          @domain={{@params.domain}}
+          class="grow"
+        />
+      </div>
       <div class="au-u-flex au-u-flex--end">
         <AuButton
           @icon="cross"

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -49,6 +49,15 @@
           class="grow"
         />
       </div>
+      <div>
+        <AuLabel for="filter-title">Nummer</AuLabel>
+        <Inventory::SelectNumber
+          @id="filter-number"
+          @selected={{@params.processNumber}}
+          @onChange={{this.onFilterUpdated}}
+          class="grow"
+        />
+      </div>
       <div class="au-u-flex au-u-flex--end">
         <AuButton
           @icon="cross"

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -35,6 +35,18 @@
           class="grow"
         />
       </div>
+      <div>
+        <AuLabel for="filter-title">Hoofdproces</AuLabel>
+        <Inventory::SelectTitle
+          @id="filter-title"
+          @selected={{@params.processTitle}}
+          @onChange={{this.onFilterUpdated}}
+          @category={{@params.category}}
+          @domain={{@params.domain}}
+          @group={{@params.group}}
+          class="grow"
+        />
+      </div>
       <div class="au-u-flex au-u-flex--end">
         <AuButton
           @icon="cross"

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -12,6 +12,7 @@
           @selected={{@params.category}}
           @onChange={{this.onFilterUpdated}}
           class="grow"
+          @disabled={{@params.domain}}
         />
       </div>
       <div>
@@ -22,6 +23,7 @@
           @onChange={{this.onFilterUpdated}}
           @category={{@params.category}}
           class="grow"
+          @disabled={{@params.group}}
         />
       </div>
       <div>

--- a/app/components/inventory/sidebar-filters.hbs
+++ b/app/components/inventory/sidebar-filters.hbs
@@ -14,6 +14,16 @@
           class="grow"
         />
       </div>
+      <div>
+        <AuLabel for="filter-domain">Procesdomein</AuLabel>
+        <Inventory::SelectDomain
+          @id="filter-domain"
+          @selected={{@params.domain}}
+          @onChange={{this.onFilterUpdated}}
+          @category={{@params.category}}
+          class="grow"
+        />
+      </div>
       <div class="au-u-flex au-u-flex--end">
         <AuButton
           @icon="cross"

--- a/app/components/inventory/sidebar-filters.js
+++ b/app/components/inventory/sidebar-filters.js
@@ -3,7 +3,13 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class InventorySidebarFilters extends Component {
-  queryParams = ['category', 'domain', 'group', 'processTitle'];
+  queryParams = [
+    'category',
+    'domain',
+    'group',
+    'processTitle',
+    'processNumber',
+  ];
 
   @action
   resetFilters() {

--- a/app/components/inventory/sidebar-filters.js
+++ b/app/components/inventory/sidebar-filters.js
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class InventorySidebarFilters extends Component {
-  queryParams = ['category', 'domain'];
+  queryParams = ['category', 'domain', 'group'];
 
   @action
   resetFilters() {

--- a/app/components/inventory/sidebar-filters.js
+++ b/app/components/inventory/sidebar-filters.js
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class InventorySidebarFilters extends Component {
-  queryParams = ['category', 'domain', 'group', 'title', 'processTitle'];
+  queryParams = ['category', 'domain', 'group', 'processTitle'];
 
   @action
   resetFilters() {

--- a/app/components/inventory/sidebar-filters.js
+++ b/app/components/inventory/sidebar-filters.js
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class InventorySidebarFilters extends Component {
-  queryParams = ['category'];
+  queryParams = ['category', 'domain'];
 
   @action
   resetFilters() {

--- a/app/components/inventory/sidebar-filters.js
+++ b/app/components/inventory/sidebar-filters.js
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+
+export default class InventorySidebarFilters extends Component {
+  queryParams = ['category'];
+
+  @action
+  resetFilters() {
+    const emptyParams = {};
+    for (const key of this.queryParams) {
+      emptyParams[key] = null;
+    }
+    this.args.onFilterApplied(emptyParams);
+  }
+
+  @action
+  onFilterUpdated({ filterKey, value }) {
+    this.args.onFilterApplied({ [filterKey]: value });
+  }
+}

--- a/app/components/inventory/sidebar-filters.js
+++ b/app/components/inventory/sidebar-filters.js
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class InventorySidebarFilters extends Component {
-  queryParams = ['category', 'domain', 'group'];
+  queryParams = ['category', 'domain', 'group', 'title', 'processTitle'];
 
   @action
   resetFilters() {

--- a/app/components/process-bar.hbs
+++ b/app/components/process-bar.hbs
@@ -21,7 +21,7 @@
         </Tab>
       {{/if}}
       <Tab>
-        <AuLink @route="inventory" @icon="folder">
+        <AuLink @route="inventory.index" @icon="folder">
           Inventaris processen
         </AuLink>
       </Tab>

--- a/app/controllers/inventory/index.js
+++ b/app/controllers/inventory/index.js
@@ -8,7 +8,7 @@ import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-mess
 
 export default class InventoryIndexController extends Controller {
   @service store;
-  queryParams = ['page', 'size', 'sort'];
+  queryParams = ['page', 'size', 'sort', 'category'];
   @service router;
   @service currentSession;
   @service toaster;
@@ -16,6 +16,7 @@ export default class InventoryIndexController extends Controller {
   @tracked page = 0;
   size = 20;
   @tracked sort = 'title';
+  @tracked category = null;
 
   @tracked isModalOpen = false;
   @tracked isDeleteModalOpen = false;
@@ -334,5 +335,13 @@ export default class InventoryIndexController extends Controller {
     this.isDeleteModalOpen = false;
     this.isModalOpen = false;
     this.addProcessModalEdited = false;
+  }
+
+  @action
+  updateFilters(filters) {
+    Object.entries(filters).map(([key, value]) => {
+      this[key] = value;
+    });
+    this.page = 0;
   }
 }

--- a/app/controllers/inventory/index.js
+++ b/app/controllers/inventory/index.js
@@ -8,7 +8,16 @@ import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-mess
 
 export default class InventoryIndexController extends Controller {
   @service store;
-  queryParams = ['page', 'size', 'sort', 'category', 'domain', 'group'];
+  queryParams = [
+    'page',
+    'size',
+    'sort',
+    'category',
+    'domain',
+    'group',
+    'title',
+    'processTitle',
+  ];
   @service router;
   @service currentSession;
   @service toaster;
@@ -19,6 +28,7 @@ export default class InventoryIndexController extends Controller {
   @tracked category = null;
   @tracked domain = null;
   @tracked group = null;
+  @tracked processTitle = null;
 
   @tracked isModalOpen = false;
   @tracked isDeleteModalOpen = false;

--- a/app/controllers/inventory/index.js
+++ b/app/controllers/inventory/index.js
@@ -17,6 +17,7 @@ export default class InventoryIndexController extends Controller {
     'group',
     'title',
     'processTitle',
+    'processNumber',
   ];
   @service router;
   @service currentSession;
@@ -29,6 +30,7 @@ export default class InventoryIndexController extends Controller {
   @tracked domain = null;
   @tracked group = null;
   @tracked processTitle = null;
+  @tracked processNumber = null;
 
   @tracked isModalOpen = false;
   @tracked isDeleteModalOpen = false;

--- a/app/controllers/inventory/index.js
+++ b/app/controllers/inventory/index.js
@@ -8,7 +8,7 @@ import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-mess
 
 export default class InventoryIndexController extends Controller {
   @service store;
-  queryParams = ['page', 'size', 'sort', 'category'];
+  queryParams = ['page', 'size', 'sort', 'category', 'domain'];
   @service router;
   @service currentSession;
   @service toaster;
@@ -17,6 +17,7 @@ export default class InventoryIndexController extends Controller {
   size = 20;
   @tracked sort = 'title';
   @tracked category = null;
+  @tracked domain = null;
 
   @tracked isModalOpen = false;
   @tracked isDeleteModalOpen = false;

--- a/app/controllers/inventory/index.js
+++ b/app/controllers/inventory/index.js
@@ -8,7 +8,7 @@ import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-mess
 
 export default class InventoryIndexController extends Controller {
   @service store;
-  queryParams = ['page', 'size', 'sort', 'category', 'domain'];
+  queryParams = ['page', 'size', 'sort', 'category', 'domain', 'group'];
   @service router;
   @service currentSession;
   @service toaster;
@@ -18,6 +18,7 @@ export default class InventoryIndexController extends Controller {
   @tracked sort = 'title';
   @tracked category = null;
   @tracked domain = null;
+  @tracked group = null;
 
   @tracked isModalOpen = false;
   @tracked isDeleteModalOpen = false;

--- a/app/routes/inventory/index.js
+++ b/app/routes/inventory/index.js
@@ -12,6 +12,7 @@ export default class InventoryIndexRoute extends Route {
     sort: { refreshModel: true },
     category: { refreshModel: true },
     domain: { refreshModel: true },
+    group: { refreshModel: true },
   };
 
   async model(params) {

--- a/app/routes/inventory/index.js
+++ b/app/routes/inventory/index.js
@@ -13,6 +13,7 @@ export default class InventoryIndexRoute extends Route {
     category: { refreshModel: true },
     domain: { refreshModel: true },
     group: { refreshModel: true },
+    processTitle: { refreshModel: true },
   };
 
   async model(params) {

--- a/app/routes/inventory/index.js
+++ b/app/routes/inventory/index.js
@@ -10,24 +10,23 @@ export default class InventoryIndexRoute extends Route {
   queryParams = {
     page: { refreshModel: true },
     sort: { refreshModel: true },
+    category: { refreshModel: true },
   };
 
   async model(params) {
     try {
       const tableContent =
-        await this.processApi.fetchInventoryProcessesTableContent({
-          page: params.page,
-          size: params.size,
-          sort: params.sort,
-        });
+        await this.processApi.fetchInventoryProcessesTableContent(params);
       return {
         tableContent: tableContent,
         couldNotFetchTableContent: false,
+        params,
       };
     } catch (error) {
       return {
         tableContent: null,
         couldNotFetchTableContent: true,
+        params,
       };
     }
   }

--- a/app/routes/inventory/index.js
+++ b/app/routes/inventory/index.js
@@ -11,6 +11,7 @@ export default class InventoryIndexRoute extends Route {
     page: { refreshModel: true },
     sort: { refreshModel: true },
     category: { refreshModel: true },
+    domain: { refreshModel: true },
   };
 
   async model(params) {

--- a/app/routes/inventory/index.js
+++ b/app/routes/inventory/index.js
@@ -14,6 +14,7 @@ export default class InventoryIndexRoute extends Route {
     domain: { refreshModel: true },
     group: { refreshModel: true },
     processTitle: { refreshModel: true },
+    processNumber: { refreshModel: true },
   };
 
   async model(params) {

--- a/app/routes/inventory/index.js
+++ b/app/routes/inventory/index.js
@@ -17,19 +17,25 @@ export default class InventoryIndexRoute extends Route {
   };
 
   async model(params) {
+    let modifiedParams = { ...params };
+    if (!params.size) {
+      modifiedParams['size'] = 20;
+    }
     try {
       const tableContent =
-        await this.processApi.fetchInventoryProcessesTableContent(params);
+        await this.processApi.fetchInventoryProcessesTableContent(
+          modifiedParams,
+        );
       return {
         tableContent: tableContent,
         couldNotFetchTableContent: false,
-        params,
+        params: modifiedParams,
       };
     } catch (error) {
       return {
         tableContent: null,
         couldNotFetchTableContent: true,
-        params,
+        params: modifiedParams,
       };
     }
   }

--- a/app/services/process-api.js
+++ b/app/services/process-api.js
@@ -5,11 +5,6 @@ export default class ProcessApiService extends Service {
 
   async fetchInventoryProcessesTableContent(fetchOptions) {
     const queryOptions = fetchOptions;
-
-    if (!fetchOptions.page) {
-      queryOptions.page = 0;
-    }
-
     const query = this.optionsToQueryParams(queryOptions);
 
     const response = await fetch(
@@ -34,11 +29,6 @@ export default class ProcessApiService extends Service {
 
   downloadLinkForInventoryProcessesPage(downloadOptions) {
     const downloadPageOptions = downloadOptions;
-
-    if (!downloadOptions.page) {
-      downloadPageOptions.page = 0;
-    }
-
     const query = this.optionsToQueryParams(downloadPageOptions);
     return `/process-api/conceptual-processes/download?${query.join('&')}`;
   }
@@ -52,6 +42,8 @@ export default class ProcessApiService extends Service {
   }
 
   optionsToQueryParams(options) {
-    return Object.keys(options).map((key) => `${key}=${options[key]}`);
+    return Object.keys(options)
+      .filter((key) => options[key])
+      .map((key) => `${key}=${options[key]}`);
   }
 }

--- a/app/services/process-api.js
+++ b/app/services/process-api.js
@@ -35,7 +35,7 @@ export default class ProcessApiService extends Service {
   downloadLinkForInventoryProcesses(downloadOptions) {
     const downloadAllOptions = downloadOptions;
     delete downloadAllOptions.page;
-    delete downloadAllOptions.size;
+    downloadAllOptions.size = 9999;
 
     const query = this.optionsToQueryParams(downloadAllOptions);
     return `/process-api/conceptual-processes/download?${query.join('&')}`;

--- a/app/services/process-api.js
+++ b/app/services/process-api.js
@@ -35,7 +35,7 @@ export default class ProcessApiService extends Service {
   downloadLinkForInventoryProcesses(downloadOptions) {
     const downloadAllOptions = downloadOptions;
     delete downloadAllOptions.page;
-    downloadAllOptions.size = 9999;
+    delete downloadAllOptions.size;
 
     const query = this.optionsToQueryParams(downloadAllOptions);
     return `/process-api/conceptual-processes/download?${query.join('&')}`;

--- a/app/templates/inventory/index.hbs
+++ b/app/templates/inventory/index.hbs
@@ -1,7 +1,6 @@
 <SidebarContainer>
   <:sidebar>
-    <div class="au-c-sidebar">
-    </div>
+    <Inventory::SidebarFilters @params={{@model.params}} @onFilterApplied={{this.updateFilters}}/>
   </:sidebar>
   <:content>
     <PageHeader>

--- a/app/templates/inventory/index.hbs
+++ b/app/templates/inventory/index.hbs
@@ -1,6 +1,9 @@
 <SidebarContainer>
   <:sidebar>
-    <Inventory::SidebarFilters @params={{@model.params}} @onFilterApplied={{this.updateFilters}}/>
+    <Inventory::SidebarFilters
+      @params={{@model.params}}
+      @onFilterApplied={{this.updateFilters}}
+    />
   </:sidebar>
   <:content>
     <PageHeader>
@@ -20,6 +23,7 @@
           >Nieuw proces</AuButton>
         {{/if}}
         <AuButton
+          @disabled={{eq @model.tableContent.content.length 0}}
           @skin="primary"
           @icon="download"
           iconAlignment="left"
@@ -166,8 +170,9 @@
               @skin="primary"
               @alert={{true}}
               {{on "click" (perform this.deleteInventoryProcess)}}
-            >Verwijderen</AuButton>
-
+            >
+              Verwijderen
+            </AuButton>
           </AuButtonGroup>
         </:footer>
       </AuModal>
@@ -179,5 +184,5 @@
   @isOpen={{this.isDownloadModalOpen}}
   @onClose={{fn (mut this.isDownloadModalOpen) false}}
   @onClickedDownloadButton={{fn (mut this.isDownloadModalOpen) false}}
-  @downloadOptions={{hash sort=this.sort page=this.page size=this.size}}
+  @downloadOptions={{@model.params}}
 />


### PR DESCRIPTION
## Description

@MartijnBogaert  already created a PR for adding filters to the inventory table. These filters worked! But as the fetching of the table content has move to the process service we need to pass on these filter values to the endpoint. Thanks for the heavy lifiting already 🙏🏻 

## How to test

1. When applying a filter the value is set in the url as a queryParam
2. When resetting the filters all fields are cleared and the url does not contain the filter values anymore
3. When a filter is set the table content is updated accordingly
4. The filters depend on each other so see that the filters are corrected when needed

Didn't add the number filter as it does not seem to be usefull. If it is needed and requested by the users I'll add it to the PR aswell 

## Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/128 <= Martijns PR
