### PR TITLE
Oph 991 diagram files table functionality

### DIFF
--- a/app/components/diagram-list/table.hbs
+++ b/app/components/diagram-list/table.hbs
@@ -1,21 +1,37 @@
 <AuDataTable
-  @content={{this.activeDiagrams}}
-  @fields="name created size"
+  @content={{this.diagrams.value}}
   @noDataMessage="Geen diagrammen gevonden"
+  @sort={{@sort}}
   as |row|
 >
   <row.content class="au-c-data-table__table--small" as |c|>
     <c.header>
-      <th>Bestandsnaam</th>
-      <th>Toegevoegd</th>
-      <th>Grootte</th>
-      <th>Positie</th>
+      <AuDataTableThSortable
+        @field="diagram-file.name"
+        @currentSorting={{@sort}}
+        @label="Bestandsnaam"
+      />
+      <AuDataTableThSortable
+        @field="diagram-file.created"
+        @currentSorting={{@sort}}
+        @label="Toegevoegd"
+      />
+      <AuDataTableThSortable
+        @field="diagram-file.size"
+        @currentSorting={{@sort}}
+        @label="Grootte"
+      />
+      <AuDataTableThSortable
+        @field="position"
+        @currentSorting={{@sort}}
+        @label="Positie"
+      />
       <th></th>
       <th></th>
     </c.header>
