### PR TITLE
OPH-1035 | diagram table pagination is off

### DIFF
--- a/app/components/diagram-list/table.hbs
+++ b/app/components/diagram-list/table.hbs
@@ -1,6 +1,6 @@
 <AuDataTable
   @content={{this.diagrams.value}}
-  @noDataMessage="Geen diagrammen gevonden"
+  @noDataMessage="Er werden geen diagrammen gevonden"
   @isLoading={{this.fetchDiagrams.isRunning}}
   @hidePagination={{true}}
   @page={{@page}}

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -54,6 +54,7 @@
     <AuDataTable
       @content={{this.attachments.value}}
       @isLoading={{this.fetchAttachments.isRunning}}
+      @noDataMessage="Er werden geen bijlagen gevonden"
       @hidePagination={{true}}
       @page={{@page}}
       @size={{@size}}

--- a/app/components/process/diagram/version.hbs
+++ b/app/components/process/diagram/version.hbs
@@ -11,6 +11,7 @@
     <AuDataTable
       @content={{this.versions.value}}
       @isLoading={{this.fetchVersions.isRunning}}
+      @noDataMessage="Er werden geen versies gevonden"
       @hidePagination={{true}}
       @page={{@page}}
       @size={{this.size}}

--- a/app/components/shared/table-pagination.js
+++ b/app/components/shared/table-pagination.js
@@ -9,17 +9,21 @@ export default class SharedTablePagination extends Component {
   get page() {
     const multiplierItems = this.currentPage + 1;
     let topItems = multiplierItems * this.itemsPerPage;
-    const bottomItems = topItems - this.itemsPerPage;
+    let bottomItems = topItems - this.itemsPerPage;
 
     if (topItems > this.totalItems) {
       topItems = this.totalItems;
+    }
+
+    if (this.totalItems !== 0) {
+      bottomItems++;
     }
 
     return `${bottomItems} - ${topItems}`;
   }
 
   get totalItems() {
-    return this.args.metadata?.count || null;
+    return this.args.metadata?.count || 0;
   }
 
   get currentPage() {


### PR DESCRIPTION
## 🗒️ Description

We should always start with bottom number 1 instead of zero. This way users do not think there are more items in the table than they are viewing.

## 🦮 How to test
1. Go tot a process detail page with more than 5 diagrams (activates the volgende button)
2. See that the first page will be 1-5 and after that 6 - X
3. When no items are found in the tables a message is shown
4. Also when no items in table the value is not `0 - null` in the pagination

## 🖼️ Attachments

**page 1**
<img width="1911" height="491" alt="image" src="https://github.com/user-attachments/assets/1f39b300-ad94-438c-9b31-a35589e268b5" />

**page 2**
<img width="1897" height="420" alt="image" src="https://github.com/user-attachments/assets/654e983a-5941-4ada-9ecc-a48dbfc712a1" />


<img width="1916" height="699" alt="image" src="https://github.com/user-attachments/assets/4608d9bd-6599-4d2b-bc95-ad17f39a6449" />

