### PR TITLE
Bugfixes v2.6.0

### DIFF
--- a/app/components/icr/versions.hbs
+++ b/app/components/icr/versions.hbs
@@ -16,9 +16,13 @@
           @skin={{if version.isArchived "default" "success"}}
         >
           <AuLink
-            @route="information-assets.edit"
+            @route="information-assets.information-asset"
             @model={{version.id}}
-            @query={{hash edit=null}}
+            @query={{hash
+              edit=null
+              process=@process
+              parentRoute=@parentRoute
+            }}
             @icon="link"
             @skin={{if
               (eq version.id @versionedAsset.id)

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -102,8 +102,12 @@
             <td>{{attachment._source}}
               {{#if attachment.informationAsset}}
                 <AuLink
-                  @route="information-assets.edit"
+                  @route="information-assets.information-asset"
                   @model={{attachment.informationAsset.id}}
+                  @query={{hash
+                    process=@process.id
+                    parentRoute=this.currentProcessRouteName
+                  }}
                 >
                   ({{attachment.informationAsset.title}})
                 </AuLink>

--- a/app/components/process/attachments.js
+++ b/app/components/process/attachments.js
@@ -11,6 +11,8 @@ import {
 import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-messages';
 
 export default class ProcessAttachments extends Component {
+  @service router;
+
   constructor() {
     super(...arguments);
     this.fetchAttachments.perform();
@@ -24,6 +26,10 @@ export default class ProcessAttachments extends Component {
 
   get process() {
     return this.args.process;
+  }
+
+  get currentProcessRouteName() {
+    return this.router.currentRouteName?.replace('.index', '');
   }
 
   @tracked pageAttachments = 0;

--- a/app/components/process/attachments.js
+++ b/app/components/process/attachments.js
@@ -127,8 +127,8 @@ export default class ProcessAttachments extends Component {
         if (infoAssetIds.length > 0) {
           infoAssetFiles = await this.store.query('file', {
             ...baseQuery,
-            'filter[information-asset][id]': infoAssetIds.join(','),
-            include: 'information-asset',
+            'filter[information-assets][id]': infoAssetIds.join(','),
+            include: 'information-assets',
           });
         }
         const allFiles = [

--- a/app/components/process/details-card.hbs
+++ b/app/components/process/details-card.hbs
@@ -169,7 +169,10 @@
           <Item>
             <:label>Beschrijving</:label>
             <:content>
-              {{or @process.description "/"}}
+              <span class="u-preserve-line-breaks">{{or
+                  (trim @process.description)
+                  "/"
+                }}</span>
             </:content>
           </Item>
           <Item>

--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -182,7 +182,9 @@
                         {{on "click" (fn this.editAsset asset)}}
                       >
                         {{asset.title}}
-                        <AuIcon @icon="pencil" />
+                        {{#if @canEdit}}
+                          <AuIcon @icon="pencil" />
+                        {{/if}}
                       </AuPill>
                     {{/if}}
                   {{/each}}

--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -196,7 +196,12 @@
           </Item>
           <Item>
             <:label>Motivering of bijkomende informatie</:label>
-            <:content>{{or @process.additionalInformation "/"}}</:content>
+            <:content>
+              <span class="u-preserve-line-breaks">{{or
+                  (trim @process.additionalInformation)
+                  "/"
+                }}</span>
+            </:content>
           </Item>
           <Item>
             <:label>Link naar maatregelen</:label>

--- a/app/components/process/icr-card.js
+++ b/app/components/process/icr-card.js
@@ -83,8 +83,12 @@ export default class ProcessIcrCardComponent extends Component {
   }
 
   @action editAsset(asset) {
-    this.router.transitionTo('information-assets.edit', asset.id, {
-      queryParams: { edit: true, process: this.args.process.id },
+    this.router.transitionTo('information-assets.information-asset', asset.id, {
+      queryParams: {
+        edit: true,
+        process: this.args.process.id,
+        parentRoute: this.router.currentRouteName?.replace('.index', ''),
+      },
     });
   }
 

--- a/app/components/table-message/error.hbs
+++ b/app/components/table-message/error.hbs
@@ -7,7 +7,7 @@
     contact op via mail
     <a
       class="au-c-link"
-      href="mailto:ict.helpdesk.abb@vlaanderen.be"
-    >ict.helpdesk.abb@vlaanderen.be</a>.
+      href="mailto:loketlokaalbestuur@vlaanderen.be"
+    >loketlokaalbestuur@vlaanderen.be</a>.
   </p>
 </TableMessage>

--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -4,10 +4,12 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import ENV from 'frontend-openproceshuis/config/environment';
-export default class InformationAssetIndexController extends Controller {
+
+export default class InformationAssetsInformationAssetController extends Controller {
   queryParams = [
     'edit',
     'process',
+    'parentRoute',
     { versionedAssetId: 'version' },
     { pageAttachments: 'page-attachments' },
     { sizeAttachments: 'size-attachments' },
@@ -22,6 +24,7 @@ export default class InformationAssetIndexController extends Controller {
 
   @tracked edit = false;
   @tracked process = null;
+  @tracked parentRoute = null;
   @tracked versionedAssetId = null;
   @tracked formIsValid = this.canonicalAsset.title?.trim().length > 0;
   @tracked isDeleteModalOpen = false;
@@ -51,6 +54,30 @@ export default class InformationAssetIndexController extends Controller {
 
   get versionedAssets() {
     return this.model.versionedAssets;
+  }
+
+  get originatingProcess() {
+    if (!this.process) return null;
+
+    return this.canonicalAsset.processes.find(
+      (process) => process.id === this.process,
+    );
+  }
+
+  get breadcrumbParentTitle() {
+    return this.originatingProcess?.title ?? 'Informatie assets';
+  }
+
+  get breadcrumbParentRoute() {
+    return this.originatingProcess && this.parentRoute
+      ? this.parentRoute
+      : 'information-assets.index';
+  }
+
+  get breadcrumbParentModel() {
+    return this.originatingProcess && this.parentRoute
+      ? this.originatingProcess.id
+      : null;
   }
 
   @action
@@ -91,7 +118,10 @@ export default class InformationAssetIndexController extends Controller {
         });
         this.edit = false;
         if (this.process) {
-          return this.router.transitionTo('processes.process', this.process);
+          return this.router.transitionTo(
+            this.parentRoute ?? 'processes.process',
+            this.process,
+          );
         }
         return;
       }
@@ -134,19 +164,24 @@ export default class InformationAssetIndexController extends Controller {
       await oldVersionedRecord.save();
 
       if (this.process) {
-        this.router.transitionTo('processes.process', this.process);
+        this.router.transitionTo(
+          this.parentRoute ?? 'processes.process',
+          this.process,
+        );
       } else {
         await this.router.transitionTo(
-          'information-assets.edit',
+          'information-assets.information-asset',
           canonicalRecord.id,
           {
             queryParams: {
               version: newVersionedRecord.id,
               edit: false,
+              process: this.process,
+              parentRoute: this.parentRoute,
             },
           },
         );
-        this.router.refresh('information-assets.edit');
+        this.router.refresh('information-assets.information-asset');
       }
 
       this.edit = false;

--- a/app/router.js
+++ b/app/router.js
@@ -48,7 +48,7 @@ Router.map(function () {
   });
 
   this.route('information-assets', { path: 'informatie-assets' }, function () {
-    this.route('edit', { path: '/:id' });
+    this.route('information-asset', { path: '/:id/' }, function () {});
   });
 
   this.route('legal', { path: '/legaal' }, function () {

--- a/app/routes/information-assets/information-asset.js
+++ b/app/routes/information-assets/information-asset.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class InformationAssetIndexRoute extends Route {
+export default class InformationAssetsInformationAssetRoute extends Route {
   @service session;
   @service router;
   @service store;
@@ -18,7 +18,7 @@ export default class InformationAssetIndexRoute extends Route {
   }
 
   async model() {
-    const params = this.paramsFor('information-assets.edit');
+    const params = this.paramsFor('information-assets.information-asset');
     const id = params.id;
     const { versionedAssetId } = params;
 
@@ -62,11 +62,15 @@ export default class InformationAssetIndexRoute extends Route {
 
     const canonical = await versionedInformationAsset.canonical;
 
-    this.router.replaceWith('information-assets.edit', canonical.id, {
-      queryParams: {
-        ...params,
-        versionedAssetId,
+    this.router.replaceWith(
+      'information-assets.information-asset',
+      canonical.id,
+      {
+        queryParams: {
+          ...params,
+          versionedAssetId,
+        },
       },
-    });
+    );
   }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -213,3 +213,7 @@ tr:hover .inventory-row-button-group .au-c-button {
     transform: translateX(-0.5rem);
   }
 }
+
+.u-preserve-line-breaks {
+  white-space: pre-wrap;
+}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -89,8 +89,9 @@
                 </c.content>
                 <c.footer>
                   <div class="au-u-h-functional au-o-flow au-o-flow--small">
-                    <AuLink @skin="button" @route="processes">Toon alle
-                      Processen</AuLink>
+                    <AuLink @skin="button" @route="processes">
+                      Toon alle processen
+                    </AuLink>
                   </div>
                 </c.footer>
               </AuCard>
@@ -193,8 +194,9 @@
                 </c.content>
                 <c.footer>
                   <div class="au-u-h-functional au-o-flow au-o-flow--small">
-                    <AuLink @skin="button" @route="sparql">Ga naar sparql
-                      endpoint</AuLink>
+                    <AuLink @skin="button" @route="sparql">
+                      Ga naar SPARQL endpoint
+                    </AuLink>
                   </div>
                 </c.footer>
               </AuCard>

--- a/app/templates/information-assets.hbs
+++ b/app/templates/information-assets.hbs
@@ -1,5 +1,4 @@
 {{page-title "Alle information assets"}}
-{{breadcrumb "Informatie assets" route="information-assets.index"}}
 
 <div class="au-c-body-container au-c-body-container--scroll">
   {{outlet}}

--- a/app/templates/information-assets/edit.hbs
+++ b/app/templates/information-assets/edit.hbs
@@ -42,7 +42,7 @@
   <div class="au-o-grid au-o-grid--small">
     <div class="au-o-grid__item au-u-4-6@medium">
 
-      {{#if this.edit}}
+      {{#if (and this.edit this.canEdit)}}
         <DataCard class="u-color-top-border-gray">
           <:title>Informatieclassificatie</:title>
           <:header>

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -1,3 +1,5 @@
+{{breadcrumb "Informatie assets" route="information-assets.index"}}
+
 <SidebarContainer>
   <:sidebar>
     <div class="au-c-sidebar">
@@ -165,7 +167,7 @@
               <LinkTo
                 class="au-c-link"
                 @model={{informationAsset.id}}
-                @route="information-assets.edit"
+                @route="information-assets.information-asset"
                 @query={{hash version=null edit=null}}
               >
                 {{informationAsset.title}}
@@ -227,7 +229,7 @@
               <td>
                 <div class="au-u-flex au-u-flex--center">
                   <AuLink
-                    @route="information-assets.edit"
+                    @route="information-assets.information-asset"
                     @model={{informationAsset.id}}
                     @query={{hash edit=true}}
                     @skin="button-naked"

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -173,7 +173,12 @@
                 {{informationAsset.title}}
               </LinkTo>
             </td>
-            <td>{{or (truncate informationAsset.description 150 true) "/"}}</td>
+            <td>
+              <span class="u-preserve-line-breaks">{{or
+                  (truncate (trim informationAsset.description) 150 true)
+                  "/"
+                }}</span>
+            </td>
             <td>
               {{informationAsset.creator.name}}
             </td>

--- a/app/templates/information-assets/information-asset.hbs
+++ b/app/templates/information-assets/information-asset.hbs
@@ -86,6 +86,7 @@
                   <:content>
                     <AuTextarea
                       @width="block"
+                      rows="8"
                       value={{this.canonicalAsset.description}}
                       {{on "input" this.setDescription}}
                     />
@@ -256,7 +257,10 @@
                 <Item>
                   <:label>Beschrijving</:label>
                   <:content>
-                    {{or this.versionedAsset.description "/"}}
+                    <span class="u-preserve-line-breaks">{{or
+                        (trim this.versionedAsset.description)
+                        "/"
+                      }}</span>
                   </:content>
                 </Item>
                 <Item>

--- a/app/templates/information-assets/information-asset.hbs
+++ b/app/templates/information-assets/information-asset.hbs
@@ -1,23 +1,18 @@
 {{breadcrumb
+  this.breadcrumbParentTitle
+  route=this.breadcrumbParentRoute
+  model=this.breadcrumbParentModel
+}}
+{{breadcrumb
   (if this.versionedAsset.isArchived "Archief " "Bewerk ")
   this.versionedAsset.title
-  route="information-assets.edit"
+  route="information-assets.information-asset"
   model=this.versionedAsset.id
 }}
 
 <PageHeader>
   <:title>
     <div class="au-u-flex au-u-flex--vertical-center">
-      <AuLink
-        @skin="button-naked"
-        @icon="arrow-left"
-        @iconAlignment="left"
-        @size="large"
-        @route="information-assets.index"
-        @hideText={{true}}
-        class="au-u-margin-right-small animate-left"
-        title="Terug naar informatie assets overzicht"
-      >Previous</AuLink>
       {{this.versionedAsset.title}}
       <AuButton
         class="au-u-padding-left-small"
@@ -402,6 +397,8 @@
           <Icr::Versions
             @versionedAsset={{this.versionedAsset}}
             @versionedAssets={{this.versionedAssets}}
+            @process={{this.process}}
+            @parentRoute={{this.parentRoute}}
           />
         </AuContent>
       </div>

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -102,7 +102,12 @@
                 {{process.title}}
               </LinkTo>
             </td>
-            <td>{{or (truncate process.description 150 true) "/"}}</td>
+            <td>
+              <span class="u-preserve-line-breaks">{{or
+                  (truncate (trim process.description) 150 true)
+                  "/"
+                }}</span>
+            </td>
             <td>
               <ul>
                 {{#each process.relevantAdministrativeUnits as |adminUnit|}}

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -143,7 +143,12 @@
                 </LinkTo>
               </div>
             </td>
-            <td>{{or (truncate process.description 150 true) "/"}}</td>
+            <td>
+              <span class="u-preserve-line-breaks">{{or
+                  (truncate (trim process.description) 150 true)
+                  "/"
+                }}</span>
+            </td>
             <td>{{date-format process.modified}}</td>
             <td>
               {{#if (this.processIsUsedBy process.users)}}

--- a/app/templates/shared-processes/index.hbs
+++ b/app/templates/shared-processes/index.hbs
@@ -99,7 +99,12 @@
                 {{process.title}}
               </LinkTo>
             </td>
-            <td>{{or (truncate process.description 150 true) "/"}}</td>
+            <td>
+              <span class="u-preserve-line-breaks">{{or
+                  (truncate (trim process.description) 150 true)
+                  "/"
+                }}</span>
+            </td>
             <td>{{date-format process.created}}</td>
             <td>{{date-format process.modified}}</td>
             <td>


### PR DESCRIPTION
* Enlarge information asset description input field

* Show newlines for description

* Fix linting error

* Restrict ICR editing to ABB and DV (#190)

* Restrict ICR editing to ABB and DV

* Only show pencil icon when able to edit

* Fix process attachments not loading correctly (#191)

* Update contact email on table error

* Fix bug where attachments didn't load correctly

* Dynamically update information asset breadcrumb (#192)

* Get rid of information asset page back button

* Dynamically set icr breadcrumb based on previous page

* Update routing structure information assets

* Update capitals on homepage

* Restrict ICR editing to ABB and DV (#190)

* Restrict ICR editing to ABB and DV

* Only show pencil icon when able to edit

* Fix process attachments not loading correctly (#191)

* Update contact email on table error

* Fix bug where attachments didn't load correctly

* Merge remote-tracking branch 'origin/feature/v2.6.0-bugfixes' into feature/fix-icr-breadcrumb

* Merge branch 'feature/v2.6.0-bugfixes' into feature/enlarge-icr-description-field

* Display newlines on all description fields

* Trim all description fields