### PR TITLE
OPH-642| Add breadcrum navigation to sparql endpoint

### DIFF
--- a/app/templates/sparql.hbs
+++ b/app/templates/sparql.hbs
@@ -1,5 +1,7 @@
 {{page-title "SPARQL"}}
+{{breadcrumb "SPARQL endpoint" route="sparql"}}
 
+<NavigationBar />
 <StaticPage>
   <div class="au-o-region-large">
     <div class="au-o-layout">


### PR DESCRIPTION
## Description

When routing to the SPARQL route there is no navigation to go back to the module overview. Add the breadcrum navigat this page.

## How to test

1. Log in as an admin
2. Go to the sparql route
3. Go back to the modules overview (main page)

## Attachments

**BEFORE**
<img width="2208" height="683" alt="image" src="https://github.com/user-attachments/assets/dace69ad-f3b8-4c2d-a468-cc3410309198" />


**AFTER**
<img width="2208" height="683" alt="image" src="https://github.com/user-attachments/assets/08230a73-0be8-45f0-8954-220d53a58d74" />

