### PR TITLE
Oph-730 | ipdc filter also filters on number

### DIFF
--- a/app/components/process-select-by-ipdc.hbs
+++ b/app/components/process-select-by-ipdc.hbs
@@ -1,7 +1,7 @@
 <div class={{if @error "ember-power-select--error"}} ...attributes>
   <PowerSelectMultiple
     @searchEnabled={{true}}
-    @searchField="name"
+    @searchField="searchKeys"
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @options={{this.ipdcProducts}}
@@ -10,6 +10,7 @@
     @triggerId={{@id}}
     as |ipdcProduct|
   >
-    {{ipdcProduct.name}}
+    {{language-string-set-nl ipdcProduct.name}}
+    ({{ipdcProduct.productNumber}})
   </PowerSelectMultiple>
 </div>

--- a/app/components/process-select-by-ipdc.hbs
+++ b/app/components/process-select-by-ipdc.hbs
@@ -13,4 +13,5 @@
     {{language-string-set-nl ipdcProduct.name}}
     ({{ipdcProduct.productNumber}})
   </PowerSelectMultiple>
+  <AuHelpText @skin="secondary">Toont enkel producten gelinkt aan een proces</AuHelpText>
 </div>

--- a/app/components/process-select-by-ipdc.js
+++ b/app/components/process-select-by-ipdc.js
@@ -4,7 +4,7 @@ import { restartableTask } from 'ember-concurrency';
 import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 import ENV from 'frontend-openproceshuis/config/environment';
 
-export default class ProcessSelectByClassificationComponent extends Component {
+export default class ProcessSelectByIpdcComponent extends Component {
   @service router;
   @service store;
 

--- a/app/models/ipdc-product.js
+++ b/app/models/ipdc-product.js
@@ -14,4 +14,9 @@ export default class IpdcProductModel extends Model {
   get url() {
     return `https://productencatalogus-v3.vlaanderen.be/product/${this.productNumber}`;
   }
+
+  get searchKeys() {
+    let names = this.name.map((ls) => ls.content?.toLowerCase()).join(' ');
+    return `${names} ${this.productNumber ?? ''}`;
+  }
 }


### PR DESCRIPTION
## Description

You can only type in a name in the searchfield on the processes page. This should also work with the number of the process.

## How to test

1. go to the processes page
2. search for a ipdc product
3. search the same product by its number

NOTE:
When using the @search method it did not give me all the results of the dropdown when i removed the last character in the searchfield. Thats why I did this backup way :(

## Attachments

<img width="257" height="259" alt="image" src="https://github.com/user-attachments/assets/a80f10ea-2e33-4053-9273-2ea545fee598" />

