### PR TITLE
Update "Laatst aangepast sinds" filter label

### DIFF
--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -33,7 +33,9 @@
           {{/if}}
           {{#if this.showModifiedSinceFilter}}
             <div>
-              <AuLabel for="filter-modified-since">Laatst aangepast sinds</AuLabel>
+              <AuLabel for="filter-modified-since">
+                Laatst aangepast of nieuw sinds
+              </AuLabel>
               <AuDateInput
                 @id="filter-modified-since"
                 @value={{this.modifiedSince}}


### PR DESCRIPTION
## 🗒️ Description

Having only "Laatst aangepast sinds" as label for the corresponding filter, wasn't clear enough. This PR updates the label to "Laatst aangepast of nieuw sinds".