### PR TITLE
OPH-1020 | Compare diagrams section with version

### DIFF
--- a/app/components/process/status-with-versioned.hbs
+++ b/app/components/process/status-with-versioned.hbs
@@ -1,0 +1,14 @@
+{{#if @isShown}}
+  {{#unless (eq this.countOfCurrent 0)}}
+    <AuPill @skin="success">
+      {{this.postfixAdded}}
+      toegevoegd
+    </AuPill>
+  {{/unless}}
+  {{#unless (eq this.countOfVersioned 0)}}
+    <AuPill @skin="error">
+      {{this.postfixRemoved}}
+      verwijderd
+    </AuPill>
+  {{/unless}}
+{{/if}}

--- a/app/components/process/status-with-versioned.js
+++ b/app/components/process/status-with-versioned.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+
+export default class ProcessStatusWithVersioned extends Component {
+  get postfixAdded() {
+    return `${this.countOfCurrent} diagram${this.countOfCurrent === 1 ? '' : 'men'}`;
+  }
+  get postfixRemoved() {
+    return `${this.countOfVersioned} diagram${this.countOfVersioned === 1 ? '' : 'men'}`;
+  }
+
+  get countOfCurrent() {
+    return this.args.countOfCurrent || 0;
+  }
+
+  get countOfVersioned() {
+    return this.args.countOfVersioned || 0;
+  }
+}

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -45,7 +45,12 @@ export default class ProcessesProcessIndexController extends Controller {
   loadVersionedProcess = restartableTask(async (versionId) => {
     this.versionedProcess = versionId
       ? await this.store.findRecord('versioned-process', versionId, {
-          include: ['ipdc-products', 'relevant-administrative-units'].join(','),
+          include: [
+            'ipdc-products',
+            'relevant-administrative-units',
+            'diagram-lists',
+            'diagram-lists.diagrams',
+          ].join(','),
         })
       : null;
   });

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -37,7 +37,8 @@
           {{date-format this.process.modified true}}
         </AuPill>
         <div class="au-u-flex au-u-flex--row">
-          <AuLabel class="au-u-margin-right-small au-u-margin-bottom-none">Toon verschillen met</AuLabel>
+          <AuLabel class="au-u-margin-right-small au-u-margin-bottom-none">Toon
+            verschillen met</AuLabel>
           <Process::VersionSelector
             @process={{@model.process}}
             @selectedVersion={{this.versionedProcess}}
@@ -64,7 +65,18 @@
 
   <span>
     <div class="au-u-flex au-u-flex--between au-u-margin-bottom-small">
-      <AuHeading @level="2" @skin="3">Diagrammen</AuHeading>
+      <AuHeading @level="2" @skin="3">Diagrammen
+
+        <Process::StatusWithVersioned
+          @isShown={{this.versionedProcess}}
+          @countOfVersioned={{get
+            (get this.versionedProcess.diagramLists "0")
+            "diagrams.length"
+          }}
+          @countOfCurrent={{@model.diagramList.diagrams.length}}
+        />
+
+      </AuHeading>
       <AuButtonGroup>
         <File::DownloadMultipleAsZip
           @buttonLabel="Download alle"


### PR DESCRIPTION
## 🗒️ Description

As we already did for the general info we also want to show whats different between the current and the selected version for the diagrams section.

- status pill with added + removed

## 🦮 How to test

1. create a new version for the process by uploading new diagrams
2. When selecting the comparison of the process, the amount of added file should be visible depending on the amount that was removed

## 🔗 Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/210 **BASE**

## 🖼️ Attachments

<img width="1475" height="1015" alt="image" src="https://github.com/user-attachments/assets/ea9ada5f-50cb-4db9-a4f2-a156996fd9d4" />

