### PR TITLE
BUG: replacement group options are dissapearing 

### DIFF
--- a/app/components/inventory/select-group.hbs
+++ b/app/components/inventory/select-group.hbs
@@ -4,13 +4,14 @@
     @searchField="label"
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
-    @options={{this.groups.value}}
+    @options={{this.options}}
     @selected={{this.selectedGroup.value}}
     @onChange={{this.onChange}}
+    @onOpen={{perform this.loadGroupsTask}}
     @allowClear={{true}}
     @triggerId={{@id}}
     @disabled={{@isDisabled}}
-    @loading={{this.selectedGroup.isRunning}}
+    @loading={{or this.selectedGroup.isRunning this.loadGroupsTask.isRunning}}
     as |group|
   >
     {{group.label}}

--- a/app/components/inventory/select-group.js
+++ b/app/components/inventory/select-group.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
 
+import { A } from '@ember/array';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 
+import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 
@@ -11,6 +13,8 @@ import ENV from 'frontend-openproceshuis/config/environment';
 export default class InventorySelectGroup extends Component {
   @service router;
   @service store;
+
+  @tracked options = A([]);
 
   loadGroupsTask = restartableTask(async () => {
     const query = {
@@ -29,8 +33,9 @@ export default class InventorySelectGroup extends Component {
 
     if (this.args.domain)
       query['filter[process-domains][id]'] = this.args.domain;
-
-    return await this.store.query('process-group', query);
+    this.options.clear();
+    const options = await this.store.query('process-group', query);
+    this.options.pushObjects(options);
   });
 
   groups = trackedTask(this, this.loadGroupsTask, () => [

--- a/app/components/inventory/select-group.js
+++ b/app/components/inventory/select-group.js
@@ -27,21 +27,18 @@ export default class InventorySelectGroup extends Component {
       },
     };
 
-    if (this.args.category)
+    if (this.args.category && !this.args.domain) {
       query['filter[process-domains][process-categories][id]'] =
         this.args.category;
-
-    if (this.args.domain)
+    }
+    if (this.args.domain) {
       query['filter[process-domains][id]'] = this.args.domain;
+    }
+
     this.options.clear();
     const options = await this.store.query('process-group', query);
     this.options.pushObjects(options);
   });
-
-  groups = trackedTask(this, this.loadGroupsTask, () => [
-    this.args.category,
-    this.args.domain,
-  ]);
 
   loadSelectedGroup = restartableTask(async () => {
     if (!this.args.selected) return null;


### PR DESCRIPTION
## Description

When opening the group dropdown it shows no options. This only is when changing the category or domain selector.
Make sure they do not dissapear.

## How to test

1. Log in as an admin
2. Go to beheer inventaris processes
3. Replace a group that is used in an active inventory proces with another and check the options

## What went wrong

Apparently the call to fetch the options was to heavey or atleast it was taking up a real long time
