### PR TITLE
OPH-1016 | add visio downloads property to download tracking

### DIFF
--- a/app/models/process-statistic.js
+++ b/app/models/process-statistic.js
@@ -5,6 +5,7 @@ export default class ProcessStatisticModel extends Model {
   @attr('number', { defaultValue: 0 }) pngDownloads;
   @attr('number', { defaultValue: 0 }) svgDownloads;
   @attr('number', { defaultValue: 0 }) bpmnDownloads;
+  @attr('number', { defaultValue: 0 }) visioDownloads;
   @attr('number', { defaultValue: 0 }) processViews;
 
   @belongsTo('process', { inverse: 'processStatistics', async: false }) process;

--- a/app/services/event-tracking.js
+++ b/app/services/event-tracking.js
@@ -51,6 +51,9 @@ export default class EventTrackingService extends Service {
           case 'svg':
             stats.svgDownloads += 1;
             break;
+          case 'vsdx':
+            stats.visioDownloads += 1;
+            break;
           default:
             console.error('fileExtension', targetExtension, 'not recognized');
             return;


### PR DESCRIPTION
## 🗒️ Description

We did not track visio files yet in the frontend, now we do. The resource model was already in place :/

## 🦮 How to test

1. Download a vsdx file and see if the increment gets triggered

## 🔗 Links to other PR's

- https://github.com/lblod/app-openproceshuis/pull/138

## 🖼️ Attachments

<img width="1462" height="815" alt="image" src="https://github.com/user-attachments/assets/418dc153-0cdf-4991-9158-e5b36f85b9db" />

