### PR TITLE
Hide information asset versions component

### DIFF
--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -52,10 +52,6 @@ export default class InformationAssetsInformationAssetController extends Control
     return this.model.versionedAsset;
   }
 
-  get versionedAssets() {
-    return this.model.versionedAssets;
-  }
-
   get originatingProcess() {
     if (!this.process) return null;
 

--- a/app/routes/information-assets/information-asset.js
+++ b/app/routes/information-assets/information-asset.js
@@ -21,39 +21,50 @@ export default class InformationAssetsInformationAssetRoute extends Route {
 
   async model() {
     const params = this.paramsFor('information-assets.information-asset');
-    const id = params.id;
-    const { versionedAssetId } = params;
+    const { id: canonicalAssetId, versionedAssetId } = params;
 
-    const canonicalAsset = await this.fetchCanonicalAsset(id);
+    const canonicalAsset = await this.fetchCanonicalAsset(canonicalAssetId);
 
     if (canonicalAsset.isVersionedInformationAsset) {
-      await this.redirectToCanonical(id, params);
+      await this.redirectToCanonical(canonicalAssetId, params);
     }
 
-    const versionedAssets = await this.fetchVersionedAssets(id);
-    const versionedAsset = versionedAssetId
-      ? [...versionedAssets].find((asset) => asset.id === versionedAssetId)
-      : versionedAssets[0];
+    let versionedAsset;
+    if (versionedAssetId) {
+      versionedAsset = await this.fetchVersionedAsset(versionedAssetId);
+    } else {
+      versionedAsset = await this.fetchNewestVersionedAsset(canonicalAssetId);
+    }
 
-    return { canonicalAsset, versionedAsset, versionedAssets };
+    return { canonicalAsset, versionedAsset };
   }
 
-  async fetchCanonicalAsset(canonicalAssetId) {
-    return await this.store.findRecord('information-asset', canonicalAssetId, {
+  async fetchCanonicalAsset(id) {
+    return await this.store.findRecord('information-asset', id, {
       include: 'creator,processes,attachments,links',
     });
   }
 
-  async fetchVersionedAssets(canonicalAssetId) {
-    return await this.store.query('versioned-information-asset', {
-      reload: true,
-      'filter[canonical][:id:]': canonicalAssetId,
+  async fetchVersionedAsset(id) {
+    return await this.store.findRecord('versioned-information-asset', id, {
       include: 'creator',
-      page: {
-        size: 50,
-      },
-      sort: '-created',
     });
+  }
+
+  async fetchNewestVersionedAsset(canonicalAssetId) {
+    const singleElementArray = await this.store.query(
+      'versioned-information-asset',
+      {
+        reload: true,
+        'filter[canonical][:id:]': canonicalAssetId,
+        include: 'creator',
+        page: {
+          size: 1,
+        },
+        sort: '-created',
+      },
+    );
+    return singleElementArray[0];
   }
 
   async redirectToCanonical(versionedAssetId, params) {

--- a/app/templates/information-assets/information-asset.hbs
+++ b/app/templates/information-assets/information-asset.hbs
@@ -397,13 +397,6 @@
           {{else}}
             <p class="au-u-margin-top-small">Geen processen gevonden</p>
           {{/if}}
-
-          <Icr::Versions
-            @versionedAsset={{this.versionedAsset}}
-            @versionedAssets={{this.versionedAssets}}
-            @process={{this.process}}
-            @parentRoute={{this.parentRoute}}
-          />
         </AuContent>
       </div>
     </aside>


### PR DESCRIPTION
## 🗒️ Description

The versions component available on an information asset's details page is removed awaiting a better aligned versioning UI throughout the application.

## 🦮 How to test

1. Run the frontend locally:
```bash
ember serve --proxy https://openproceshuis.lblod.info
```

2. Go to an information asset's details page and make sure the versions tab is no longer visible.