### PR TITLE
Oph 956 vendor filter and column

### DIFF
--- a/app/components/process-select-by-group.hbs
+++ b/app/components/process-select-by-group.hbs
@@ -11,6 +11,7 @@
     @onChange={{@onChange}}
     @classifications={{@classifications}}
     @triggerId={{@id}}
+    class="au-u-flex au-u-flex--vertical-center"
     as |group|
   >
     <p class="au-u-word-break-all">{{group}}</p>

--- a/app/components/process-select-by-vendor.hbs
+++ b/app/components/process-select-by-vendor.hbs
@@ -1,0 +1,18 @@
+<div class={{if @error "ember-power-select--error"}} ...attributes>
+  <PowerSelect
+    @allowClear={{true}}
+    @searchEnabled={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten"
+    @searchMessage="Typ om te zoeken"
+    @options={{this.vendors}}
+    @onOpen={{perform this.loadVendors}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
+    @triggerId={{@id}}
+    class="au-u-flex au-u-flex--vertical-center"
+    as |vendor|
+  >
+    <p class="au-u-word-break-all">{{vendor}}</p>
+  </PowerSelect>
+</div>

--- a/app/components/process-select-by-vendor.js
+++ b/app/components/process-select-by-vendor.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+import { A } from '@ember/array';
+import { service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { VENDOR_CLASSIFICATION_ID } from '../utils/well-known-ids';
+import { ARCHIVED_STATUS_URI } from '../utils/well-known-uris';
+
+export default class ProcessSelectByVendor extends Component {
+  @service store;
+
+  @tracked vendors = A([]);
+
+  loadVendors = task({ restartable: true }, async () => {
+    const vendorGroups = await this.store.query('group', {
+      'filter[classification][id]': VENDOR_CLASSIFICATION_ID,
+      'filter[:has:processes]': true,
+      'filter[processes][:not:status]': ARCHIVED_STATUS_URI,
+    });
+
+    this.vendors.clear();
+    this.vendors.pushObjects([
+      ...new Set(vendorGroups.map((group) => group.name)),
+    ]);
+  });
+}

--- a/app/components/process-select-by-vendor.js
+++ b/app/components/process-select-by-vendor.js
@@ -17,12 +17,21 @@ export default class ProcessSelectByVendor extends Component {
     const vendorGroups = await this.store.query('group', {
       'filter[classification][id]': VENDOR_CLASSIFICATION_ID,
       'filter[:has:processes]': true,
-      'filter[processes][:not:status]': ARCHIVED_STATUS_URI,
     });
-
     this.vendors.clear();
-    this.vendors.pushObjects([
-      ...new Set(vendorGroups.map((group) => group.name)),
-    ]);
+    for (let index = 0; index < vendorGroups.length; index++) {
+      const vendor = vendorGroups[index];
+      const processesCreatedBy = await this.store.query('process', {
+        'filter[creator][id]': vendor.id,
+        'filter[:not:status]': ARCHIVED_STATUS_URI,
+        page: {
+          number: 0,
+          size: 1,
+        },
+      });
+      if (processesCreatedBy.length >= 1) {
+        this.vendors.pushObject(vendor.name ?? 'NO-LABEL');
+      }
+    }
   });
 }

--- a/app/components/process-select-by-vendor.js
+++ b/app/components/process-select-by-vendor.js
@@ -4,8 +4,9 @@ import { A } from '@ember/array';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { VENDOR_CLASSIFICATION_ID } from '../utils/well-known-ids';
 import { ARCHIVED_STATUS_URI } from '../utils/well-known-uris';
+
+const VENDOR_CLASSIFICATION_ID = 'c4483583-f9fe-4d2f-96f4-47ddb3440d71';
 
 export default class ProcessSelectByVendor extends Component {
   @service store;

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -11,6 +11,7 @@ export default class ProcessesIndexController extends Controller {
     'title',
     'classifications',
     'group',
+    'creator',
     'blueprint',
     'ipdcProducts',
   ];
@@ -24,6 +25,7 @@ export default class ProcessesIndexController extends Controller {
   @tracked selectedIpdcProducts = undefined;
   @tracked ipdcProducts = undefined;
   @tracked group = '';
+  @tracked creator = '';
   @tracked blueprint = false;
   @service currentSession;
 
@@ -85,6 +87,12 @@ export default class ProcessesIndexController extends Controller {
   }
 
   @action
+  setCreator(selection) {
+    this.page = null;
+    this.creator = selection;
+  }
+
+  @action
   toggleBlueprintFilter(event) {
     this.page = null;
     this.blueprint = event;
@@ -101,6 +109,7 @@ export default class ProcessesIndexController extends Controller {
     this.classifications = undefined;
     this.selectedClassifications = undefined;
     this.group = '';
+    this.creator = '';
     this.page = 0;
     this.sort = 'title';
     this.blueprint = false;

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -13,6 +13,7 @@ export default class ProcessesIndexRoute extends Route {
     title: { refreshModel: true, replace: true },
     classifications: { refreshModel: true, replace: true },
     group: { refreshModel: true, replace: true },
+    creator: { refreshModel: true, replace: true },
     blueprint: { refreshModel: true },
     ipdcProducts: { refreshModel: true, replace: true },
   };
@@ -37,6 +38,7 @@ export default class ProcessesIndexRoute extends Route {
       },
       include: [
         'publisher',
+        'creator',
         'users',
         'publisher.primary-site',
         'publisher.primary-site.contacts',
@@ -72,6 +74,7 @@ export default class ProcessesIndexRoute extends Route {
     }
 
     if (params.group) query['filter[publisher][:exact:name]'] = params.group;
+    if (params.creator) query['filter[creator][:exact:name]'] = params.creator;
 
     if (params.blueprint) {
       query['filter[is-blueprint]'] = params.blueprint;

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -125,6 +125,11 @@
             @currentSorting={{this.sort}}
             @label="Bestuur"
           />
+          <AuDataTableThSortable
+            @field="creator"
+            @currentSorting={{this.sort}}
+            @label="Via leverancier"
+          />
         </c.header>
         {{#if this.hasErrored}}
           <TableMessage::Error />
@@ -172,6 +177,7 @@
                 }}<li>{{relevantAdministrativeUnit.label}}</li>
                 {{/each}}</ul></td>
             <td>{{process.publisher.name}}</td>
+            <td>{{or process.creator.name "/"}}</td>
           </c.body>
         {{/if}}
       </t.content>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -44,6 +44,15 @@
             />
           </div>
           <div>
+            <AuLabel for="filter-vendor">Via leverancier</AuLabel>
+            <ProcessSelectByVendor
+              @id="filter-vendor"
+              @selected={{this.creator}}
+              @onChange={{this.setCreator}}
+              class="grow"
+            />
+          </div>
+          <div>
             <AuLabel for="filter-ipdc">Filter op IPDC product</AuLabel>
             <ProcessSelectByIpdc
               @id="filter-ipdc"

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -1,1 +1,0 @@
-export const VENDOR_CLASSIFICATION_ID = 'c4483583-f9fe-4d2f-96f4-47ddb3440d71';

--- a/app/utils/well-known-ids.js
+++ b/app/utils/well-known-ids.js
@@ -1,0 +1,1 @@
+export const VENDOR_CLASSIFICATION_ID = 'c4483583-f9fe-4d2f-96f4-47ddb3440d71';

--- a/app/utils/well-known-uris.js
+++ b/app/utils/well-known-uris.js
@@ -1,0 +1,2 @@
+export const ARCHIVED_STATUS_URI =
+  'http://lblod.data.gift/concepts/concept-status/gearchiveerd';


### PR DESCRIPTION
## 🗒️ Description

As we now provide integrations for our vendor we would also like them to be visible in our application. For this we will add a vendor filter and an extra column to the processes table.

## 🦮 How to test

1. Filter is added on the "alle processen" overview page
2. Extra column with the vendor is shown + a '/' is shown when not added by integration
3. Setting the filter in the sidebar will update the result of the table
4. Clicking the column will filter on the vendor ASC/DESC

## 🔗 Links to other PR's

- /

## 🖼️ Attachments


**Added filter**
<img width="286" height="713" alt="image" src="https://github.com/user-attachments/assets/63e07911-908f-4ebd-b255-50e51d147613" />

** Column**
<img width="1830" height="668" alt="image" src="https://github.com/user-attachments/assets/5c4ccc81-fb3c-4364-8332-c69c56312a27" />

**Filtering on the column is also possible**
<img width="348" height="634" alt="image" src="https://github.com/user-attachments/assets/b4c9c3b5-9c40-4542-be54-39825dd9bbba" />