### PR TITLE
fix: also fetch the relevant administrative units in the process route

### DIFF
--- a/app/routes/processes/process.js
+++ b/app/routes/processes/process.js
@@ -31,6 +31,7 @@ export default class ProcessesProcessRoute extends Route {
           'linked-concept',
           'linked-concept.process-groups.process-domains',
           'linked-concept.process-groups.process-domains.process-categories',
+          'relevant-administrative-units',
         ].join(','),
         reload: true,
       });


### PR DESCRIPTION
## 🗒️ Description
Relevant for is not being fetched when directly going to a process detail page

## 🦮 How to test

It should be there when using a direct link


