### PR TITLE
Link new/existing information asset to process

### DIFF
--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -86,19 +86,56 @@
                   @checked={{this.containsPersonalData}}
                   @disabled="true"
                 >
-                  Professionele gegevens
+                  <label for="contains-personal-data">Professionele gegevens</label>
+                  <Shared::Tooltip
+                    @show={{true}}
+                    @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
+                    @placement="top"
+                  >
+                    <AuIcon
+                      class="color--info"
+                      @icon="circle-question"
+                      @size="large"
+                      @alignment="right"
+                    />
+                  </Shared::Tooltip>
                 </AuCheckbox>
                 <AuCheckbox
                   @checked={{this.containsProfessionalData}}
                   @disabled="true"
                 >
-                  Persoonsgegevens
+                  <label
+                    for="contains-professional-data"
+                  >Persoonsgegevens</label>
+                  <Shared::Tooltip
+                    @show={{true}}
+                    @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
+                  >
+                    <AuIcon
+                      class="color--info"
+                      @icon="circle-question"
+                      @size="large"
+                      @alignment="right"
+                    />
+                  </Shared::Tooltip>
                 </AuCheckbox>
                 <AuCheckbox
                   @checked={{this.containsSensitivePersonalData}}
                   @disabled="true"
                 >
-                  Bijzondere persoonsgegevens
+                  <label for="contains-sensitive-personal-data">Bijzondere
+                    persoonsgegevens</label>
+                  <Shared::Tooltip
+                    @show={{true}}
+                    @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
+                  >
+                    <AuIcon
+                      class="color--info"
+                      @icon="circle-question"
+                      @size="large"
+                      @alignment="right"
+                    />
+                  </Shared::Tooltip>
                 </AuCheckbox>
               </div>
             </:content>

--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -22,102 +22,15 @@
         <Card.Columns>
           <:left as |Item|>
             <Item>
