### PR TITLE
OPH-1011 |Reset process query param when routing away from the icr page

### DIFF
--- a/app/routes/information-assets/information-asset.js
+++ b/app/routes/information-assets/information-asset.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+
 import { service } from '@ember/service';
 
 export default class InformationAssetsInformationAssetRoute extends Route {
@@ -11,6 +12,7 @@ export default class InformationAssetsInformationAssetRoute extends Route {
     { pageAttachments: { refreshModel: true } },
     { sizeAttachments: { refreshModel: true } },
     { sortAttachments: { refreshModel: true } },
+    { process: { refreshModel: false } },
   ];
 
   beforeModel(transition) {
@@ -72,5 +74,13 @@ export default class InformationAssetsInformationAssetRoute extends Route {
         },
       },
     );
+  }
+
+  resetController(controller, _isExiting, transition) {
+    if (
+      transition.targetName !== 'information-assets.information-asset.index'
+    ) {
+      controller.process = null;
+    }
   }
 }


### PR DESCRIPTION
## 🗒️ Description

When routing to an icr detail page the breadcrum is dynamic so we can say that the previously you came directly from a process. This process value stays saved in the url when swithcing and so later on coming from an other page to that same ICR it shows the process breadcrum instead of the overview page.

## 🦮 How to test

1. Test out on QA firsty and follow the steps in the clip  of the bug ticket!
2. `ember serve --proxy https://openproceshuis.lblod.info/`
3. Do the exact same as on the QA env 


