### PR TITLE
Oph-877 | Enable sparql endpoint for everyone

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,15 @@
-## Description
+## 🗒️ Description
 
 Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context.
 
-## How to test
+## 🦮 How to test
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 
-## Links to other PR's
+## 🔗 Links to other PR's
+
+- /
+
+## 🖼️ Attachments
 
 - /

--- a/app/modifiers/yasgui.js
+++ b/app/modifiers/yasgui.js
@@ -4,10 +4,11 @@ import config from './../config/environment';
 const defaultQuery =
   config.yasgui.defaultQuery !== '{{YASGUI_DEFAULT_QUERY}}'
     ? config.yasgui.defaultQuery
-    : `
-        SELECT * WHERE {
-            ?s ?p ?o .
-        } LIMIT 10
+    : `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT * WHERE {
+  ?sub ?pred ?obj .
+} LIMIT 10
     `;
 
 export default modifier(function yasgui(element /*, params, hash*/) {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -174,6 +174,33 @@
               </AuCard>
             </div>
           {{/if}}
+          {{#if this.currentSession.isAuthenticated}}
+            <div class="au-o-grid__item au-u-1-2@medium">
+              <AuCard @flex={{true}} as |c|>
+                <c.header
+                  @badgeSkin="brand"
+                  @badgeIcon="folder"
+                  @badgeSize="small"
+                >
+                  <AuHeading @level="2" @skin="4">
+                    SPARQL endpoint
+                  </AuHeading>
+                </c.header>
+                <c.content>
+                  <AuList @divider={{true}} as |Item|>
+                    <Item>Bevraag de databank met behulp van een sparql query en
+                      krijg linked data terug.</Item>
+                  </AuList>
+                </c.content>
+                <c.footer>
+                  <div class="au-u-h-functional au-o-flow au-o-flow--small">
+                    <AuLink @skin="button" @route="sparql">Ga naar sparql
+                      endpoint</AuLink>
+                  </div>
+                </c.footer>
+              </AuCard>
+            </div>
+          {{/if}}
           {{#if this.currentSession.isAdmin}}
             <div class="au-o-grid__item au-u-1-2@medium">
               <AuCard @flex={{true}} as |c|>
@@ -189,7 +216,6 @@
                 <c.content>
                   <AuList @divider={{true}} as |Item|>
                     <Item>Raadpleeg rapporten</Item>
-                    <Item>Bevraag de databank</Item>
                   </AuList>
                 </c.content>
                 <c.footer>
@@ -198,10 +224,6 @@
                       @skin="button"
                       @route="reporting"
                     >Rapportering</AuLink>
-                    <AuLink
-                      @skin="button-secondary"
-                      @route="sparql"
-                    >SPARQL</AuLink>
                   </div>
                 </c.footer>
               </AuCard>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -188,8 +188,7 @@
                 </c.header>
                 <c.content>
                   <AuList @divider={{true}} as |Item|>
-                    <Item>Bevraag de databank met behulp van een sparql query en
-                      krijg linked data terug.</Item>
+                    <Item>Bevraag de databank met behulp van een SPARQL query</Item>
                   </AuList>
                 </c.content>
                 <c.footer>


### PR DESCRIPTION
## Description

The sparql endpoint can be used by every authenticated user. For now the button to this endpoint is only visible for admin roles under "rapportering". This button may be visible for every authenticated user.

## How to test

1. Is the module visible?
2. Can fetch process data?
3. When not authenticated you cannot access this route (redirect to homescreen)

##  Attachments

**Admin**
<img width="2235" height="1141" alt="image" src="https://github.com/user-attachments/assets/21c4eb6e-eb1a-47b0-830c-b458fd047ec2" />