-    {{#if this.diagramsHaveErrored}}
+    {{#if this.fetchDiagrams.isError}}
       <TableMessage::Error />
-    {{else if (eq this.activeDiagrams.length 0)}}
+    {{else if this.hasNoResults}}
       <TableMessage>
         <p>Er werden geen zoekresultaten gevonden.</p>
       </TableMessage>

--- a/app/components/diagram-list/table.hbs
+++ b/app/components/diagram-list/table.hbs
@@ -1,6 +1,10 @@
 <AuDataTable
   @content={{this.diagrams.value}}
   @noDataMessage="Geen diagrammen gevonden"
+  @isLoading={{this.fetchDiagrams.isRunning}}
+  @hidePagination={{true}}
+  @page={{@page}}
+  @size={{this.size}}
   @sort={{@sort}}
   as |row|
 >
@@ -81,6 +85,10 @@
     {{/if}}
   </row.content>
 </AuDataTable>
+<Shared::TablePagination
+  @metadata={{this.diagramsTableMeta}}
+  @pageQueryParamName="diagramsPage"
+/>
 
 <File::Download
   @showAsModal={{true}}

--- a/app/components/diagram-list/table.js
+++ b/app/components/diagram-list/table.js
@@ -18,6 +18,9 @@ export default class DiagramListTable extends Component {
   @tracked fileToDownload;
   @tracked fileToDelete;
   @tracked canDeleteFile = true;
+  @tracked diagramsTableMeta = {};
+
+  size = 5;
 
   get hasNoResults() {
     return this.fetchDiagrams?.value?.length === 0;
@@ -53,9 +56,14 @@ export default class DiagramListTable extends Component {
 
     const diagrams = await this.store.query('diagram-list-item', {
       sort: this.args.sort,
+      page: {
+        number: this.args.page,
+        size: this.size,
+      },
       'filter[id]': diagramsInList.map((diagram) => diagram.id).join(','),
       'filter[diagram-file][:not:status]': ARCHIVED_STATUS_URI,
     });
+    this.diagramsTableMeta = diagrams.meta;
 
     return diagrams;
   });

--- a/app/components/diagram-list/table.js
+++ b/app/components/diagram-list/table.js
@@ -1,10 +1,13 @@
 import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 
 import { downloadFileByUrl } from 'frontend-openproceshuis/utils/file-downloader';
+import { ARCHIVED_STATUS_URI } from '../../utils/well-known-uris';
 
 export default class DiagramListTable extends Component {
   @service toaster;
@@ -16,11 +19,8 @@ export default class DiagramListTable extends Component {
   @tracked fileToDelete;
   @tracked canDeleteFile = true;
 
-  get activeDiagrams() {
-    const diagrams = this.args.diagramList.diagrams;
-    return diagrams
-      .filter((diagrams) => !diagrams.diagramFile.isArchived)
-      .sort((latest, current) => latest.position - current.position);
+  get hasNoResults() {
+    return this.fetchDiagrams?.value?.length === 0;
   }
 
   @action
@@ -43,4 +43,25 @@ export default class DiagramListTable extends Component {
       this.args.process?.id,
     );
   }
+
+  fetchDiagrams = task({ restartable: true }, async () => {
+    const diagramsInList = this.args.diagramList.diagrams;
+
+    if (diagramsInList?.length === 0) {
+      return [];
+    }
+
+    const diagrams = await this.store.query('diagram-list-item', {
+      sort: this.args.sort,
+      'filter[id]': diagramsInList.map((diagram) => diagram.id).join(','),
+      'filter[diagram-file][:not:status]': ARCHIVED_STATUS_URI,
+    });
+
+    return diagrams;
+  });
+
+  diagrams = trackedTask(this, this.fetchDiagrams, () => [
+    this.args.process,
+    this.args.sort,
+  ]);
 }

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -13,6 +13,7 @@ export default class ProcessesProcessIndexController extends Controller {
     'attachmentsSort',
     'diagramVersionsPage',
     'diagramVersionsSort',
+    'diagramsPage',
     'diagramsSort',
   ];
   @tracked attachmentsPage = 0;
@@ -20,6 +21,7 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked attachmentsSort = 'name';
   @tracked diagramVersionsPage = 0;
   @tracked diagramVersionsSort = '-created';
+  @tracked diagramsPage = 0;
   @tracked diagramsSort = 'position';
 
   @service store;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -17,7 +17,7 @@ export default class ProcessesProcessIndexController extends Controller {
     'diagramsSort',
   ];
   @tracked attachmentsPage = 0;
-  @tracked attachmentsSize = 10;
+  @tracked attachmentsSize = 5;
   @tracked attachmentsSort = 'name';
   @tracked diagramVersionsPage = 0;
   @tracked diagramVersionsSort = '-created';
@@ -93,16 +93,9 @@ export default class ProcessesProcessIndexController extends Controller {
 
     this.isWizardModalOpen = false;
 
-    this.downloadModalOpened = false;
-    this.replaceModalOpened = false;
-    this.addModalOpened = false;
-    this.deleteModalOpened = false;
-
-    this.latestDiagramAsBpmn = undefined;
-    this.latestDiagramAsSvg = undefined;
-
-    this.diagrams = undefined;
-    this.latestDiagram = undefined;
+    this.attachmentsPage = 0;
+    this.diagramVersionsPage = 0;
+    this.diagramsPage = 0;
 
     this.selectedDiagramFile = this.diagram.getFirstFileOfList(
       this.model.diagramList,

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -13,12 +13,14 @@ export default class ProcessesProcessIndexController extends Controller {
     'attachmentsSort',
     'diagramVersionsPage',
     'diagramVersionsSort',
+    'diagramsSort',
   ];
   @tracked attachmentsPage = 0;
   @tracked attachmentsSize = 10;
   @tracked attachmentsSort = 'name';
   @tracked diagramVersionsPage = 0;
   @tracked diagramVersionsSort = '-created';
+  @tracked diagramsSort = 'position';
 
   @service store;
   @service router;

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -37,6 +37,12 @@ export default class ProcessesProcessIndexRoute extends Route {
       },
     },
     {
+      diagramsPage: {
+        replace: true,
+        refreshModel: true,
+      },
+    },
+    {
       diagramsSort: {
         replace: true,
       },

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -36,6 +36,11 @@ export default class ProcessesProcessIndexRoute extends Route {
         replace: true,
       },
     },
+    {
+      diagramsSort: {
+        replace: true,
+      },
+    },
   ];
 
   beforeModel(transition) {

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -81,6 +81,7 @@
           @selectedDiagramFile={{this.selectedDiagramFile}}
           @onDiagramFileSelected={{this.openDiagramFile}}
           @process={{@model.process}}
+          @sort={{this.diagramsSort}}
         />
       </div>
       <div class="au-o-box au-u-background-gray-100">

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -81,6 +81,7 @@
           @selectedDiagramFile={{this.selectedDiagramFile}}
           @onDiagramFileSelected={{this.openDiagramFile}}
           @process={{@model.process}}
+          @page={{this.diagramsPage}}
           @sort={{this.diagramsSort}}
         />
       </div>


### PR DESCRIPTION
## 🗒️ Description
We want the process diagrams table to be sorted and paginated 

## 🦮 How to test

1. max of 5 files are shown in the table
2. can paginate for other files
3. can download single file
4. can go to detail page
5. can sort on columns

## 🔗 Links to other PR's

- **BASE** https://github.com/lblod/frontend-openproceshuis/pull/205

## 🖼️ Attachments

<img width="1511" height="359" alt="image" src="https://github.com/user-attachments/assets/a474ee42-cbb9-46a7-a630-099f013cd966" />