-              <:label>Beschikbaarheid</:label>
-              <:content>
-                <Process::IcrCard::Score
-                  @selectedScore={{@process.availabilityScore}}
-                  @onScoreChange={{this.setAvailabilityScore}}
-                />
-              </:content>
-            </Item>
-            <Item>
-              <:label>Integriteit</:label>
-              <:content>
-                <Process::IcrCard::Score
-                  @selectedScore={{@process.integrityScore}}
-                  @onScoreChange={{this.setIntegrityScore}}
-                />
-              </:content>
-            </Item>
-            <Item>
-              <:label>Vertrouwelijkheid</:label>
-              <:content>
-                <Process::IcrCard::Score
-                  @selectedScore={{@process.confidentialityScore}}
-                  @onScoreChange={{this.setConfidentialityScore}}
-                />
-              </:content>
-            </Item>
-            <Item>
-              <:label>Persoonsgegevens</:label>
-              <:content>
-                <div
-                  class="au-u-flex au-u-flex--column au-u-flex--spaced-small"
-                >
-                  <AuToggleSwitch
-                    @checked={{@process.containsPersonalData}}
-                    @onChange={{this.setContainsPersonalData}}
-                  />
-                  {{#if @process.containsPersonalData}}
-                    <AuCheckbox
-                      @checked={{@process.containsProfessionalData}}
-                      @onChange={{this.setContainsProfessionalData}}
-                      @disabled={{@process.containsSensitivePersonalData}}
-                    >
-                      Professionele gegevens
-                    </AuCheckbox>
-                    <AuCheckbox
-                      @checked={{@process.containsSensitivePersonalData}}
-                      @onChange={{this.setContainsSensitivePersonalData}}
-                    >
-                      Bijzondere persoonsgegevens
-                    </AuCheckbox>
-                  {{/if}}
-                </div>
-              </:content>
-            </Item>
-          </:left>
-          <:right as |Item|>
-            <Item>
-              <:label>Motivering of bijkomende informatie</:label>
-              <:content>
-                <AuTextarea
-                  value={{@process.additionalInformation}}
-                  {{on "input" this.setAdditionalInformation}}
-                  rows="5"
-                  @width="block"
-                  @error={{this.hasError "additionalInformation"}}
-                />
-                {{#if (this.hasError "additionalInformation")}}
-                  <div class="au-u-error">Mag niet meer dan 3000 karakters
-                    bevatten</div>
-                {{/if}}
-              </:content>
-            </Item>
-            <Item>
               <:label>Informatieassets</:label>
               <:content>
                 <Process::IcrCard::AssetsMultipleSelect
-                  @selected={{this.draftInformationAssets}}
-                  @onChange={{this.setDraftInformationAssets}}
+                  @selected={{this.informationAssets}}
+                  @onChange={{this.setInformationAssets}}
                 />
               </:content>
             </Item>
-            <Item>
-              <:label>Link naar maatregelen</:label>
-              <:content>
-                <AuInput
-                  value={{@process.hasControlMeasure}}
-                  {{on "input" this.setControlMeasure}}
-                  @width="block"
-                  @error={{this.hasError "hasControlMeasure"}}
-                />
-                {{#if (this.hasError "hasControlMeasure")}}
-                  <div class="au-u-error">Moet URL zijn</div>
-                {{/if}}
-              </:content>
-            </Item>
-          </:right>
+          </:left>
         </Card.Columns>
       </:card>
     </DataCard>
@@ -137,84 +50,76 @@
       {{/if}}
     </:header>
     <:card as |Card|>
-      <Card.Columns>
+      <Card.Columns class="au-u-flex au-u-flex--spaced-small au-u-flex--wrap">
         <:left as |Item|>
-          <Item>
-            <:label>Beschikbaarheid</:label>
-            <:content>
-              <Process::IcrCard::Score
-                @selectedScore={{@process.availabilityScore}}
-              />
-            </:content>
-          </Item>
-          <Item>
-            <:label>Integriteit</:label>
-            <:content>
-              <Process::IcrCard::Score
-                @selectedScore={{@process.integrityScore}}
-              />
-            </:content>
-          </Item>
-          <Item>
-            <:label>Vertrouwelijkheid</:label>
-            <:content>
-              <Process::IcrCard::Score
-                @selectedScore={{@process.confidentialityScore}}
-              />
-            </:content>
-          </Item>
+          {{#unless this.showIcrModal}}
+            <Item>
+              <:label>Beschikbaarheid</:label>
+              <:content>
+                <Process::IcrCard::Score
+                  @selectedScore={{this.availabilityScore}}
+                />
+              </:content>
+            </Item>
+            <Item>
+              <:label>Integriteit</:label>
+              <:content>
+                <Process::IcrCard::Score
+                  @selectedScore={{this.integrityScore}}
+                />
+              </:content>
+            </Item>
+            <Item>
+              <:label>Vertrouwelijkheid</:label>
+              <:content>
+                <Process::IcrCard::Score
+                  @selectedScore={{this.confidentialityScore}}
+                />
+              </:content>
+            </Item>
+          {{/unless}}
           <Item>
             <:label>Persoonsgegevens</:label>
             <:content>
               <div class="au-u-flex au-u-flex--column au-u-flex--spaced-small">
-                <AuToggleSwitch
-                  @checked={{@process.containsPersonalData}}
+                <AuCheckbox
+                  @checked={{this.containsPersonalData}}
                   @disabled="true"
-                />
-                {{#if @process.containsPersonalData}}
-                  <AuCheckbox
-                    @checked={{@process.containsProfessionalData}}
-                    @disabled="true"
-                  >
-                    Professionele gegevens
-                  </AuCheckbox>
-                  <AuCheckbox
-                    @checked={{@process.containsSensitivePersonalData}}
-                    @disabled="true"
-                  >
-                    Bijzondere persoonsgegevens
-                  </AuCheckbox>
-                {{/if}}
+                >
+                  Professionele gegevens
+                </AuCheckbox>
+                <AuCheckbox
+                  @checked={{this.containsProfessionalData}}
+                  @disabled="true"
+                >
+                  Persoonsgegevens
+                </AuCheckbox>
+                <AuCheckbox
+                  @checked={{this.containsSensitivePersonalData}}
+                  @disabled="true"
+                >
+                  Bijzondere persoonsgegevens
+                </AuCheckbox>
               </div>
             </:content>
           </Item>
         </:left>
         <:right as |Item|>
           <Item>
-            <:label>Motivering of bijkomende informatie</:label>
-            <:content>{{or @process.additionalInformation "/"}}</:content>
-          </Item>
-          <Item>
             <:label>Informatieassets</:label>
             <:content>
               {{#if @process.informationAssets.length}}
                 <div class="au-u-flex au-u-flex--wrap au-u-flex--spaced-tiny">
                   {{#each @process.informationAssets as |asset|}}
-                    <AuPill>{{asset.label}}</AuPill>
+                    <AuPill
+                      class="pointer information-asset-pill"
+                      {{on "click" (fn this.openIcrModal asset)}}
+                    >
+                      {{asset.title}}
+                      <AuIcon @icon="pencil" />
+                    </AuPill>
                   {{/each}}
                 </div>
-              {{else}}
-                /
-              {{/if}}
-            </:content>
-          </Item>
-          <Item>
-            <:label>Link naar maatregelen</:label>
-            <:content>
-              {{#if @process.hasControlMeasure}}
-                <AuLinkExternal href="{{@process.hasControlMeasure}}">
-                  {{@process.hasControlMeasure}}
-                </AuLinkExternal>
               {{else}}
                 /
               {{/if}}
@@ -243,3 +148,12 @@
     </:card>
   </DataCard>
 {{/if}}
+
+<Process::IcrModal
+  @modalOpen={{this.showIcrModal}}
+  @closeModal={{this.closeIcrModal}}
+  @process={{@process}}
+  @options={{this.informationAssets}}
+  @setOptions={{this.setInformationAssets}}
+  @selected={{this.selectedAsset}}
+/>

--- a/app/components/process/icr-card/assets-multiple-select.hbs
+++ b/app/components/process/icr-card/assets-multiple-select.hbs
@@ -12,9 +12,19 @@
   >
     {{asset.title}}
     {{#if asset.isDraft}}
-      ⌛ (Concept)
+      <AuPill
+        @skin="default"
+        @icon="clock"
+        @size="small"
+        class="au-u-margin-left-tiny"
+      >
+        Concept
+      </AuPill>
     {{else}}
-      ✅ (Gepubliceerd)
+      <AuPill @skin="success" @size="small" class="au-u-margin-left-tiny">
+        Gepubliceerd
+      </AuPill>
     {{/if}}
+
   </PowerSelectMultiple>
 </div>

--- a/app/components/process/icr-card/assets-multiple-select.hbs
+++ b/app/components/process/icr-card/assets-multiple-select.hbs
@@ -1,4 +1,4 @@
-<div class={{if @error "ember-power-select--error"}}>
+<div class={{if @error "ember-power-select--error" "assets-multiple-select"}}>
   <PowerSelectMultiple
     @searchEnabled="true"
     @searchMessage="Typ om te zoeken"
@@ -7,8 +7,14 @@
     @search={{perform this.loadInformationAssetsTask}}
     @selected={{@selected}}
     @onChange={{@onChange}}
+    @searchField="title"
     as |asset|
   >
-    {{asset.label}}
+    {{asset.title}}
+    {{#if asset.isDraft}}
+      ⌛ (Concept)
+    {{else}}
+      ✅ (Gepubliceerd)
+    {{/if}}
   </PowerSelectMultiple>
 </div>

--- a/app/components/process/icr-card/assets-multiple-select.js
+++ b/app/components/process/icr-card/assets-multiple-select.js
@@ -2,57 +2,59 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { restartableTask, timeout } from 'ember-concurrency';
 import ENV from 'frontend-openproceshuis/config/environment';
-import {
-  sortedIndexOf,
-  sortedIncludes,
-  sortedInsert,
-} from 'frontend-openproceshuis/utils/sorted-array-helpers';
 
 export default class ProcessIcrCardAssetsMultipleSelectComponent extends Component {
   @service store;
 
   @restartableTask
   *loadInformationAssetsTask(searchParams = '') {
-    const searchLabel = searchParams.trim();
-    if (!searchLabel) return;
+    const searchTitle = searchParams.trim();
+    if (!searchTitle) return [];
 
     yield timeout(500);
 
     const query = {
       filter: {
-        label: searchLabel,
-        ':exact:scheme': ENV.conceptSchemes.informationAssets,
+        title: searchTitle,
       },
-      sort: ':no-case:label',
+      'filter[:not:status]': ENV.resourceStates.archived,
+      sort: ':no-case:title',
     };
 
-    let assets;
+    let assets = [];
     try {
       assets = [...(yield this.store.query('information-asset', query))];
     } catch {
       return [];
     }
 
-    assets.forEach((asset) => (asset.isDraft = true));
+    const normalized = (v) => v.toLowerCase();
+    const assetMap = new Map();
 
-    // Combine stored and selected assets (no duplicates + alphabetically sorted)
+    for (const asset of assets) {
+      const key = asset.id ?? normalized(asset.title);
+      assetMap.set(key, asset);
+    }
+
     this.args.selected?.forEach((selectedAsset) => {
-      if (
-        selectedAsset.label.toLowerCase().startsWith(searchLabel.toLowerCase())
-      ) {
-        const index = sortedIndexOf(assets, selectedAsset, 'label', true);
-
-        if (index >= 0) {
-          // In case select list contains stored asset --> overwrite stored asset
-          assets[index] = selectedAsset;
-        } else {
-          // In case select list contains unstored asset --> add unstored asset
-          assets = sortedInsert(assets, selectedAsset, 'label', true);
-        }
+      if (normalized(selectedAsset.title).startsWith(normalized(searchTitle))) {
+        const key = selectedAsset.id ?? normalized(selectedAsset.title);
+        assetMap.set(key, selectedAsset);
       }
     });
 
-    if (sortedIncludes(assets, searchLabel, 'label', true)) return assets;
-    else return [{ label: searchLabel, isDraft: true }, ...assets];
+    let uniqueAssets = Array.from(assetMap.values()).sort((a, b) =>
+      a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }),
+    );
+
+    const hasExactTitle = uniqueAssets.some(
+      (a) => normalized(a.title) === normalized(searchTitle),
+    );
+
+    if (!hasExactTitle) {
+      uniqueAssets = [{ title: searchTitle, isDraft: true }, ...uniqueAssets];
+    }
+
+    return uniqueAssets;
   }
 }

--- a/app/components/process/icr-modal.hbs
+++ b/app/components/process/icr-modal.hbs
@@ -1,0 +1,141 @@
+<AuModal @modalOpen={{@modalOpen}} @closeModal={{this.closeModal}}>
+  <:title>{{this.header}}</:title>
+  <:body>
+
+    <form {{on "submit" (perform this.updateModel)}}>
+      <div class="au-u-margin-bottom">
+        <label
+          class="au-u-flex au-c-card-item__label au-c-card-item__label--data au-u-h6 au-u-margin-bottom-tiny"
+        >Titel</label>
+        <AuInput
+          value={{@selected.title}}
+          {{on "input" this.setTitle}}
+          rows="4"
+          @width="block"
+          @error={{this.hasError "title"}}
+        />
+      </div>
+      <div class="au-u-margin-bottom">
+        <label
+          class="au-u-flex au-c-card-item__label au-c-card-item__label--data au-u-h6 au-u-margin-bottom-tiny"
+        >Beschrijving</label>
+        <AuTextarea
+          value={{@selected.description}}
+          {{on "input" this.setDescription}}
+          rows="4"
+          @width="block"
+          @error={{this.hasError "description"}}
+        />
+      </div>
+      <AuCard class="no-border" as |c|>
+        <c.content>
+          <div class="au-o-grid">
+            <div class="au-u-1-1">
+              <label
+                class="au-u-flex au-c-card-item__label au-c-card-item__label--data au-u-h6 au-u-margin-bottom-tiny"
+              >Beschikbaarheid</label>
+              <Process::IcrCard::Score
+                @selectedScore={{@selected.availabilityScore}}
+                @onScoreChange={{this.setAvailabilityScore}}
+              />
+            </div>
+            <div class="au-u-1-1">
+              <label
+                class="au-u-flex au-c-card-item__label au-c-card-item__label--data au-u-h6 au-u-margin-bottom-tiny"
+              >Integriteit</label>
+              <Process::IcrCard::Score
+                @selectedScore={{@selected.integrityScore}}
+                @onScoreChange={{this.setIntegrityScore}}
+              />
+            </div>
+            <div class="au-u-1-1">
+              <label
+                class="au-u-flex au-c-card-item__label au-c-card-item__label--data au-u-h6 au-u-margin-bottom-tiny"
+              >Vertrouwelijkheid</label>
+              <Process::IcrCard::Score
+                @selectedScore={{@selected.confidentialityScore}}
+                @onScoreChange={{this.setConfidentialityScore}}
+              />
+            </div>
+          </div>
+        </c.content>
+      </AuCard>
+
+      <label
+        class="au-u-flex au-c-card-item__label au-c-card-item__label--data au-u-h6 au-u-margin-bottom-tiny"
+      >Persoonsgegevens</label>
+
+      <div class="au-u-flex au-u-flex--column au-u-flex--spaced-small">
+        <AuCheckbox
+          id="contains-personal-data"
+          @checked={{@selected.containsPersonalData}}
+          @onChange={{this.setContainsPersonalData}}
+        >
+          <label for="contains-personal-data">Professionele gegevens</label>
+          <Shared::Tooltip
+            @show={{true}}
+            @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
+            @placement="top"
+          >
+            <AuIcon
+              class="color--info"
+              @icon="circle-question"
+              @size="large"
+              @alignment="right"
+            />
+          </Shared::Tooltip>
+        </AuCheckbox>
+        <AuCheckbox
+          id="contains-professional-data"
+          @checked={{@selected.containsProfessionalData}}
+          @onChange={{this.setContainsProfessionalData}}
+        >
+          <label for="contains-professional-data">Persoonsgegevens</label>
+
+          <Shared::Tooltip
+            @show={{true}}
+            @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
+          >
+            <AuIcon
+              class="color--info"
+              @icon="circle-question"
+              @size="large"
+              @alignment="right"
+            />
+          </Shared::Tooltip>
+        </AuCheckbox>
+        <AuCheckbox
+          id="contains-sensitive-personal-data"
+          @checked={{@selected.containsSensitivePersonalData}}
+          @onChange={{this.setContainsSensitivePersonalData}}
+        >
+          <label for="contains-sensitive-personal-data">Bijzondere
+            persoonsgegevens</label>
+          <Shared::Tooltip
+            @show={{true}}
+            @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
+          >
+            <AuIcon
+              class="color--info"
+              @icon="circle-question"
+              @size="large"
+              @alignment="right"
+            />
+          </Shared::Tooltip>
+        </AuCheckbox>
+      </div>
+    </form>
+  </:body>
+
+  <:footer>
+    <AuButtonGroup class="au-u-flex--end">
+      <AuButton @skin="naked" {{on "click" this.closeModal}}>Annuleer</AuButton>
+      <AuButton
+        @skin="primary"
+        {{on "click" (perform this.updateModel)}}
+        @loading={{this.updateModel.isRunning}}
+        @disabled={{not this.formIsValid}}
+      >Opslaan</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>

--- a/app/components/process/icr-modal.js
+++ b/app/components/process/icr-modal.js
@@ -1,0 +1,170 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { dropTask } from 'ember-concurrency';
+import { tracked } from 'tracked-built-ins';
+import { service } from '@ember/service';
+
+import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-messages';
+
+export default class IcrModalComponent extends Component {
+  @service store;
+  @service toaster;
+  @tracked selected;
+  @tracked isLoading = false;
+  @tracked formIsValid = this.args.selected.title?.trim().length > 0;
+  @tracked draftInformationAssets = this.args.options || [];
+
+  get header() {
+    if (this.args.selected.isDraft) {
+      return 'Nieuwe informatieclassificatie';
+    } else {
+      return 'Wijzig informatieclassificatie: ' + this.args.selected.title;
+    }
+  }
+
+  @action
+  closeModal() {
+    if (this.args.selected.isDraft) {
+      const newOptions = this.draftInformationAssets.filter(
+        (asset) => asset.isDraft !== true,
+      );
+      this.args.setOptions(newOptions);
+    }
+    this.args.closeModal();
+  }
+
+  @action
+  setAvailabilityScore(value) {
+    if (!this.args.selected) return;
+    this.args.selected.availabilityScore = value;
+    this.validateForm();
+  }
+
+  @action
+  setTitle(event) {
+    if (!this.args.selected) return;
+    this.args.selected.title = event.target.value;
+    this.validateForm();
+  }
+
+  @action
+  setDescription(event) {
+    if (!this.args.process) return;
+    this.args.selected.description = event.target.value;
+    this.validateForm();
+  }
+
+  @action
+  setIntegrityScore(value) {
+    if (!this.args.selected) return;
+    this.args.selected.integrityScore = value;
+    this.validateForm();
+  }
+
+  @action
+  setConfidentialityScore(value) {
+    if (!this.args.selected) return;
+    this.args.selected.confidentialityScore = value;
+    this.validateForm();
+  }
+
+  @action
+  setContainsPersonalData(value) {
+    if (!this.args.selected) return;
+    this.args.selected.containsPersonalData = value;
+    this.validateForm();
+  }
+
+  @action
+  setContainsProfessionalData(value) {
+    this.args.selected.containsProfessionalData = value;
+    this.validateForm();
+  }
+
+  @action
+  setContainsSensitivePersonalData(value) {
+    this.args.selected.containsSensitivePersonalData = value;
+    this.validateForm();
+  }
+
+  @action
+  resetModal() {
+    this.draftInformationAssets = this.args.options || [];
+    this.formIsValid = false;
+  }
+
+  @action
+  validateForm() {
+    this.formIsValid = this.args.selected.title?.trim().length > 0;
+  }
+
+  @dropTask
+  *updateModel(event) {
+    event.preventDefault();
+
+    if (!this.args.selected || !this.formIsValid) {
+      return;
+    }
+
+    this.isLoading = true;
+
+    let assetRecord;
+
+    const assetData = {
+      title: this.args.selected.title,
+      availabilityScore: this.args.selected.availabilityScore,
+      confidentialityScore: this.args.selected.confidentialityScore,
+      integrityScore: this.args.selected.integrityScore,
+      containsPersonalData: this.args.selected.containsPersonalData,
+      containsProfessionalData: this.args.selected.containsProfessionalData,
+      containsSensitivePersonalData:
+        this.args.selected.containsSensitivePersonalData,
+      created: new Date(),
+      description: this.args.selected.description,
+      status: this.args.selected.status,
+    };
+
+    try {
+      if (this.args.selected.isDraft) {
+        assetRecord = this.store.createRecord('information-asset', assetData);
+        yield assetRecord.save();
+      } else {
+        assetRecord = this.args.selected;
+        assetRecord.setProperties(assetData);
+
+        const savedAsset = yield assetRecord.save();
+
+        this.args.process.informationAssets = [
+          ...this.args.process.informationAssets.filter(
+            (ia) => ia.id !== savedAsset.id,
+          ),
+          savedAsset,
+        ];
+
+        yield this.args.process.save();
+      }
+      const nonDraftAssets = this.draftInformationAssets.filter(
+        (asset) => !asset.isDraft,
+      );
+      this.args.setOptions([...nonDraftAssets, assetRecord]);
+
+      this.toaster.success(
+        'Informatieclassificatie succesvol bijgewerkt',
+        'Gelukt!',
+        { timeOut: 5000 },
+      );
+
+      this.resetModal();
+      this.args.closeModal();
+    } catch (error) {
+      console.error(error);
+      const errorMessage = getMessageForErrorCode('oph.icrDataUpdateFailed');
+      this.toaster.error(errorMessage, 'Fout');
+
+      this.resetModal();
+      this.args.closeModal();
+    } finally {
+      this.isLoading = false;
+    }
+  }
+}

--- a/app/models/information-asset.js
+++ b/app/models/information-asset.js
@@ -1,6 +1,19 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class InformationAssetModel extends Model {
-  @attr('string') label;
-  @attr('string') scheme;
+  @attr('string') title;
+  @attr('string') description;
+  @attr('iso-date') created;
+  @attr('string') status;
+  @attr('number') confidentialityScore;
+  @attr('number') integrityScore;
+  @attr('number') availabilityScore;
+  @attr('boolean') containsPersonalData;
+  @attr('boolean') containsProfessionalData;
+  @attr('boolean') containsSensitivePersonalData;
+  @belongsTo('informationAsset', { inverse: null, async: false })
+  previousVersion;
+  @belongsTo('group', { inverse: null, async: false }) creator;
+  @hasMany('processes', { inverse: null, async: false })
+  processes;
 }

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -4,7 +4,6 @@ import ENV from 'frontend-openproceshuis/config/environment';
 import {
   isOnlyWhitespace,
   isEmptyOrEmail,
-  isEmptyOrUrl,
 } from 'frontend-openproceshuis/utils/custom-validators';
 
 @modelValidator
@@ -16,14 +15,6 @@ export default class ProcessModel extends Model {
   @attr('iso-date') modified;
   @attr('string') status;
   @attr('boolean') isBlueprint;
-  @attr('number') confidentialityScore;
-  @attr('number') integrityScore;
-  @attr('number') availabilityScore;
-  @attr('boolean') containsPersonalData;
-  @attr('boolean') containsProfessionalData;
-  @attr('boolean') containsSensitivePersonalData;
-  @attr('string') additionalInformation;
-  @attr('string') hasControlMeasure;
 
   @belongsTo('group', { inverse: null, async: false }) publisher;
   @belongsTo('process-statistic', { inverse: 'process', async: false })
@@ -73,14 +64,6 @@ export default class ProcessModel extends Model {
     },
     email: {
       custom: (_, value) => isEmptyOrEmail(value),
-    },
-    additionalInformation: {
-      length: {
-        maximum: 3000,
-      },
-    },
-    hasControlMeasure: {
-      custom: (_, value) => isEmptyOrUrl(value),
     },
   };
 

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -170,3 +170,26 @@ tr:hover .inventory-row-button-group .au-c-button {
 .color--warning {
   color: var(--au-orange-700);
 }
+.no-border {
+  border: none !important;
+}
+.pointer {
+  cursor: pointer;
+}
+
+.information-asset-pill {
+  &:hover {
+    color: var(--vl-orange-120);
+    background-color: var(--vl-orange-10);
+    border-color: var(--vl-orange-100);
+    transition: 0.2s ease-in-out;
+  }
+  &:active {
+    scale: 0.95;
+  }
+}
+.assets-multiple-select {
+  .ember-power-select-multiple-options > li {
+    flex-grow: 0;
+  }
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -170,9 +170,11 @@ tr:hover .inventory-row-button-group .au-c-button {
 .color--warning {
   color: var(--au-orange-700);
 }
+
 .no-border {
   border: none !important;
 }
+
 .pointer {
   cursor: pointer;
 }
@@ -184,10 +186,12 @@ tr:hover .inventory-row-button-group .au-c-button {
     border-color: var(--vl-orange-100);
     transition: 0.2s ease-in-out;
   }
+
   &:active {
     scale: 0.95;
   }
 }
+
 .assets-multiple-select {
   .ember-power-select-multiple-options > li {
     flex-grow: 0;


### PR DESCRIPTION
## 🗒️ Description

No design has been worked out for this feature.

The informatieclassificatie section on the process details page should focus on linked information assets. There should be an add button to link an new/existing information asset. A pop-up should (probably) appear, giving the users two options:

Link an existing information asset: select an entry from the list of information assets that are already in OPH (the list should mustn’t include information assets with adms:status set to archived, and should only contain the latest versions of information assets (cfr. prov:wasRevisionOf))

Link a new information asset: create a new information asset by setting its title, description (optiona), confidentiality score, integrity score, availability score, and personal/professional/sensitive data toggles

Design context:

The informatieclassificatie section on the process details page should be largely overhauled: what’s in the left column can (for now) disappear, as well as most of the right column. The list of information assets should become the main focus, and the “Gekoppeld aan” part can also stay.

