### PR TITLE
Oph 1021 compare icr on process with selected version

### DIFF
--- a/app/components/process/blueprint-card.hbs
+++ b/app/components/process/blueprint-card.hbs
@@ -59,19 +59,28 @@
           <Item>
             <:label>Gekoppeld aan</:label>
             <:content>
-              {{#if (gt this.linkedBlueprints.length 0)}}
-                <ul>
-                  {{#each this.linkedBlueprints as |blueprint|}}
-                    <li>
-                      <AuLinkExternal @newTab={{true}} href={{blueprint.href}}>
-                        {{blueprint.title}}
-                      </AuLinkExternal>
-                    </li>
-                  {{/each}}
-                </ul>
-              {{else}}
-                <p>/</p>
-              {{/if}}
+              <Shared::TextCompare
+                @current={{this.linkedBlueprints}}
+                @old={{this.versionedLinkedBlueprints}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                {{#if (gt this.linkedBlueprints.length 0)}}
+                  <ul>
+                    {{#each this.linkedBlueprints as |blueprint|}}
+                      <li>
+                        <AuLinkExternal
+                          @newTab={{true}}
+                          href={{blueprint.href}}
+                        >
+                          {{blueprint.title}}
+                        </AuLinkExternal>
+                      </li>
+                    {{/each}}
+                  </ul>
+                {{else}}
+                  <p>/</p>
+                {{/if}}
+              </Shared::TextCompare>
             </:content>
           </Item>
         </:left>

--- a/app/components/process/blueprint-card.js
+++ b/app/components/process/blueprint-card.js
@@ -14,6 +14,10 @@ export default class ProcessBlueprintCardComponent extends Component {
     return this.args.process.linkedBlueprints || [];
   }
 
+  get versionedLinkedBlueprints() {
+    return this.args.versionedProcess?.linkedBlueprints || [];
+  }
+
   @action
   toggleEdit() {
     this.edit = !this.edit;

--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -87,84 +87,128 @@
           <Item>
             <:label>Beschikbaarheid</:label>
             <:content>
-              <Process::IcrCard::Score
-                @selectedScore={{this.availabilityScore}}
-              />
+              <Shared::TextCompare
+                @current={{this.availabilityScore}}
+                @old={{this.versionedScores.availabilityScore}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                <Process::IcrCard::Score
+                  @selectedScore={{this.availabilityScore}}
+                />
+              </Shared::TextCompare>
             </:content>
           </Item>
           <Item>
             <:label>Integriteit</:label>
             <:content>
-              <Process::IcrCard::Score @selectedScore={{this.integrityScore}} />
+              <Shared::TextCompare
+                @current={{this.integrityScore}}
+                @old={{this.versionedScores.integrityScore}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                <Process::IcrCard::Score
+                  @selectedScore={{this.integrityScore}}
+                />
+              </Shared::TextCompare>
             </:content>
           </Item>
           <Item>
             <:label>Vertrouwelijkheid</:label>
             <:content>
-              <Process::IcrCard::Score
-                @selectedScore={{this.confidentialityScore}}
-              />
+              <Shared::TextCompare
+                @current={{this.confidentialityScore}}
+                @old={{this.versionedScores.confidentialityScore}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                <Process::IcrCard::Score
+                  @selectedScore={{this.confidentialityScore}}
+                />
+              </Shared::TextCompare>
             </:content>
           </Item>
           <Item>
             <:label>Persoonsgegevens</:label>
             <:content>
               <div class="au-u-flex au-u-flex--column au-u-flex--spaced-small">
-                <AuCheckbox
-                  @checked={{this.containsPersonalData}}
-                  @disabled="true"
-                >
-                  <label for="contains-personal-data">Professionele gegevens</label>
-                  <Shared::Tooltip
-                    @show={{true}}
-                    @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
-                    @placement="top"
+                <div class="width-full">
+                  <Shared::TextCompare
+                    @current={{this.containsPersonalData}}
+                    @old={{this.versionedScores.containsPersonalData}}
+                    @enableHighlighting={{if @versionedProcess true}}
                   >
-                    <AuIcon
-                      class="color--info"
-                      @icon="circle-question"
-                      @size="large"
-                      @alignment="right"
-                    />
-                  </Shared::Tooltip>
-                </AuCheckbox>
-                <AuCheckbox
-                  @checked={{this.containsProfessionalData}}
-                  @disabled="true"
-                >
-                  <label
-                    for="contains-professional-data"
-                  >Persoonsgegevens</label>
-                  <Shared::Tooltip
-                    @show={{true}}
-                    @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
+                    <AuCheckbox
+                      @checked={{this.containsPersonalData}}
+                      @disabled="true"
+                    >
+                      <label for="contains-personal-data">Professionele gegevens</label>
+                      <Shared::Tooltip
+                        @show={{true}}
+                        @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
+                        @placement="top"
+                      >
+                        <AuIcon
+                          class="color--info"
+                          @icon="circle-question"
+                          @size="large"
+                          @alignment="right"
+                        />
+                      </Shared::Tooltip>
+                    </AuCheckbox>
+                  </Shared::TextCompare>
+                </div>
+                <div class="width-full">
+                  <Shared::TextCompare
+                    @current={{this.containsProfessionalData}}
+                    @old={{this.versionedScores.containsProfessionalData}}
+                    @enableHighlighting={{if @versionedProcess true}}
                   >
-                    <AuIcon
-                      class="color--info"
-                      @icon="circle-question"
-                      @size="large"
-                      @alignment="right"
-                    />
-                  </Shared::Tooltip>
-                </AuCheckbox>
-                <AuCheckbox
-                  @checked={{this.containsSensitivePersonalData}}
-                  @disabled="true"
-                >
-                  <label for="contains-sensitive-personal-data">Bijzondere
-                    persoonsgegevens</label>
-                  <Shared::Tooltip
-                    @show={{true}}
-                    @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
+                    <AuCheckbox
+                      @checked={{this.containsProfessionalData}}
+                      @disabled="true"
+                    >
+                      <label
+                        for="contains-professional-data"
+                      >Persoonsgegevens</label>
+                      <Shared::Tooltip
+                        @show={{true}}
+                        @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
+                      >
+                        <AuIcon
+                          class="color--info"
+                          @icon="circle-question"
+                          @size="large"
+                          @alignment="right"
+                        />
+                      </Shared::Tooltip>
+                    </AuCheckbox>
+                  </Shared::TextCompare>
+                </div>
+                <div class="width-full">
+                  <Shared::TextCompare
+                    @current={{this.containsSensitivePersonalData}}
+                    @old={{this.versionedScores.containsSensitivePersonalData}}
+                    @enableHighlighting={{if @versionedProcess true}}
                   >
-                    <AuIcon
-                      class="color--info"
-                      @icon="circle-question"
-                      @size="large"
-                      @alignment="right"
-                    />
-                  </Shared::Tooltip>
-                </AuCheckbox>
+                    <AuCheckbox
+                      @checked={{this.containsSensitivePersonalData}}
+                      @disabled="true"
+                    >
+                      <label for="contains-sensitive-personal-data">Bijzondere
+                        persoonsgegevens</label>
+                      <Shared::Tooltip
+                        @show={{true}}
+                        @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
+                      >
+                        <AuIcon
+                          class="color--info"
+                          @icon="circle-question"
+                          @size="large"
+                          @alignment="right"
+                        />
+                      </Shared::Tooltip>
+                    </AuCheckbox>
+                  </Shared::TextCompare>
+                </div>
               </div>
             </:content>
           </Item>
@@ -173,64 +217,88 @@
           <Item>
             <:label>Informatieassets</:label>
             <:content>
-              {{#if @process.informationAssets.length}}
-                <div class="au-u-flex au-u-flex--wrap au-u-flex--spaced-tiny">
-                  {{#each @process.informationAssets as |asset|}}
-                    {{#if (not-eq asset.status this.archivedUri)}}
-                      <AuPill
-                        class="pointer information-asset-pill"
-                        {{on "click" (fn this.editAsset asset)}}
-                      >
-                        {{asset.title}}
-                        {{#if @canEdit}}
-                          <AuIcon @icon="pencil" />
-                        {{/if}}
-                      </AuPill>
-                    {{/if}}
-                  {{/each}}
-                </div>
-              {{else}}
-                /
-              {{/if}}
+              <Shared::TextCompare
+                @current={{@process.informationAssets}}
+                @old={{@versionedProcess.informationAssets}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                {{#if @process.informationAssets.length}}
+                  <div class="au-u-flex au-u-flex--wrap au-u-flex--spaced-tiny">
+                    {{#each @process.informationAssets as |asset|}}
+                      {{#if (not-eq asset.status this.archivedUri)}}
+                        <AuPill
+                          class="pointer information-asset-pill"
+                          {{on "click" (fn this.editAsset asset)}}
+                        >
+                          {{asset.title}}
+                          {{#if @canEdit}}
+                            <AuIcon @icon="pencil" />
+                          {{/if}}
+                        </AuPill>
+                      {{/if}}
+                    {{/each}}
+                  </div>
+                {{else}}
+                  /
+                {{/if}}
+              </Shared::TextCompare>
             </:content>
           </Item>
           <Item>
             <:label>Motivering of bijkomende informatie</:label>
             <:content>
-              <span class="u-preserve-line-breaks">{{or
-                  (trim @process.additionalInformation)
-                  "/"
-                }}</span>
+              <Shared::TextCompare
+                @current={{@process.additionalInformation}}
+                @old={{@versionedProcess.additionalInformation}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                <span class="u-preserve-line-breaks">{{or
+                    (trim @process.additionalInformation)
+                    "/"
+                  }}</span>
+              </Shared::TextCompare>
             </:content>
           </Item>
           <Item>
             <:label>Link naar maatregelen</:label>
             <:content>
-              {{#if @process.hasControlMeasure}}
-                <AuLinkExternal href="{{@process.hasControlMeasure}}">
-                  {{@process.hasControlMeasure}}
-                </AuLinkExternal>
-              {{else}}
-                /
-              {{/if}}
+              <Shared::TextCompare
+                @current={{@process.hasControlMeasure}}
+                @old={{@versionedProcess.hasControlMeasure}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                {{#if @process.hasControlMeasure}}
+                  <AuLinkExternal href="{{@process.hasControlMeasure}}">
+                    {{@process.hasControlMeasure}}
+                  </AuLinkExternal>
+                {{else}}
+                  /
+                {{/if}}
+              </Shared::TextCompare>
             </:content>
           </Item>
           <Item>
             <:label>Gekoppeld aan</:label>
             <:content>
-              {{#if (gt this.blueprintUsages.length 0)}}
-                <ul>
-                  {{#each this.blueprintUsages as |usage|}}
-                    <li>
-                      <AuLinkExternal @newTab={{true}} href={{usage.href}}>
-                        {{usage.title}}
-                      </AuLinkExternal>
-                    </li>
-                  {{/each}}
-                </ul>
-              {{else}}
-                <p>/</p>
-              {{/if}}
+              <Shared::TextCompare
+                @current={{this.blueprintUsages}}
+                @old={{this.versionedBlueprintUsages}}
+                @enableHighlighting={{if @versionedProcess true}}
+              >
+                {{#if (gt this.blueprintUsages.length 0)}}
+                  <ul>
+                    {{#each this.blueprintUsages as |usage|}}
+                      <li>
+                        <AuLinkExternal @newTab={{true}} href={{usage.href}}>
+                          {{usage.title}}
+                        </AuLinkExternal>
+                      </li>
+                    {{/each}}
+                  </ul>
+                {{else}}
+                  <p>/</p>
+                {{/if}}
+              </Shared::TextCompare>
             </:content>
           </Item>
         </:right>

--- a/app/components/process/icr-card.js
+++ b/app/components/process/icr-card.js
@@ -17,6 +17,7 @@ export default class ProcessIcrCardComponent extends Component {
 
   @tracked informationAssets = [];
   @tracked blueprintUsages = A([]);
+  @tracked versionedBlueprintUsages = A([]);
 
   @tracked edit = false;
   @tracked formIsValid = false;
@@ -31,9 +32,19 @@ export default class ProcessIcrCardComponent extends Component {
       this.store
         .query('process', {
           'filter[linked-blueprints][id]': this.args.process.id,
+          'filter[:not:is-versioned-resource]': true,
         })
         .then((processes) => {
           this.blueprintUsages.pushObjects(processes);
+        });
+    }
+    if (this.args.versionedProcess?.isBlueprint) {
+      this.store
+        .query('versioned-process', {
+          'filter[linked-blueprints][id]': this.args.versionedProcess.id,
+        })
+        .then((processes) => {
+          this.versionedBlueprintUsages.pushObjects(processes);
         });
     }
   }
@@ -80,6 +91,34 @@ export default class ProcessIcrCardComponent extends Component {
     return this.args.process.informationAssets.some(
       (asset) => asset.containsSensitivePersonalData,
     );
+  }
+
+  get versionedScores() {
+    if (!this.args.versionedProcess) {
+      return {};
+    }
+
+    const versionedAssets = this.args.versionedProcess.informationAssets || [];
+    return {
+      confidentialityScore: Math.max(
+        ...versionedAssets.map((asset) => asset.confidentialityScore),
+      ),
+      integrityScore: Math.max(
+        ...versionedAssets.map((asset) => asset.integrityScore),
+      ),
+      availabilityScore: Math.max(
+        ...versionedAssets.map((asset) => asset.availabilityScore),
+      ),
+      containsPersonalData: versionedAssets.some(
+        (asset) => asset.containsPersonalData,
+      ),
+      containsProfessionalData: versionedAssets.some(
+        (asset) => asset.containsProfessionalData,
+      ),
+      containsSensitivePersonalData: versionedAssets.some(
+        (asset) => asset.containsSensitivePersonalData,
+      ),
+    };
   }
 
   @action editAsset(asset) {

--- a/app/components/shared/text-compare.js
+++ b/app/components/shared/text-compare.js
@@ -8,7 +8,11 @@ export default class SharedTextCompared extends Component {
 
     if (Array.isArray(old) && Array.isArray(current)) {
       if (old.length !== current.length) return true;
-      return old.some((item, index) => item.id !== current[index].id);
+      return old.some((item) =>
+        current.find((currentItem) => {
+          return currentItem.id !== item.id;
+        }),
+      );
     }
 
     return old !== current;

--- a/app/components/shared/text-compare.js
+++ b/app/components/shared/text-compare.js
@@ -8,11 +8,10 @@ export default class SharedTextCompared extends Component {
 
     if (Array.isArray(old) && Array.isArray(current)) {
       if (old.length !== current.length) return true;
-      return old.some((item) =>
-        current.find((currentItem) => {
-          return currentItem.id !== item.id;
-        }),
-      );
+      return old.some((item) => {
+        const index = current.indexOf(item);
+        return index === -1;
+      });
     }
 
     return old !== current;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -53,6 +53,7 @@ export default class ProcessesProcessIndexController extends Controller {
             'linked-concept',
             'linked-concept.process-groups.process-domains',
             'linked-concept.process-groups.process-domains.process-categories',
+            'linked-blueprints',
           ].join(','),
         })
       : null;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -54,6 +54,7 @@ export default class ProcessesProcessIndexController extends Controller {
             'linked-concept.process-groups.process-domains',
             'linked-concept.process-groups.process-domains.process-categories',
             'linked-blueprints',
+            'information-assets',
           ].join(','),
         })
       : null;

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -56,7 +56,7 @@ export default class ProcessModel extends Model {
   informationAssets;
   @hasMany('process', {
     inverse: 'linkedBlueprints',
-    async: true,
+    async: false,
     polymorphic: true,
     as: 'process',
   })

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -69,6 +69,7 @@ export default class ProcessesProcessIndexRoute extends Route {
         'linked-concept.process-groups.process-domains',
         'linked-concept.process-groups.process-domains.process-categories',
         'relevant-administrative-units',
+        'linked-blueprints',
       ].join(','),
       reload: true,
     });

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -237,3 +237,9 @@ tr:hover .inventory-row-button-group .au-c-button {
     fill: var(--au-green-700) !important;
   }
 }
+
+.icr-score {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -129,7 +129,11 @@
   </span>
 
   {{#if (and this.process.isBlueprint this.process.isPublishedByAbbOrDv)}}
-    <Process::IcrCard @canEdit={{this.canEdit}} @process={{this.process}} />
+    <Process::IcrCard
+      @canEdit={{this.canEdit}}
+      @process={{this.process}}
+      @versionedProcess={{this.versionedProcess}}
+    />
   {{else}}
     <Process::BlueprintCard
       @canEdit={{this.canEdit}}

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -134,6 +134,7 @@
     <Process::BlueprintCard
       @canEdit={{this.canEdit}}
       @process={{this.process}}
+      @versionedProcess={{this.versionedProcess}}
     />
   {{/if}}
 


### PR DESCRIPTION
## 🗒️ Description

We want to compare the values of the process ICR with a previous version.

## 🦮 How to test

1. start with a new process and select the blauwdruk checkbox
2. Add an ICR asset to the process
3. The history should show all yellow as this is new to the process
4. Add a second ICR to the process
5. When looking back in the history only the differences should be made yellow in the UI 

## 🔗 Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/210 **base**

## 🖼️ Attachments

Started from asset 1 i added a second asset where the scores where different to get this result
<img width="1483" height="475" alt="image" src="https://github.com/user-attachments/assets/7143da91-fee3-4fbc-9321-105d764be34c" />

