### PR TITLE
Update design processes overview

### DIFF
--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -3,73 +3,75 @@
     <div class="au-c-sidebar">
       <div class="au-c-sidebar__content">
         <form
-          {{on "reset" @resetFilters}}
+          {{on "reset" this.resetFilters}}
           class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
         >
           <h1 class="au-u-h3 au-u-medium">Filters</h1>
-          {{#if @toggleBlueprintFilter}}
+          {{#if this.showBlueprintFilter}}
             <div
               class="au-u-flex au-u-flex--between au-u-flex--vertical-center"
             >
               <AuLabel for="filter-blueprint">Blauwdruk</AuLabel>
               <AuCheckbox
                 id="filter-blueprint"
-                @checked={{@blueprint}}
-                @onChange={{@toggleBlueprintFilter}}
+                @checked={{this.blueprint}}
+                @onChange={{this.toggleBlueprintFilter}}
               />
             </div>
           {{/if}}
-          <div>
-            <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
-            <ProcessSelectByTitle
-              @id="filter-title"
-              @selected={{@title}}
-              @onChange={{@setTitle}}
-              @publisher={{@titlePublisher}}
-              class="grow"
-            />
-          </div>
-          {{#if @setClassifications}}
+          {{#if this.showTitleFilter}}
+            <div>
+              <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
+              <ProcessSelectByTitle
+                @id="filter-title"
+                @selected={{this.title}}
+                @onChange={{this.setTitle}}
+                @publisher={{@titlePublisher}}
+                class="grow"
+              />
+            </div>
+          {{/if}}
+          {{#if this.showClassificationFilter}}
             <div>
               <AuLabel for="filter-classification">Relevant voor</AuLabel>
               <ProcessSelectByClassification
                 @id="filter-classification"
-                @selected={{@selectedClassifications}}
-                @onChange={{@setClassifications}}
+                @selected={{this.selectedClassifications}}
+                @onChange={{this.setClassifications}}
                 class="grow"
               />
             </div>
           {{/if}}
-          {{#if @setGroup}}
+          {{#if this.showGroupFilter}}
             <div>
               <AuLabel for="filter-group">Naam bestuur</AuLabel>
               <ProcessSelectByGroup
                 @id="filter-group"
-                @selected={{@group}}
-                @onChange={{@setGroup}}
-                @classifications={{@classifications}}
+                @selected={{this.group}}
+                @onChange={{this.setGroup}}
+                @classifications={{this.classifications}}
                 class="grow"
               />
             </div>
           {{/if}}
-          {{#if @setCreator}}
+          {{#if this.showCreatorFilter}}
             <div>
               <AuLabel for="filter-vendor">Via leverancier</AuLabel>
               <ProcessSelectByVendor
                 @id="filter-vendor"
-                @selected={{@creator}}
-                @onChange={{@setCreator}}
+                @selected={{this.creator}}
+                @onChange={{this.setCreator}}
                 class="grow"
               />
             </div>
           {{/if}}
-          {{#if @setIpdcProducts}}
+          {{#if this.showIpdcFilter}}
             <div>
               <AuLabel for="filter-ipdc">Filter op IPDC product</AuLabel>
               <ProcessSelectByIpdc
                 @id="filter-ipdc"
-                @selected={{@selectedIpdcProducts}}
-                @onChange={{@setIpdcProducts}}
+                @selected={{this.selectedIpdcProducts}}
+                @onChange={{this.setIpdcProducts}}
                 class="grow"
               />
             </div>
@@ -102,42 +104,54 @@
     <AuDataTable
       @content={{this.processes}}
       @isLoading={{this.isLoading}}
-      @page={{@page}}
-      @size={{@size}}
+      @page={{this.page}}
+      @size={{this.size}}
       as |t|
     >
       <t.content class="au-c-data-table__table--small" as |c|>
         <c.header>
-          <AuDataTableThSortable
-            @field="title"
-            @currentSorting={{@sort}}
-            @label="Titel"
-          />
-          <AuDataTableThSortable
-            @field="description"
-            @currentSorting={{@sort}}
-            @label="Beschrijving"
-          />
-          <AuDataTableThSortable
-            @field="modified"
-            @currentSorting={{@sort}}
-            @label="Laatst aangepast op"
-          />
-          <AuDataTableThSortable
-            @field="classification"
-            @currentSorting={{@sort}}
-            @label="Relevant voor"
-          />
-          <AuDataTableThSortable
-            @field="organization"
-            @currentSorting={{@sort}}
-            @label="Bestuur"
-          />
-          <AuDataTableThSortable
-            @field="creator"
-            @currentSorting={{@sort}}
-            @label="Via leverancier"
-          />
+          {{#if this.showTitleColumn}}
+            <AuDataTableThSortable
+              @field="title"
+              @currentSorting={{this.sort}}
+              @label="Titel"
+            />
+          {{/if}}
+          {{#if this.showDescriptionColumn}}
+            <AuDataTableThSortable
+              @field="description"
+              @currentSorting={{this.sort}}
+              @label="Beschrijving"
+            />
+          {{/if}}
+          {{#if this.showModifiedColumn}}
+            <AuDataTableThSortable
+              @field="modified"
+              @currentSorting={{this.sort}}
+              @label="Laatst aangepast op"
+            />
+          {{/if}}
+          {{#if this.showClassificationColumn}}
+            <AuDataTableThSortable
+              @field="classification"
+              @currentSorting={{this.sort}}
+              @label="Relevant voor"
+            />
+          {{/if}}
+          {{#if this.showOrganizationColumn}}
+            <AuDataTableThSortable
+              @field="organization"
+              @currentSorting={{this.sort}}
+              @label="Bestuur"
+            />
+          {{/if}}
+          {{#if this.showCreatorColumn}}
+            <AuDataTableThSortable
+              @field="creator"
+              @currentSorting={{this.sort}}
+              @label="Via leverancier"
+            />
+          {{/if}}
         </c.header>
         {{#if this.hasErrored}}
           <TableMessage::Error />
@@ -149,41 +163,53 @@
           </TableMessage>
         {{else}}
           <c.body as |process|>
-            <td>
-              <div
-                class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
-              >
-                {{#if process.isBlueprint}}
-                  <CustomIcon @icon="blueprint" @size="large" />
-                {{/if}}
-                <LinkTo
-                  class="au-c-link"
-                  @model={{process.id}}
-                  @route={{@processRoute}}
+            {{#if this.showTitleColumn}}
+              <td>
+                <div
+                  class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
                 >
-                  {{process.title}}
-                </LinkTo>
-                {{#if process.isUsedByCurrentGroup}}
-                  <AuPill @skin="success">In gebruik</AuPill>
-                {{/if}}
-              </div>
-            </td>
-            <td>
-              <span class="u-preserve-line-breaks">{{or
-                  (truncate (trim process.description) 150 true)
-                  "/"
-                }}</span>
-            </td>
-            <td>{{date-format process.modified}}</td>
-            <td>
-              <ul>
-                {{#each process.relevantAdministrativeUnits as |adminUnit|}}
-                  <li>{{adminUnit.label}}</li>
-                {{/each}}
-              </ul>
-            </td>
-            <td>{{process.publisher.name}}</td>
-            <td>{{or process.creator.name "/"}}</td>
+                  {{#if process.isBlueprint}}
+                    <CustomIcon @icon="blueprint" @size="large" />
+                  {{/if}}
+                  <LinkTo
+                    class="au-c-link"
+                    @model={{process.id}}
+                    @route={{@processRoute}}
+                  >
+                    {{process.title}}
+                  </LinkTo>
+                  {{#if process.isUsedByCurrentGroup}}
+                    <AuPill @skin="success">In gebruik</AuPill>
+                  {{/if}}
+                </div>
+              </td>
+            {{/if}}
+            {{#if this.showDescriptionColumn}}
+              <td>
+                <span class="u-preserve-line-breaks">{{or
+                    (truncate (trim process.description) 150 true)
+                    "/"
+                  }}</span>
+              </td>
+            {{/if}}
+            {{#if this.showModifiedColumn}}
+              <td>{{date-format process.modified}}</td>
+            {{/if}}
+            {{#if this.showClassificationColumn}}
+              <td>
+                <ul>
+                  {{#each process.relevantAdministrativeUnits as |adminUnit|}}
+                    <li>{{adminUnit.label}}</li>
+                  {{/each}}
+                </ul>
+              </td>
+            {{/if}}
+            {{#if this.showOrganizationColumn}}
+              <td>{{process.publisher.name}}</td>
+            {{/if}}
+            {{#if this.showCreatorColumn}}
+              <td>{{or process.creator.name "/"}}</td>
+            {{/if}}
           </c.body>
         {{/if}}
       </t.content>

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -163,6 +163,9 @@
                 >
                   {{process.title}}
                 </LinkTo>
+                {{#if process.isUsedByCurrentGroup}}
+                  <AuPill @skin="success">In gebruik</AuPill>
+                {{/if}}
               </div>
             </td>
             <td>

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -1,0 +1,189 @@
+<SidebarContainer>
+  <:sidebar>
+    <div class="au-c-sidebar">
+      <div class="au-c-sidebar__content">
+        <form
+          {{on "reset" @resetFilters}}
+          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
+        >
+          <h1 class="au-u-h3 au-u-medium">Filters</h1>
+          {{#if @toggleBlueprintFilter}}
+            <div
+              class="au-u-flex au-u-flex--between au-u-flex--vertical-center"
+            >
+              <AuLabel for="filter-blueprint">Blauwdruk</AuLabel>
+              <AuCheckbox
+                id="filter-blueprint"
+                @checked={{@blueprint}}
+                @onChange={{@toggleBlueprintFilter}}
+              />
+            </div>
+          {{/if}}
+          <div>
+            <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
+            <ProcessSelectByTitle
+              @id="filter-title"
+              @selected={{@title}}
+              @onChange={{@setTitle}}
+              @publisher={{@titlePublisher}}
+              class="grow"
+            />
+          </div>
+          {{#if @setClassifications}}
+            <div>
+              <AuLabel for="filter-classification">Relevant voor</AuLabel>
+              <ProcessSelectByClassification
+                @id="filter-classification"
+                @selected={{@selectedClassifications}}
+                @onChange={{@setClassifications}}
+                class="grow"
+              />
+            </div>
+          {{/if}}
+          {{#if @setGroup}}
+            <div>
+              <AuLabel for="filter-group">Naam bestuur</AuLabel>
+              <ProcessSelectByGroup
+                @id="filter-group"
+                @selected={{@group}}
+                @onChange={{@setGroup}}
+                @classifications={{@classifications}}
+                class="grow"
+              />
+            </div>
+          {{/if}}
+          {{#if @setCreator}}
+            <div>
+              <AuLabel for="filter-vendor">Via leverancier</AuLabel>
+              <ProcessSelectByVendor
+                @id="filter-vendor"
+                @selected={{@creator}}
+                @onChange={{@setCreator}}
+                class="grow"
+              />
+            </div>
+          {{/if}}
+          {{#if @setIpdcProducts}}
+            <div>
+              <AuLabel for="filter-ipdc">Filter op IPDC product</AuLabel>
+              <ProcessSelectByIpdc
+                @id="filter-ipdc"
+                @selected={{@selectedIpdcProducts}}
+                @onChange={{@setIpdcProducts}}
+                class="grow"
+              />
+            </div>
+          {{/if}}
+          <div class="au-u-flex au-u-flex--end">
+            <AuButton
+              @icon="cross"
+              @skin="link"
+              type="reset"
+              class="au-u-padding-none au-u-medium"
+            >
+              Herstel alle filters
+            </AuButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  </:sidebar>
+  <:content>
+    <PageHeader>
+      <:title>{{@pageTitle}}</:title>
+      <:subtitle>
+        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/informatie-oph">
+          Handleiding Open Proces Huis
+        </AuLinkExternal>
+      </:subtitle>
+      <:action></:action>
+    </PageHeader>
+
+    <AuDataTable
+      @content={{@processes}}
+      @isLoading={{@isLoading}}
+      @page={{@page}}
+      @size={{@size}}
+      as |t|
+    >
+      <t.content class="au-c-data-table__table--small" as |c|>
+        <c.header>
+          <AuDataTableThSortable
+            @field="title"
+            @currentSorting={{@sort}}
+            @label="Titel"
+          />
+          <AuDataTableThSortable
+            @field="description"
+            @currentSorting={{@sort}}
+            @label="Beschrijving"
+          />
+          <AuDataTableThSortable
+            @field="modified"
+            @currentSorting={{@sort}}
+            @label="Laatst aangepast op"
+          />
+          <AuDataTableThSortable
+            @field="classification"
+            @currentSorting={{@sort}}
+            @label="Relevant voor"
+          />
+          <AuDataTableThSortable
+            @field="organization"
+            @currentSorting={{@sort}}
+            @label="Bestuur"
+          />
+          <AuDataTableThSortable
+            @field="creator"
+            @currentSorting={{@sort}}
+            @label="Via leverancier"
+          />
+        </c.header>
+        {{#if @hasErrored}}
+          <TableMessage::Error />
+        {{else if @hasNoResults}}
+          <TableMessage>
+            <p>
+              Er werden geen zoekresultaten gevonden.
+            </p>
+          </TableMessage>
+        {{else}}
+          <c.body as |process|>
+            <td>
+              <div
+                class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
+              >
+                {{#if process.isBlueprint}}
+                  <CustomIcon @icon="blueprint" @size="large" />
+                {{/if}}
+                <LinkTo
+                  class="au-c-link"
+                  @model={{process.id}}
+                  @route={{@processRoute}}
+                >
+                  {{process.title}}
+                </LinkTo>
+              </div>
+            </td>
+            <td>
+              <span class="u-preserve-line-breaks">{{or
+                  (truncate (trim process.description) 150 true)
+                  "/"
+                }}</span>
+            </td>
+            <td>{{date-format process.modified}}</td>
+            <td>
+              <ul>
+                {{#each process.relevantAdministrativeUnits as |adminUnit|}}
+                  <li>{{adminUnit.label}}</li>
+                {{/each}}
+              </ul>
+            </td>
+            <td>{{process.publisher.name}}</td>
+            <td>{{or process.creator.name "/"}}</td>
+          </c.body>
+        {{/if}}
+      </t.content>
+    </AuDataTable>
+  </:content>
+</SidebarContainer>

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -100,8 +100,8 @@
     </PageHeader>
 
     <AuDataTable
-      @content={{@processes}}
-      @isLoading={{@isLoading}}
+      @content={{this.processes}}
+      @isLoading={{this.isLoading}}
       @page={{@page}}
       @size={{@size}}
       as |t|
@@ -139,9 +139,9 @@
             @label="Via leverancier"
           />
         </c.header>
-        {{#if @hasErrored}}
+        {{#if this.hasErrored}}
           <TableMessage::Error />
-        {{else if @hasNoResults}}
+        {{else if this.hasNoResults}}
           <TableMessage>
             <p>
               Er werden geen zoekresultaten gevonden.

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -31,6 +31,16 @@
               />
             </div>
           {{/if}}
+          {{#if this.showModifiedSinceFilter}}
+            <div>
+              <AuLabel for="filter-modified-since">Laatst aangepast sinds</AuLabel>
+              <AuDateInput
+                @id="filter-modified-since"
+                @value={{this.modifiedSince}}
+                @onChange={{this.setModifiedSince}}
+              />
+            </div>
+          {{/if}}
           {{#if this.showClassificationFilter}}
             <div>
               <AuLabel for="filter-classification">Relevant voor</AuLabel>

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -188,6 +188,13 @@
                   >
                     {{process.title}}
                   </LinkTo>
+                  {{#if
+                    (and
+                      this.modifiedSince process.isCreatedAndModifiedOnSameDay
+                    )
+                  }}
+                    <AuPill @skin="link">Nieuw</AuPill>
+                  {{/if}}
                   {{#if process.isUsedByCurrentGroup}}
                     <AuPill @skin="success">In gebruik</AuPill>
                   {{/if}}

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -108,7 +108,9 @@
           Handleiding Open Proces Huis
         </AuLinkExternal>
       </:subtitle>
-      <:action></:action>
+      <:action>
+        {{yield to="action"}}
+      </:action>
     </PageHeader>
 
     <AuDataTable
@@ -141,6 +143,13 @@
               @label="Laatst aangepast op"
             />
           {{/if}}
+          {{#if this.showCreatedColumn}}
+            <AuDataTableThSortable
+              @field="created"
+              @currentSorting={{this.sort}}
+              @label="Aangemaakt op"
+            />
+          {{/if}}
           {{#if this.showClassificationColumn}}
             <AuDataTableThSortable
               @field="classification"
@@ -161,6 +170,9 @@
               @currentSorting={{this.sort}}
               @label="Via leverancier"
             />
+          {{/if}}
+          {{#if this.showActionsColumn}}
+            <th></th>
           {{/if}}
         </c.header>
         {{#if this.hasErrored}}
@@ -212,6 +224,9 @@
             {{#if this.showModifiedColumn}}
               <td>{{date-format process.modified}}</td>
             {{/if}}
+            {{#if this.showCreatedColumn}}
+              <td>{{date-format process.created}}</td>
+            {{/if}}
             {{#if this.showClassificationColumn}}
               <td>
                 <ul>
@@ -226,6 +241,9 @@
             {{/if}}
             {{#if this.showCreatorColumn}}
               <td>{{or process.creator.name "/"}}</td>
+            {{/if}}
+            {{#if this.showActionsColumn}}
+              <td>{{yield process to="rowActions"}}</td>
             {{/if}}
           </c.body>
         {{/if}}

--- a/app/components/process-overview.js
+++ b/app/components/process-overview.js
@@ -138,6 +138,10 @@ export default class ProcessOverviewComponent extends Component {
     return this.columns.includes('modified');
   }
 
+  get showCreatedColumn() {
+    return this.columns.includes('created');
+  }
+
   get showClassificationColumn() {
     return this.columns.includes('classification');
   }
@@ -148,6 +152,10 @@ export default class ProcessOverviewComponent extends Component {
 
   get showCreatorColumn() {
     return this.columns.includes('creator');
+  }
+
+  get showActionsColumn() {
+    return this.columns.includes('actions');
   }
 
   @action

--- a/app/components/process-overview.js
+++ b/app/components/process-overview.js
@@ -1,6 +1,19 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class ProcessOverviewComponent extends Component {
+  get filters() {
+    return this.args.filters ?? [];
+  }
+
+  get columns() {
+    return this.args.columns ?? [];
+  }
+
+  get query() {
+    return this.args.query ?? {};
+  }
+
   get loadProcessesTaskInstance() {
     return this.args.model?.loadProcessesTaskInstance;
   }
@@ -23,5 +36,195 @@ export default class ProcessOverviewComponent extends Component {
 
   get hasErrored() {
     return this.loadProcessesTaskInstance?.isError ?? false;
+  }
+
+  get page() {
+    return this.query.page;
+  }
+
+  set page(page) {
+    this.updateQuery({ page });
+  }
+
+  get size() {
+    return this.query.size;
+  }
+
+  set size(size) {
+    this.updateQuery({ size });
+  }
+
+  get sort() {
+    return this.query.sort;
+  }
+
+  set sort(sort) {
+    this.updateQuery({ sort });
+  }
+
+  get title() {
+    return this.query.title ?? '';
+  }
+
+  get classifications() {
+    return this.query.classifications;
+  }
+
+  get selectedClassifications() {
+    return this.query.selectedClassifications;
+  }
+
+  get group() {
+    return this.query.group ?? '';
+  }
+
+  get creator() {
+    return this.query.creator ?? '';
+  }
+
+  get blueprint() {
+    return this.query.blueprint ?? false;
+  }
+
+  get ipdcProducts() {
+    return this.query.ipdcProducts;
+  }
+
+  get selectedIpdcProducts() {
+    return this.query.selectedIpdcProducts;
+  }
+
+  get showBlueprintFilter() {
+    return this.filters.includes('blueprint');
+  }
+
+  get showTitleFilter() {
+    return this.filters.includes('title');
+  }
+
+  get showClassificationFilter() {
+    return this.filters.includes('classification');
+  }
+
+  get showGroupFilter() {
+    return this.filters.includes('group');
+  }
+
+  get showCreatorFilter() {
+    return this.filters.includes('creator');
+  }
+
+  get showIpdcFilter() {
+    return this.filters.includes('ipdc');
+  }
+
+  get showTitleColumn() {
+    return this.columns.includes('title');
+  }
+
+  get showDescriptionColumn() {
+    return this.columns.includes('description');
+  }
+
+  get showModifiedColumn() {
+    return this.columns.includes('modified');
+  }
+
+  get showClassificationColumn() {
+    return this.columns.includes('classification');
+  }
+
+  get showOrganizationColumn() {
+    return this.columns.includes('organization');
+  }
+
+  get showCreatorColumn() {
+    return this.columns.includes('creator');
+  }
+
+  @action
+  updateQuery(changes) {
+    this.args.onQueryChange?.({
+      ...this.query,
+      ...changes,
+    });
+  }
+
+  @action
+  setTitle(selection) {
+    this.updateQuery({
+      page: null,
+      title: selection,
+    });
+  }
+
+  @action
+  setClassifications(selection) {
+    this.updateQuery({
+      page: null,
+      selectedClassifications: selection,
+      classifications: selection.length
+        ? selection.map((classification) => classification.id).join(',')
+        : undefined,
+    });
+  }
+
+  @action
+  setGroup(selection) {
+    this.updateQuery({
+      page: null,
+      group: selection,
+    });
+  }
+
+  @action
+  setCreator(selection) {
+    this.updateQuery({
+      page: null,
+      creator: selection,
+    });
+  }
+
+  @action
+  toggleBlueprintFilter(checked) {
+    this.updateQuery({
+      page: null,
+      blueprint: checked,
+    });
+  }
+
+  @action
+  setIpdcProducts(selection) {
+    this.updateQuery({
+      page: null,
+      selectedIpdcProducts: selection,
+      ipdcProducts: selection.length
+        ? selection.map((ipdcProduct) => ipdcProduct.id).join(',')
+        : undefined,
+    });
+  }
+
+  @action
+  resetFilters() {
+    const resetQuery = {
+      ...this.query,
+      page: null,
+      sort: 'title',
+    };
+
+    if (this.showTitleFilter) resetQuery.title = '';
+    if (this.showBlueprintFilter) resetQuery.blueprint = false;
+    if (this.showClassificationFilter) {
+      resetQuery.classifications = undefined;
+      resetQuery.selectedClassifications = undefined;
+    }
+    if (this.showGroupFilter) resetQuery.group = '';
+    if (this.showCreatorFilter) resetQuery.creator = '';
+    if (this.showIpdcFilter) {
+      resetQuery.ipdcProducts = undefined;
+      resetQuery.selectedIpdcProducts = undefined;
+    }
+
+    this.args.onQueryChange?.(resetQuery);
   }
 }

--- a/app/components/process-overview.js
+++ b/app/components/process-overview.js
@@ -66,6 +66,10 @@ export default class ProcessOverviewComponent extends Component {
     return this.query.title ?? '';
   }
 
+  get modifiedSince() {
+    return this.query.modifiedSince;
+  }
+
   get classifications() {
     return this.query.classifications;
   }
@@ -100,6 +104,10 @@ export default class ProcessOverviewComponent extends Component {
 
   get showTitleFilter() {
     return this.filters.includes('title');
+  }
+
+  get showModifiedSinceFilter() {
+    return this.filters.includes('modifiedSince');
   }
 
   get showClassificationFilter() {
@@ -159,6 +167,14 @@ export default class ProcessOverviewComponent extends Component {
   }
 
   @action
+  setModifiedSince(value) {
+    this.updateQuery({
+      page: null,
+      modifiedSince: value || undefined,
+    });
+  }
+
+  @action
   setClassifications(selection) {
     this.updateQuery({
       page: null,
@@ -213,6 +229,7 @@ export default class ProcessOverviewComponent extends Component {
     };
 
     if (this.showTitleFilter) resetQuery.title = '';
+    if (this.showModifiedSinceFilter) resetQuery.modifiedSince = undefined;
     if (this.showBlueprintFilter) resetQuery.blueprint = false;
     if (this.showClassificationFilter) {
       resetQuery.classifications = undefined;

--- a/app/components/process-overview.js
+++ b/app/components/process-overview.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+export default class ProcessOverviewComponent extends Component {
+  get loadProcessesTaskInstance() {
+    return this.args.model?.loadProcessesTaskInstance;
+  }
+
+  get processes() {
+    return this.loadProcessesTaskInstance?.isFinished
+      ? this.loadProcessesTaskInstance.value
+      : this.args.model?.loadedProcesses;
+  }
+
+  get isLoading() {
+    return this.loadProcessesTaskInstance?.isRunning ?? false;
+  }
+
+  get hasNoResults() {
+    return (
+      this.loadProcessesTaskInstance?.isFinished && this.processes?.length === 0
+    );
+  }
+
+  get hasErrored() {
+    return this.loadProcessesTaskInstance?.isError ?? false;
+  }
+}

--- a/app/controllers/my-local-government/index.js
+++ b/app/controllers/my-local-government/index.js
@@ -13,12 +13,13 @@ export default class MyLocalGovernmentIndexController extends Controller {
     'organization',
   ];
 
-  queryParams = ['page', 'size', 'sort', 'title'];
+  queryParams = ['page', 'size', 'sort', 'title', 'modifiedSince'];
 
   @tracked page = 0;
   @tracked size = 20;
   @tracked sort = 'title';
   @tracked title = '';
+  @tracked modifiedSince = undefined;
   @service currentSession;
 
   get query() {
@@ -27,6 +28,7 @@ export default class MyLocalGovernmentIndexController extends Controller {
       size: this.size,
       sort: this.sort,
       title: this.title,
+      modifiedSince: this.modifiedSince,
     };
   }
 
@@ -36,5 +38,6 @@ export default class MyLocalGovernmentIndexController extends Controller {
     this.size = query.size;
     this.sort = query.sort;
     this.title = query.title;
+    this.modifiedSince = query.modifiedSince;
   }
 }

--- a/app/controllers/my-local-government/index.js
+++ b/app/controllers/my-local-government/index.js
@@ -24,27 +24,6 @@ export default class MyLocalGovernmentIndexController extends Controller {
   @tracked blueprint = false;
   @service currentSession;
 
-  get processes() {
-    return this.model.loadProcessesTaskInstance.isFinished
-      ? this.model.loadProcessesTaskInstance.value
-      : this.model.loadedProcesses;
-  }
-
-  get isLoading() {
-    return this.model.loadProcessesTaskInstance.isRunning;
-  }
-
-  get hasNoResults() {
-    return (
-      this.model.loadProcessesTaskInstance.isFinished &&
-      this.processes?.length === 0
-    );
-  }
-
-  get hasErrored() {
-    return this.model.loadProcessesTaskInstance.isError;
-  }
-
   @action
   setTitle(selection) {
     this.page = null;

--- a/app/controllers/my-local-government/index.js
+++ b/app/controllers/my-local-government/index.js
@@ -4,62 +4,37 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class MyLocalGovernmentIndexController extends Controller {
-  queryParams = [
-    'page',
-    'size',
-    'sort',
+  filters = ['title'];
+  columns = [
     'title',
+    'description',
+    'modified',
     'classification',
-    'group',
-    'blueprint',
+    'organization',
   ];
 
+  queryParams = ['page', 'size', 'sort', 'title'];
+
   @tracked page = 0;
-  size = 20;
+  @tracked size = 20;
   @tracked sort = 'title';
   @tracked title = '';
-  @tracked classification = '';
-  @tracked selectedClassification = '';
-  @tracked group = '';
-  @tracked blueprint = false;
   @service currentSession;
 
-  @action
-  setTitle(selection) {
-    this.page = null;
-    this.title = selection;
+  get query() {
+    return {
+      page: this.page,
+      size: this.size,
+      sort: this.sort,
+      title: this.title,
+    };
   }
 
   @action
-  setClassification(selection) {
-    this.page = null;
-    this.selectedClassification = selection;
-    this.classification = selection?.label;
-  }
-
-  @action
-  setGroup(selection) {
-    this.page = null;
-    this.group = selection;
-  }
-
-  @action
-  toggleBlueprintFilter(event) {
-    this.page = null;
-    this.blueprint = event;
-  }
-
-  @action
-  resetFilters() {
-    this.title = '';
-    this.classification = '';
-    this.selectedClassification = '';
-    this.group = '';
-    this.page = 0;
-    this.sort = 'title';
-    this.blueprint = false;
-
-    // Triggers a refresh of the model
-    this.page = null;
+  updateQuery(query) {
+    this.page = query.page;
+    this.size = query.size;
+    this.sort = query.sort;
+    this.title = query.title;
   }
 }

--- a/app/controllers/my-local-government/index.js
+++ b/app/controllers/my-local-government/index.js
@@ -11,6 +11,7 @@ export default class MyLocalGovernmentIndexController extends Controller {
     'modified',
     'classification',
     'organization',
+    'creator',
   ];
 
   queryParams = ['page', 'size', 'sort', 'title', 'modifiedSince'];

--- a/app/controllers/my-local-government/index.js
+++ b/app/controllers/my-local-government/index.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class MyLocalGovernmentIndexController extends Controller {
-  filters = ['title'];
+  filters = ['title', 'modifiedSince'];
   columns = [
     'title',
     'description',

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -6,6 +6,7 @@ export default class ProcessesIndexController extends Controller {
   filters = [
     'blueprint',
     'title',
+    'modifiedSince',
     'classification',
     'group',
     'creator',

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -25,6 +25,7 @@ export default class ProcessesIndexController extends Controller {
     'size',
     'sort',
     'title',
+    'modifiedSince',
     'classifications',
     'group',
     'creator',
@@ -36,6 +37,7 @@ export default class ProcessesIndexController extends Controller {
   @tracked size = 20;
   @tracked sort = 'title';
   @tracked title = '';
+  @tracked modifiedSince = undefined;
   @tracked classifications = undefined;
   @tracked selectedClassifications = undefined;
   @tracked selectedIpdcProducts = undefined;
@@ -50,6 +52,7 @@ export default class ProcessesIndexController extends Controller {
       size: this.size,
       sort: this.sort,
       title: this.title,
+      modifiedSince: this.modifiedSince,
       classifications: this.classifications,
       selectedClassifications: this.selectedClassifications,
       group: this.group,
@@ -66,6 +69,7 @@ export default class ProcessesIndexController extends Controller {
     this.size = query.size;
     this.sort = query.sort;
     this.title = query.title;
+    this.modifiedSince = query.modifiedSince;
     this.classifications = query.classifications;
     this.selectedClassifications = query.selectedClassifications;
     this.group = query.group;

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -29,27 +29,6 @@ export default class ProcessesIndexController extends Controller {
   @tracked blueprint = false;
   @service currentSession;
 
-  get processes() {
-    return this.model.loadProcessesTaskInstance.isFinished
-      ? this.model.loadProcessesTaskInstance.value
-      : this.model.loadedProcesses;
-  }
-
-  get isLoading() {
-    return this.model.loadProcessesTaskInstance.isRunning;
-  }
-
-  get hasNoResults() {
-    return (
-      this.model.loadProcessesTaskInstance.isFinished &&
-      this.processes?.length === 0
-    );
-  }
-
-  get hasErrored() {
-    return this.model.loadProcessesTaskInstance.isError;
-  }
-
   @action
   setTitle(selection) {
     this.page = null;

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -3,6 +3,23 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class ProcessesIndexController extends Controller {
+  filters = [
+    'blueprint',
+    'title',
+    'classification',
+    'group',
+    'creator',
+    'ipdc',
+  ];
+  columns = [
+    'title',
+    'description',
+    'modified',
+    'classification',
+    'organization',
+    'creator',
+  ];
+
   queryParams = [
     'page',
     'size',
@@ -16,7 +33,7 @@ export default class ProcessesIndexController extends Controller {
   ];
 
   @tracked page = 0;
-  size = 20;
+  @tracked size = 20;
   @tracked sort = 'title';
   @tracked title = '';
   @tracked classifications = undefined;
@@ -27,68 +44,34 @@ export default class ProcessesIndexController extends Controller {
   @tracked creator = '';
   @tracked blueprint = false;
 
-  @action
-  setTitle(selection) {
-    this.page = null;
-    this.title = selection;
+  get query() {
+    return {
+      page: this.page,
+      size: this.size,
+      sort: this.sort,
+      title: this.title,
+      classifications: this.classifications,
+      selectedClassifications: this.selectedClassifications,
+      group: this.group,
+      creator: this.creator,
+      blueprint: this.blueprint,
+      ipdcProducts: this.ipdcProducts,
+      selectedIpdcProducts: this.selectedIpdcProducts,
+    };
   }
 
   @action
-  setClassifications(selection) {
-    this.page = null;
-    this.selectedClassifications = selection;
-    if (selection.length === 0) {
-      this.classifications = undefined;
-    } else {
-      this.classifications = selection
-        .map((classification) => {
-          return classification.id;
-        })
-        .join(',');
-    }
-  }
-
-  @action
-  setIpdcProducts(selection) {
-    this.page = null;
-    this.selectedIpdcProducts = selection;
-    this.ipdcProducts = selection.length
-      ? selection.map((ipdcProduct) => ipdcProduct.id).join(',')
-      : undefined;
-  }
-
-  @action
-  setGroup(selection) {
-    this.page = null;
-    this.group = selection;
-  }
-
-  @action
-  setCreator(selection) {
-    this.page = null;
-    this.creator = selection;
-  }
-
-  @action
-  toggleBlueprintFilter(event) {
-    this.page = null;
-    this.blueprint = event;
-  }
-
-  @action
-  resetFilters() {
-    this.title = '';
-    this.classifications = undefined;
-    this.selectedClassifications = undefined;
-    this.group = '';
-    this.creator = '';
-    this.page = 0;
-    this.sort = 'title';
-    this.blueprint = false;
-    this.selectedIpdcProducts = undefined;
-    this.ipdcProducts = undefined;
-
-    // Triggers a refresh of the model
-    this.page = null;
+  updateQuery(query) {
+    this.page = query.page;
+    this.size = query.size;
+    this.sort = query.sort;
+    this.title = query.title;
+    this.classifications = query.classifications;
+    this.selectedClassifications = query.selectedClassifications;
+    this.group = query.group;
+    this.creator = query.creator;
+    this.blueprint = query.blueprint;
+    this.ipdcProducts = query.ipdcProducts;
+    this.selectedIpdcProducts = query.selectedIpdcProducts;
   }
 }

--- a/app/controllers/processes/index.js
+++ b/app/controllers/processes/index.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { service } from '@ember/service';
 
 export default class ProcessesIndexController extends Controller {
   queryParams = [
@@ -27,7 +26,6 @@ export default class ProcessesIndexController extends Controller {
   @tracked group = '';
   @tracked creator = '';
   @tracked blueprint = false;
-  @service currentSession;
 
   @action
   setTitle(selection) {
@@ -75,11 +73,6 @@ export default class ProcessesIndexController extends Controller {
   toggleBlueprintFilter(event) {
     this.page = null;
     this.blueprint = event;
-  }
-
-  @action
-  processIsUsedBy(usersArray) {
-    return usersArray.includes(this.currentSession.group);
   }
 
   @action

--- a/app/controllers/shared-processes/index.js
+++ b/app/controllers/shared-processes/index.js
@@ -6,13 +6,16 @@ import { service } from '@ember/service';
 import { getMessageForErrorCode } from 'frontend-openproceshuis/utils/error-messages';
 
 export default class SharedProcessesIndexController extends Controller {
+  filters = ['title'];
+  columns = ['title', 'description', 'created', 'modified', 'actions'];
+
   queryParams = ['page', 'size', 'sort', 'title'];
 
   @service router;
   @service toaster;
 
   @tracked page = 0;
-  size = 20;
+  @tracked size = 20;
   @tracked sort = 'title';
   @tracked title = '';
   @tracked processToDelete = undefined;
@@ -21,41 +24,21 @@ export default class SharedProcessesIndexController extends Controller {
 
   newProcessId = undefined;
 
-  get processes() {
-    return this.model.loadProcessesTaskInstance.isFinished
-      ? this.model.loadProcessesTaskInstance.value
-      : this.model.loadedProcesses;
-  }
-
-  get isLoading() {
-    return this.model.loadProcessesTaskInstance.isRunning;
-  }
-
-  get hasNoResults() {
-    return (
-      this.model.loadProcessesTaskInstance.isFinished &&
-      this.processes?.length === 0
-    );
-  }
-
-  get hasErrored() {
-    return this.model.loadProcessesTaskInstance.isError;
+  get query() {
+    return {
+      page: this.page,
+      size: this.size,
+      sort: this.sort,
+      title: this.title,
+    };
   }
 
   @action
-  setTitle(selection) {
-    this.page = null;
-    this.title = selection;
-  }
-
-  @action
-  resetFilters() {
-    this.title = '';
-    this.page = 0;
-    this.sort = 'title';
-
-    // Triggers a refresh of the model
-    this.page = null;
+  updateQuery(query) {
+    this.page = query.page;
+    this.size = query.size;
+    this.sort = query.sort;
+    this.title = query.title;
   }
 
   @action

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -105,6 +105,26 @@ export default class ProcessModel extends Model {
     return this.users?.includes(this.currentSession.group);
   }
 
+  get isCreatedAndModifiedOnSameDay() {
+    if (!this.created || !this.modified) return false;
+
+    const createdAt = new Date(this.created);
+    const modifiedAt = new Date(this.modified);
+
+    if (
+      Number.isNaN(createdAt.getTime()) ||
+      Number.isNaN(modifiedAt.getTime())
+    ) {
+      return false;
+    }
+
+    return (
+      createdAt.getFullYear() === modifiedAt.getFullYear() &&
+      createdAt.getMonth() === modifiedAt.getMonth() &&
+      createdAt.getDate() === modifiedAt.getDate()
+    );
+  }
+
   get href() {
     return `${window.location.origin}/processen/${this.id}`;
   }

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -6,9 +6,12 @@ import {
   isEmptyOrEmail,
   isEmptyOrUrl,
 } from 'frontend-openproceshuis/utils/custom-validators';
+import { service } from '@ember/service';
 
 @modelValidator
 export default class ProcessModel extends Model {
+  @service currentSession;
+
   @attr('string') title;
   @attr('string') description;
   @attr('string') email;
@@ -96,6 +99,10 @@ export default class ProcessModel extends Model {
   get isPublishedByAbbOrDv() {
     const ovoCodes = [ENV.ovoCodes.abb, ENV.ovoCodes.dv];
     return ovoCodes.includes(this.publisher?.identifier);
+  }
+
+  get isUsedByCurrentGroup() {
+    return this.users?.includes(this.currentSession.group);
   }
 
   get href() {

--- a/app/routes/my-local-government/index.js
+++ b/app/routes/my-local-government/index.js
@@ -13,6 +13,7 @@ export default class MyLocalGovernmentIndexRoute extends Route {
     page: { refreshModel: true },
     sort: { refreshModel: true },
     title: { refreshModel: true, replace: true },
+    modifiedSince: { refreshModel: true, replace: true },
     classification: { refreshModel: true, replace: true },
     group: { refreshModel: true, replace: true },
     blueprint: { refreshModel: true },
@@ -58,6 +59,10 @@ export default class MyLocalGovernmentIndexRoute extends Route {
     if (params.title) {
       query['filter[:or:][title]'] = params.title;
       query['filter[:or:][description]'] = params.title;
+    }
+
+    if (params.modifiedSince) {
+      query['filter[:gte:modified]'] = params.modifiedSince;
     }
 
     if (params.classification)

--- a/app/routes/my-local-government/index.js
+++ b/app/routes/my-local-government/index.js
@@ -37,7 +37,7 @@ export default class MyLocalGovernmentIndexRoute extends Route {
         size: params.size,
       },
       include:
-        'publisher,users,publisher.primary-site,publisher.primary-site.contacts,publisher.classification,relevant-administrative-units',
+        'publisher,creator,users,publisher.primary-site,publisher.primary-site.contacts,publisher.classification,relevant-administrative-units',
     };
 
     if (params.sort) {

--- a/app/routes/processes/index.js
+++ b/app/routes/processes/index.js
@@ -11,6 +11,7 @@ export default class ProcessesIndexRoute extends Route {
     page: { refreshModel: true },
     sort: { refreshModel: true },
     title: { refreshModel: true, replace: true },
+    modifiedSince: { refreshModel: true, replace: true },
     classifications: { refreshModel: true, replace: true },
     group: { refreshModel: true, replace: true },
     creator: { refreshModel: true, replace: true },
@@ -66,6 +67,10 @@ export default class ProcessesIndexRoute extends Route {
     if (params.title) {
       query['filter[:or:][title]'] = params.title;
       query['filter[:or:][description]'] = params.title;
+    }
+
+    if (params.modifiedSince) {
+      query['filter[:gte:modified]'] = params.modifiedSince;
     }
 
     if (params.classifications) {

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -2,13 +2,10 @@
   @pageTitle="Mijn lokaal bestuur"
   @processRoute="my-local-government.process"
   @titlePublisher={{this.currentSession.group.id}}
-  @processes={{this.processes}}
-  @isLoading={{this.isLoading}}
+  @model={{this.model}}
   @page={{this.page}}
   @size={{this.size}}
   @sort={{this.sort}}
-  @hasErrored={{this.hasErrored}}
-  @hasNoResults={{this.hasNoResults}}
   @title={{this.title}}
   @resetFilters={{this.resetFilters}}
   @setTitle={{this.setTitle}}

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -3,10 +3,8 @@
   @processRoute="my-local-government.process"
   @titlePublisher={{this.currentSession.group.id}}
   @model={{this.model}}
-  @page={{this.page}}
-  @size={{this.size}}
-  @sort={{this.sort}}
-  @title={{this.title}}
-  @resetFilters={{this.resetFilters}}
-  @setTitle={{this.setTitle}}
+  @filters={{this.filters}}
+  @columns={{this.columns}}
+  @query={{this.query}}
+  @onQueryChange={{this.updateQuery}}
 />

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -1,125 +1,15 @@
-<SidebarContainer>
-  <:sidebar>
-    <div class="au-c-sidebar">
-      <div class="au-c-sidebar__content">
-        <form
-          {{on "reset" this.resetFilters}}
-          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
-        >
-          <h1 class="au-u-h3 au-u-medium">Filters</h1>
-          <div>
-            <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
-            <ProcessSelectByTitle
-              @id="filter-title"
-              @selected={{this.title}}
-              @onChange={{this.setTitle}}
-              @publisher={{this.currentSession.group.id}}
-              class="grow"
-            />
-          </div>
-          <div class="au-u-flex au-u-flex--end">
-            <AuButton
-              @icon="cross"
-              @skin="link"
-              type="reset"
-              class="au-u-padding-none au-u-medium"
-            >
-              Herstel alle filters
-            </AuButton>
-          </div>
-        </form>
-      </div>
-    </div>
-  </:sidebar>
-  <:content>
-    <PageHeader>
-      <:title>Mijn lokaal bestuur</:title>
-      <:subtitle>
-        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/informatie-oph">
-          Handleiding Open Proces Huis
-        </AuLinkExternal>
-      </:subtitle>
-      <:action>
-      </:action>
-    </PageHeader>
-
-    <AuDataTable
-      @content={{this.processes}}
-      @isLoading={{this.isLoading}}
-      @page={{this.page}}
-      @size={{this.size}}
-      as |t|
-    >
-      <t.content class="au-c-data-table__table--small" as |c|>
-        <c.header>
-          <AuDataTableThSortable
-            @field="title"
-            @currentSorting={{this.sort}}
-            @label="Titel"
-          />
-          <AuDataTableThSortable
-            @field="description"
-            @currentSorting={{this.sort}}
-            @label="Beschrijving"
-          />
-          <AuDataTableThSortable
-            @field="modified"
-            @currentSorting={{this.sort}}
-            @label="Laatst aangepast op"
-          />
-          <AuDataTableThSortable
-            @field="classification"
-            @currentSorting={{this.sort}}
-            @label="Relevant voor"
-          />
-          <AuDataTableThSortable
-            @field="organization"
-            @currentSorting={{this.sort}}
-            @label="Bestuur"
-          />
-        </c.header>
-        {{#if this.hasErrored}}
-          <TableMessage::Error />
-        {{else if this.hasNoResults}}
-          <TableMessage>
-            <p>
-              Er werden geen zoekresultaten gevonden.
-            </p>
-          </TableMessage>
-        {{else}}
-          <c.body as |process|>
-            <td
-              class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
-            >
-              {{#if process.isBlueprint}}
-                <CustomIcon @icon="blueprint" @size="large" />
-              {{/if}}
-              <LinkTo
-                class="au-c-link"
-                @model={{process.id}}
-                @route="my-local-government.process"
-              >
-                {{process.title}}
-              </LinkTo>
-            </td>
-            <td>
-              <span class="u-preserve-line-breaks">{{or
-                  (truncate (trim process.description) 150 true)
-                  "/"
-                }}</span>
-            </td>
-            <td>{{date-format process.modified}}</td>
-            <td>
-              <ul>
-                {{#each process.relevantAdministrativeUnits as |adminUnit|}}
-                  <li>{{adminUnit.label}}</li>
-                {{/each}}
-              </ul>
-            </td>
-            <td>{{process.publisher.name}}</td>
-          </c.body>
-        {{/if}}
-      </t.content>
-    </AuDataTable>
-  </:content>
-</SidebarContainer>
+<ProcessOverview
+  @pageTitle="Mijn lokaal bestuur"
+  @processRoute="my-local-government.process"
+  @titlePublisher={{this.currentSession.group.id}}
+  @processes={{this.processes}}
+  @isLoading={{this.isLoading}}
+  @page={{this.page}}
+  @size={{this.size}}
+  @sort={{this.sort}}
+  @hasErrored={{this.hasErrored}}
+  @hasNoResults={{this.hasNoResults}}
+  @title={{this.title}}
+  @resetFilters={{this.resetFilters}}
+  @setTitle={{this.setTitle}}
+/>

--- a/app/templates/my-local-government/index.hbs
+++ b/app/templates/my-local-government/index.hbs
@@ -63,6 +63,11 @@
             @label="Beschrijving"
           />
           <AuDataTableThSortable
+            @field="modified"
+            @currentSorting={{this.sort}}
+            @label="Laatst aangepast op"
+          />
+          <AuDataTableThSortable
             @field="classification"
             @currentSorting={{this.sort}}
             @label="Relevant voor"
@@ -71,11 +76,6 @@
             @field="organization"
             @currentSorting={{this.sort}}
             @label="Bestuur"
-          />
-          <AuDataTableThSortable
-            @field="modified"
-            @currentSorting={{this.sort}}
-            @label="Laatst aangepast op"
           />
         </c.header>
         {{#if this.hasErrored}}
@@ -108,6 +108,7 @@
                   "/"
                 }}</span>
             </td>
+            <td>{{date-format process.modified}}</td>
             <td>
               <ul>
                 {{#each process.relevantAdministrativeUnits as |adminUnit|}}
@@ -116,8 +117,6 @@
               </ul>
             </td>
             <td>{{process.publisher.name}}</td>
-            <td>{{date-format process.modified}}</td>
-
           </c.body>
         {{/if}}
       </t.content>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -1,13 +1,10 @@
 <ProcessOverview
   @pageTitle="Processen"
   @processRoute="processes.process"
-  @processes={{this.processes}}
-  @isLoading={{this.isLoading}}
+  @model={{this.model}}
   @page={{this.page}}
   @size={{this.size}}
   @sort={{this.sort}}
-  @hasErrored={{this.hasErrored}}
-  @hasNoResults={{this.hasNoResults}}
   @title={{this.title}}
   @selectedClassifications={{this.selectedClassifications}}
   @classifications={{this.classifications}}

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -1,179 +1,25 @@
-<SidebarContainer>
-  <:sidebar>
-    <div class="au-c-sidebar">
-      <div class="au-c-sidebar__content">
-        <form
-          {{on "reset" this.resetFilters}}
-          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
-        >
-          <h1 class="au-u-h3 au-u-medium">Filters</h1>
-          <div class="au-u-flex au-u-flex--between au-u-flex--vertical-center">
-            <AuLabel for="filter-blueprint">Blauwdruk</AuLabel>
-            <AuCheckbox
-              id="filter-blueprint"
-              @checked={{this.isBlueprint}}
-              @onChange={{this.toggleBlueprintFilter}}
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
-            <ProcessSelectByTitle
-              @id="filter-title"
-              @selected={{this.title}}
-              @onChange={{this.setTitle}}
-              class="grow"
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-classification">Relevant voor</AuLabel>
-            <ProcessSelectByClassification
-              @id="filter-classification"
-              @selected={{this.selectedClassifications}}
-              @onChange={{this.setClassifications}}
-              class="grow"
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-group">Naam bestuur</AuLabel>
-            <ProcessSelectByGroup
-              @id="filter-group"
-              @selected={{this.group}}
-              @onChange={{this.setGroup}}
-              @classifications={{this.classifications}}
-              class="grow"
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-vendor">Via leverancier</AuLabel>
-            <ProcessSelectByVendor
-              @id="filter-vendor"
-              @selected={{this.creator}}
-              @onChange={{this.setCreator}}
-              class="grow"
-            />
-          </div>
-          <div>
-            <AuLabel for="filter-ipdc">Filter op IPDC product</AuLabel>
-            <ProcessSelectByIpdc
-              @id="filter-ipdc"
-              @selected={{this.selectedIpdcProducts}}
-              @onChange={{this.setIpdcProducts}}
-              class="grow"
-            />
-          </div>
-          <div class="au-u-flex au-u-flex--end">
-            <AuButton
-              @icon="cross"
-              @skin="link"
-              type="reset"
-              class="au-u-padding-none au-u-medium"
-            >
-              Herstel alle filters
-            </AuButton>
-          </div>
-        </form>
-      </div>
-    </div>
-  </:sidebar>
-  <:content>
-    <PageHeader>
-      <:title>Processen</:title>
-      <:subtitle>
-        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/informatie-oph">
-          Handleiding Open Proces Huis
-        </AuLinkExternal>
-      </:subtitle>
-      <:action></:action>
-    </PageHeader>
-
-    <AuDataTable
-      @content={{this.processes}}
-      @isLoading={{this.isLoading}}
-      @page={{this.page}}
-      @size={{this.size}}
-      as |t|
-    >
-      <t.content class="au-c-data-table__table--small" as |c|>
-        <c.header>
-          <AuDataTableThSortable
-            @field="title"
-            @currentSorting={{this.sort}}
-            @label="Titel"
-          />
-          <AuDataTableThSortable
-            @field="description"
-            @currentSorting={{this.sort}}
-            @label="Beschrijving"
-          />
-          <AuDataTableThSortable
-            @field="modified"
-            @currentSorting={{this.sort}}
-            @label="Laatst aangepast op"
-          />
-          <AuDataTableThSortable
-            @field="classification"
-            @currentSorting={{this.sort}}
-            @label="Relevant voor"
-          />
-          <AuDataTableThSortable
-            @field="organization"
-            @currentSorting={{this.sort}}
-            @label="Bestuur"
-          />
-          <AuDataTableThSortable
-            @field="creator"
-            @currentSorting={{this.sort}}
-            @label="Via leverancier"
-          />
-        </c.header>
-        {{#if this.hasErrored}}
-          <TableMessage::Error />
-        {{else if this.hasNoResults}}
-          <TableMessage>
-            <p>
-              Er werden geen zoekresultaten gevonden.
-            </p>
-          </TableMessage>
-        {{else}}
-          <c.body as |process|>
-            <td>
-              <div
-                class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
-              >
-                {{#if process.isBlueprint}}
-                  <CustomIcon @icon="blueprint" @size="large" />
-                {{/if}}
-                <LinkTo
-                  class="au-c-link"
-                  @model={{process.id}}
-                  @route="processes.process"
-                >
-                  {{process.title}}
-                </LinkTo>
-              </div>
-            </td>
-            <td>
-              <span class="u-preserve-line-breaks">{{or
-                  (truncate (trim process.description) 150 true)
-                  "/"
-                }}</span>
-            </td>
-            <td>{{date-format process.modified}}</td>
-            <td>
-              <ul>
-                {{#each
-                  process.relevantAdministrativeUnits
-                  as |relevantAdministrativeUnit|
-                }}
-                  <li>{{relevantAdministrativeUnit.label}}</li>
-                {{/each}}
-              </ul>
-            </td>
-            <td>{{process.publisher.name}}</td>
-            <td>{{or process.creator.name "/"}}</td>
-          </c.body>
-        {{/if}}
-      </t.content>
-    </AuDataTable>
-  </:content>
-</SidebarContainer>
+<ProcessOverview
+  @pageTitle="Processen"
+  @processRoute="processes.process"
+  @processes={{this.processes}}
+  @isLoading={{this.isLoading}}
+  @page={{this.page}}
+  @size={{this.size}}
+  @sort={{this.sort}}
+  @hasErrored={{this.hasErrored}}
+  @hasNoResults={{this.hasNoResults}}
+  @title={{this.title}}
+  @selectedClassifications={{this.selectedClassifications}}
+  @classifications={{this.classifications}}
+  @group={{this.group}}
+  @creator={{this.creator}}
+  @blueprint={{this.blueprint}}
+  @selectedIpdcProducts={{this.selectedIpdcProducts}}
+  @resetFilters={{this.resetFilters}}
+  @setTitle={{this.setTitle}}
+  @setClassifications={{this.setClassifications}}
+  @setGroup={{this.setGroup}}
+  @setCreator={{this.setCreator}}
+  @toggleBlueprintFilter={{this.toggleBlueprintFilter}}
+  @setIpdcProducts={{this.setIpdcProducts}}
+/>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -111,11 +111,6 @@
             @label="Laatst aangepast op"
           />
           <AuDataTableThSortable
-            @field="users"
-            @currentSorting={{this.sort}}
-            @label="Gebruikt door ons"
-          />
-          <AuDataTableThSortable
             @field="classification"
             @currentSorting={{this.sort}}
             @label="Relevant voor"
@@ -165,17 +160,15 @@
             </td>
             <td>{{date-format process.modified}}</td>
             <td>
-              {{#if (this.processIsUsedBy process.users)}}
-                <AuIcon @icon="check" />
-              {{/if}}
-            </td>
-
-            <td><ul>
+              <ul>
                 {{#each
                   process.relevantAdministrativeUnits
                   as |relevantAdministrativeUnit|
-                }}<li>{{relevantAdministrativeUnit.label}}</li>
-                {{/each}}</ul></td>
+                }}
+                  <li>{{relevantAdministrativeUnit.label}}</li>
+                {{/each}}
+              </ul>
+            </td>
             <td>{{process.publisher.name}}</td>
             <td>{{or process.creator.name "/"}}</td>
           </c.body>

--- a/app/templates/processes/index.hbs
+++ b/app/templates/processes/index.hbs
@@ -2,21 +2,8 @@
   @pageTitle="Processen"
   @processRoute="processes.process"
   @model={{this.model}}
-  @page={{this.page}}
-  @size={{this.size}}
-  @sort={{this.sort}}
-  @title={{this.title}}
-  @selectedClassifications={{this.selectedClassifications}}
-  @classifications={{this.classifications}}
-  @group={{this.group}}
-  @creator={{this.creator}}
-  @blueprint={{this.blueprint}}
-  @selectedIpdcProducts={{this.selectedIpdcProducts}}
-  @resetFilters={{this.resetFilters}}
-  @setTitle={{this.setTitle}}
-  @setClassifications={{this.setClassifications}}
-  @setGroup={{this.setGroup}}
-  @setCreator={{this.setCreator}}
-  @toggleBlueprintFilter={{this.toggleBlueprintFilter}}
-  @setIpdcProducts={{this.setIpdcProducts}}
+  @filters={{this.filters}}
+  @columns={{this.columns}}
+  @query={{this.query}}
+  @onQueryChange={{this.updateQuery}}
 />

--- a/app/templates/shared-processes/index.hbs
+++ b/app/templates/shared-processes/index.hbs
@@ -1,128 +1,27 @@
-<SidebarContainer>
-  <:sidebar>
-    <div class="au-c-sidebar">
-      <div class="au-c-sidebar__content">
-        <form
-          {{on "reset" this.resetFilters}}
-          class="au-o-box au-o-box--small au-o-flow au-o-flow--small au-u-padding"
-        >
-          <h1 class="au-u-h3 au-u-medium">Filters</h1>
-          <div>
-            <AuLabel for="filter-title">Titel of beschrijving</AuLabel>
-            <ProcessSelectByTitle
-              @id="filter-title"
-              @selected={{this.title}}
-              @onChange={{this.setTitle}}
-              @publisher={{this.currentSession.group.id}}
-              class="grow"
-            />
-          </div>
-          <div class="au-u-flex au-u-flex--end">
-            <AuButton
-              @icon="cross"
-              @skin="link"
-              type="reset"
-              class="au-u-padding-none au-u-medium"
-            >
-              Herstel alle filters
-            </AuButton>
-          </div>
-        </form>
-      </div>
-    </div>
-  </:sidebar>
-  <:content>
-    <PageHeader>
-      <:title>Gedeelde processen</:title>
-      <:subtitle>
-        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/informatie-oph">
-          Handleiding Open Proces Huis
-        </AuLinkExternal>
-      </:subtitle>
-      <:action>
-        <AuButton {{on "click" this.openUploadModal}}>Voeg proces toe</AuButton>
-      </:action>
-    </PageHeader>
-
-    <AuDataTable
-      @content={{this.processes}}
-      @isLoading={{this.isLoading}}
-      @page={{this.page}}
-      @size={{this.size}}
-      as |t|
-    >
-      <t.content class="au-c-data-table__table--small" as |c|>
-        <c.header>
-          <AuDataTableThSortable
-            @field="title"
-            @currentSorting={{this.sort}}
-            @label="Titel"
-          />
-          <AuDataTableThSortable
-            @field="description"
-            @currentSorting={{this.sort}}
-            @label="Beschrijving"
-          />
-          <AuDataTableThSortable
-            @field="created"
-            @currentSorting={{this.sort}}
-            @label="Aangemaakt op"
-          />
-          <AuDataTableThSortable
-            @field="modified"
-            @currentSorting={{this.sort}}
-            @label="Laatst aangepast op"
-          />
-          <th></th>
-        </c.header>
-        {{#if this.hasErrored}}
-          <TableMessage::Error />
-        {{else if this.hasNoResults}}
-          <TableMessage>
-            <p>
-              Er werden geen zoekresultaten gevonden.
-            </p>
-          </TableMessage>
-        {{else}}
-          <c.body as |process|>
-            <td
-              class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center"
-            >
-              {{#if process.isBlueprint}}
-                <CustomIcon @icon="blueprint" @size="large" />
-              {{/if}}
-              <LinkTo
-                class="au-c-link"
-                @model={{process.id}}
-                @route="shared-processes.process"
-              >
-                {{process.title}}
-              </LinkTo>
-            </td>
-            <td>
-              <span class="u-preserve-line-breaks">{{or
-                  (truncate (trim process.description) 150 true)
-                  "/"
-                }}</span>
-            </td>
-            <td>{{date-format process.created}}</td>
-            <td>{{date-format process.modified}}</td>
-            <td>
-              <AuButton
-                @icon="bin"
-                @skin="naked"
-                @alert="true"
-                @width="block"
-                @hideText="true"
-                {{on "click" (fn this.openDeleteModal process)}}
-              >Verwijder</AuButton>
-            </td>
-          </c.body>
-        {{/if}}
-      </t.content>
-    </AuDataTable>
-  </:content>
-</SidebarContainer>
+<ProcessOverview
+  @pageTitle="Gedeelde processen"
+  @processRoute="shared-processes.process"
+  @titlePublisher={{this.currentSession.group.id}}
+  @model={{this.model}}
+  @filters={{this.filters}}
+  @columns={{this.columns}}
+  @query={{this.query}}
+  @onQueryChange={{this.updateQuery}}
+>
+  <:action>
+    <AuButton {{on "click" this.openUploadModal}}>Voeg proces toe</AuButton>
+  </:action>
+  <:rowActions as |process|>
+    <AuButton
+      @icon="bin"
+      @skin="naked"
+      @alert="true"
+      @width="block"
+      @hideText="true"
+      {{on "click" (fn this.openDeleteModal process)}}
+    >Verwijder</AuButton>
+  </:rowActions>
+</ProcessOverview>
 
 {{#if this.uploadModalOpened}}
   <Process::Wizard @onCloseModal={{this.closeUploadModal}} />


### PR DESCRIPTION
## 🗒️ Description

First off, the "Alle processen", "Processen mijn bestuur" and "Gedeelde processen" pages now share the same table+filters component. The only functionality the different controllers/routes need to take care of, is fetching the data and controlling the query params. The component does all the rest 

On top of this, a few elements have been added to align with the new design for the introduction of versioned processes:
- A filter "Laatst aangepast sinds" has been added to the "Alle processen" and "Processen mijn bestuur" pages.

<img width="261" height="82" alt="image" src="https://github.com/user-attachments/assets/3e63d6ec-e089-4afb-83bb-8ad74b2ed135" />

- If the "Laatst aangepast sinds" filter is set, *new* processes will have a "Nieuw" pill next to them. Processes are considered new when their created and modified timestamps lie within the same day.

<img width="167" height="39" alt="image" src="https://github.com/user-attachments/assets/17e5c41f-7b65-4622-9bc7-b8b66ea71ddd" />

- The "In gebruik" column has been removed in favour of a pill next to the correct processes.

<img width="302" height="38" alt="image" src="https://github.com/user-attachments/assets/d5ac9743-821e-4503-9358-6f8014fd4b65" />

- The tables on "Alle processen" and "Processen mijn bestuur" have been aligned: the same columns and the same order of columns.

> [!CAUTION]
> When the title/description filter under "Processen mijn bestuur" is used, this leads to the table showing too much records. This is a known issue that will be handled by OPH-1027.

## 🦮 How to test

1. Start the application:

```bash
ember serve --proxy https://dev.openproceshuis.lblod.info
```

2. Play with the "Alle processen", "Processen mijn bestuur" and "Gedeelde processen" pages. Pay special attention to the new filters and pills.
