### PR TITLE
Add information assets feature with routing, controller, and templates

### DIFF
--- a/app/components/process-bar.hbs
+++ b/app/components/process-bar.hbs
@@ -27,6 +27,11 @@
           Inventaris processen
         </AuLink>
       </Tab>
+      <Tab>
+        <AuLink @route="information-assets.index" @icon="folder">
+          Informatie assets
+        </AuLink>
+      </Tab>
     </AuTabs>
   </Group>
   <Group>

--- a/app/components/process/icr-modal.js
+++ b/app/components/process/icr-modal.js
@@ -13,6 +13,7 @@ export default class IcrModalComponent extends Component {
   @tracked isLoading = false;
   @tracked formIsValid = this.args.selected.title?.trim().length > 0;
   @tracked draftInformationAssets = this.args.options || [];
+  @service currentSession;
 
   get header() {
     if (this.args.selected.isDraft) {
@@ -122,6 +123,7 @@ export default class IcrModalComponent extends Component {
       created: new Date(),
       description: this.args.selected.description,
       status: this.args.selected.status,
+      creator: this.currentSession.group,
     };
 
     try {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -40,6 +40,7 @@ export default class ApplicationController extends Controller {
       'shared-processes',
       'my-local-government',
       'inventory',
+      'information-assets',
     ].includes(this.compareRouteName);
   }
 

--- a/app/controllers/information-assets/index.js
+++ b/app/controllers/information-assets/index.js
@@ -35,5 +35,7 @@ export default class InformationAssetsIndexController extends Controller {
   @action
   resetFilters() {
     this.title = null;
+    this.page = 0;
+    this.sort = 'title';
   }
 }

--- a/app/controllers/information-assets/index.js
+++ b/app/controllers/information-assets/index.js
@@ -1,0 +1,39 @@
+import Controller from '@ember/controller';
+
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { restartableTask, timeout } from 'ember-concurrency';
+
+export default class InformationAssetsIndexController extends Controller {
+  size = 20;
+  queryParams = ['page', 'size'];
+  @service store;
+  @service router;
+  @service currentSession;
+
+  @tracked isLoadingRoute;
+  @tracked page = 0;
+  @tracked sort = 'title';
+  @tracked title = null;
+
+  get informationAssets() {
+    return this.model.informationAssets.isFinished
+      ? this.model.informationAssets.value
+      : this.model.loadedInformationAssets;
+  }
+
+  get isLoading() {
+    return this.model.informationAssets.isRunning;
+  }
+
+  setTitle = restartableTask(async (event) => {
+    await timeout(250);
+    this.title = event.target?.value;
+  });
+
+  @action
+  resetFilters() {
+    this.title = null;
+  }
+}

--- a/app/controllers/information-assets/index.js
+++ b/app/controllers/information-assets/index.js
@@ -8,11 +8,8 @@ import { restartableTask, timeout } from 'ember-concurrency';
 export default class InformationAssetsIndexController extends Controller {
   size = 20;
   queryParams = ['page', 'size'];
-  @service store;
-  @service router;
   @service currentSession;
 
-  @tracked isLoadingRoute;
   @tracked page = 0;
   @tracked sort = 'title';
   @tracked title = null;
@@ -20,7 +17,7 @@ export default class InformationAssetsIndexController extends Controller {
   get informationAssets() {
     return this.model.informationAssets.isFinished
       ? this.model.informationAssets.value
-      : this.model.loadedInformationAssets;
+      : null;
   }
 
   get isLoading() {

--- a/app/router.js
+++ b/app/router.js
@@ -50,6 +50,10 @@ Router.map(function () {
     this.route('admin');
   });
 
+  this.route('information-assets', { path: 'informatie-assets' }, function () {
+    this.route('information-asset', { path: '/:id' });
+  });
+
   this.route('legal', { path: '/legaal' }, function () {
     this.route('disclaimer');
     this.route('cookiestatement', { path: '/cookieverklaring' });

--- a/app/routes/information-assets/index.js
+++ b/app/routes/information-assets/index.js
@@ -36,6 +36,17 @@ export default class InformationAssetsIndexRoute extends Route {
       'filter[:not:status]': ENV.resourceStates.archived,
       sort: ':no-case:title',
     };
+    if (params.sort) {
+      if (params.sort.includes('title')) {
+        if (params.sort.startsWith('-')) {
+          query.sort = `-:no-case:${params.sort.slice(1)}`;
+        } else {
+          query.sort = `:no-case:${params.sort}`;
+        }
+      } else {
+        query.sort = params.sort;
+      }
+    }
     if (params.title) {
       query['filter[title]'] = params.title;
     }

--- a/app/routes/information-assets/index.js
+++ b/app/routes/information-assets/index.js
@@ -1,0 +1,45 @@
+import Route from '@ember/routing/route';
+
+import { service } from '@ember/service';
+import { keepLatestTask } from 'ember-concurrency';
+import ENV from 'frontend-openproceshuis/config/environment';
+
+export default class InformationAssetsIndexRoute extends Route {
+  @service session;
+  @service store;
+  @service processApi;
+
+  queryParams = {
+    page: { refreshModel: true },
+    sort: { refreshModel: true },
+    title: { refreshModel: true },
+  };
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'auth.login');
+  }
+
+  async model(params) {
+    return {
+      informationAssets: this.loadInformationAssetsTask.perform(params),
+    };
+  }
+
+  @keepLatestTask({ cancelOn: 'deactivate' })
+  *loadInformationAssetsTask(params) {
+    let query = {
+      page: {
+        number: params.page,
+        size: params.size,
+      },
+      include: 'creator',
+      'filter[:not:status]': ENV.resourceStates.archived,
+      sort: ':no-case:title',
+    };
+    if (params.title) {
+      query['filter[title]'] = params.title;
+    }
+
+    return yield this.store.query('information-asset', query);
+  }
+}

--- a/app/templates/information-assets/error.hbs
+++ b/app/templates/information-assets/error.hbs
@@ -1,0 +1,10 @@
+{{page-title "Process niet gevonden"}}
+
+<LayoutDetail>
+  <Oops
+    @title="Het lijkt erop dat de informatie asset waarnaar je zoekt niet bestaat of niet meer beschikbaar is."
+    @content="Controleer even of je de juiste link gebruikt of neem contact op met de beheerder indien je denkt dat dit een fout is."
+    @image="/assets/images/page-not-found.svg"
+  />
+  {{outlet}}
+</LayoutDetail>

--- a/app/templates/information-assets/error.hbs
+++ b/app/templates/information-assets/error.hbs
@@ -1,4 +1,4 @@
-{{page-title "Process niet gevonden"}}
+{{page-title "Informatie asset niet gevonden"}}
 
 <LayoutDetail>
   <Oops

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -1,0 +1,109 @@
+<SidebarContainer>
+  <:sidebar>
+    <div class="au-c-sidebar">
+      <div class="au-c-sidebar__content">
+        <form
+          {{on "reset" this.resetFilters}}
+          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
+        >
+          <h1 class="au-u-h3 au-u-medium">Filters</h1>
+          <div>
+            <AuLabel for="filter-title">Titel</AuLabel>
+            <AuInput
+              @id="filter-title"
+              @type="hidden"
+              value={{this.title}}
+              {{on "keyup" (perform this.setTitle)}}
+            />
+          </div>
+          <div class="au-u-flex au-u-flex--end">
+            <AuButton
+              @icon="cross"
+              @skin="link"
+              type="reset"
+              class="au-u-padding-none au-u-medium"
+            >
+              Herstel alle filters
+            </AuButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  </:sidebar>
+  <:content>
+    <PageHeader>
+      <:title>Informatie assets</:title>
+      <:action>
+        {{#if this.currentSession.isAdmin}}
+          <AuButton
+            @skin="secondary"
+            @icon="add"
+            iconAlignment="left"
+            {{on "click" (fn this.openUpsertModal null)}}
+          >Nieuwe informatie asset</AuButton>
+        {{/if}}
+      </:action>
+    </PageHeader>
+    <AuDataTable
+      @content={{this.informationAssets}}
+      @isLoading={{this.isLoading}}
+      @page={{this.page}}
+      @size={{this.size}}
+      as |t|
+    >
+      <t.content class="au-c-data-table__table--small" as |c|>
+        <c.header>
+          <AuDataTableThSortable
+            @field="title"
+            @currentSorting={{this.sort}}
+            @label="Titel"
+          />
+          <AuDataTableThSortable
+            @field="description"
+            @currentSorting={{this.sort}}
+            @label="Beschrijving"
+          />
+          <AuDataTableThSortable
+            @field="creator"
+            @currentSorting={{this.sort}}
+            @label="Auteur"
+          />
+
+          <AuDataTableThSortable
+            @field="created"
+            @currentSorting={{this.sort}}
+            @label="Laatst aangemaakt op"
+          />
+        </c.header>
+        {{#if this.hasErrored}}
+          <TableMessage::Error />
+        {{else if this.hasNoResults}}
+          <TableMessage>
+            <p>
+              Er werden geen zoekresultaten gevonden.
+            </p>
+          </TableMessage>
+        {{else}}
+          <c.body as |informationAsset|>
+            <td
+              class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
+            >
+              <LinkTo
+                class="au-c-link"
+                @model={{informationAsset.id}}
+                @route="information-assets.information-asset"
+              >
+                {{informationAsset.title}}
+              </LinkTo>
+            </td>
+            <td>{{or (truncate informationAsset.description 150 true) "/"}}</td>
+            <td>
+              {{informationAsset.creator.name}}
+            </td>
+            <td>{{date-format informationAsset.created}}</td>
+          </c.body>
+        {{/if}}
+      </t.content>
+    </AuDataTable>
+  </:content>
+</SidebarContainer>


### PR DESCRIPTION
## 🗒️ Description

A new page/route should be added that lists the information assets, e.g. /informatie-assets. De table should show the title, creator, created timestamp (beware: only the latest version of each asset). When clicking an entry, the user should be redirected to the asset’s details page . On the left hand side, there should be a filter option to filter on title.

## 🦮 How to test

- You should see a tab inside the process bar.
<img width="928" height="55" alt="image" src="https://github.com/user-attachments/assets/5f0e6b41-05e8-4978-a051-3390758174b9" />

- Click on the tab [Informatie assets](/informatie-assets).
- All the not archived assets should load inside the table.
- You would be able to filter on the title in the left sidebar. 
- Clicking on the entry it should navigate to the detail page.
