### PR TITLE
Don't require admin role for editing ICR assets

### DIFF
--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -39,8 +39,7 @@ export default class InformationAssetsInformationAssetController extends Control
     return (
       this.currentSession.canEdit &&
       this.currentSession.group &&
-      this.currentSession.isAbbOrDv &&
-      this.currentSession.isAdmin
+      this.currentSession.isAbbOrDv
     );
   }
 


### PR DESCRIPTION
## 🗒️ Description

This is a bugfix. Before, ABB/DV and admin role was required to edit ICR data. This was wrong: only ABB/DV should be required. This has now been fixed.