### PR TITLE
OPH-998 | (re-)Direct link to page not working anymore

### DIFF
--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -80,7 +80,10 @@ export default class ProcessesProcessIndexController extends Controller {
   @action
   copyUrl() {
     try {
-      navigator.clipboard.writeText(window.location.href);
+      const baseUrl = window.location.origin;
+      navigator.clipboard.writeText(
+        `${baseUrl}/processen/${this.model.process.id}`,
+      );
       this.toaster.success('Link naar proces gekopieerd', undefined, {
         timeOut: 5000,
       });

--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -9,6 +9,7 @@ export default class AuthLoginRoute extends Route {
   @service router;
 
   beforeModel() {
+    this.session.setRouteForAfterLogin();
     if (this.session.prohibitAuthentication('index')) {
       if (isValidAcmidmConfig(ENV.acmidm)) {
         window.location.replace(buildLoginUrl(ENV.acmidm));

--- a/app/routes/auth/login.js
+++ b/app/routes/auth/login.js
@@ -9,7 +9,6 @@ export default class AuthLoginRoute extends Route {
   @service router;
 
   beforeModel() {
-    this.session.setRouteForAfterLogin();
     if (this.session.prohibitAuthentication('index')) {
       if (isValidAcmidmConfig(ENV.acmidm)) {
         window.location.replace(buildLoginUrl(ENV.acmidm));

--- a/app/routes/inventory/admin.js
+++ b/app/routes/inventory/admin.js
@@ -11,7 +11,10 @@ export default class InventoryAdminRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'auth.login');
-    if (!this.currentSession.isAdmin) this.router.transitionTo('unauthorized');
+    if (!this.currentSession.isAdmin) {
+      this.session.clearAfterLoginRoute();
+      this.router.transitionTo('unauthorized');
+    }
   }
 
   async model() {

--- a/app/routes/inventory/admin.js
+++ b/app/routes/inventory/admin.js
@@ -8,6 +8,7 @@ export default class InventoryAdminRoute extends Route {
   @service session;
   @service currentSession;
   @service store;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'auth.login');

--- a/app/routes/inventory/admin.js
+++ b/app/routes/inventory/admin.js
@@ -9,8 +9,8 @@ export default class InventoryAdminRoute extends Route {
   @service currentSession;
   @service store;
 
-  async beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'index');
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'auth.login');
     if (!this.currentSession.isAdmin) this.router.transitionTo('unauthorized');
   }
 

--- a/app/routes/processes/process.js
+++ b/app/routes/processes/process.js
@@ -5,6 +5,11 @@ import { service } from '@ember/service';
 export default class ProcessesProcessRoute extends Route {
   @service store;
   @service router;
+  @service session;
+
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'auth.login');
+  }
 
   async model({ id }, transition) {
     const parentRouteName = transition.to?.name?.replace('.index', '');

--- a/app/routes/reporting.js
+++ b/app/routes/reporting.js
@@ -16,7 +16,10 @@ export default class ReportingRoute extends Route {
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'auth.login');
 
-    if (!this.currentSession.isAdmin) this.router.transitionTo('unauthorized');
+    if (!this.currentSession.isAdmin) {
+      this.session.clearAfterLoginRoute();
+      this.router.transitionTo('unauthorized');
+    }
   }
 
   async model(params) {

--- a/app/routes/reporting.js
+++ b/app/routes/reporting.js
@@ -13,8 +13,8 @@ export default class ReportingRoute extends Route {
     sort: { refreshModel: true },
   };
 
-  async beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'index');
+  beforeModel(transition) {
+    this.session.requireAuthentication(transition, 'auth.login');
 
     if (!this.currentSession.isAdmin) this.router.transitionTo('unauthorized');
   }

--- a/app/routes/shared-processes/index.js
+++ b/app/routes/shared-processes/index.js
@@ -19,6 +19,7 @@ export default class SharedProcessesIndexRoute extends Route {
     this.session.requireAuthentication(transition, 'auth.login');
 
     if (!this.currentSession.canEdit) {
+      this.session.clearAfterLoginRoute();
       this.router.transitionTo('unauthorized');
     }
   }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -35,4 +35,8 @@ export default class OPHSessionService extends SessionService {
   setRouteForAfterLogin() {
     localStorage.setItem('BEFORE_LOGIN_PATH', window.location.pathname);
   }
+
+  clearAfterLoginRoute() {
+    localStorage.removeItem('BEFORE_LOGIN_PATH');
+  }
 }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -12,6 +12,11 @@ export default class OPHSessionService extends SessionService {
       : false;
   }
 
+  requireAuthentication(transition, routeOrCallback) {
+    this.setRouteForAfterLogin();
+    return super.requireAuthentication(transition, routeOrCallback);
+  }
+
   async handleAuthentication(routeAfterAuthentication) {
     await this.currentSession.load();
     const pathName = localStorage.getItem('BEFORE_LOGIN_PATH');


### PR DESCRIPTION
## 🗒️ Description

- When the user uses a direct link to a page this page should load all info
- When a process url is copied (from next to the title) it should always point to the shared processes overview
- When the suer is not logged in they should be redirected to login and back to the initial page

## 🦮 How to test

- Login and go to "gedeelde processen"  
- View a detail page and copy the URL
- Open the url in a new tab and you should be redirected to the "all processen" page
- Keep that url in copy and log out
- Go directly to that url again => you should be redirected but end up on the correct page
- Visit the /rapportering or another route (/inventaris/admin) where you will be unauthorized to go to
- You should not be in a loop of redirecting to the last login route

