### PR TITLE
fix: the diagram versioned pills should only show when they diverge

### DIFF
--- a/app/components/process/status-with-versioned.hbs
+++ b/app/components/process/status-with-versioned.hbs
@@ -1,4 +1,4 @@
-{{#if @isShown}}
+{{#if (and @isShown this.isListDiverging)}}
   {{#unless (eq this.countOfCurrent 0)}}
     <AuPill @skin="success">
       {{this.postfixAdded}}

--- a/app/components/process/status-with-versioned.js
+++ b/app/components/process/status-with-versioned.js
@@ -9,10 +9,20 @@ export default class ProcessStatusWithVersioned extends Component {
   }
 
   get countOfCurrent() {
-    return this.args.countOfCurrent || 0;
+    return this.args.currentDiagrams?.length || 0;
   }
 
   get countOfVersioned() {
-    return this.args.countOfVersioned || 0;
+    return this.args.versionedDiagrams?.length || 0;
+  }
+
+  get isListDiverging() {
+    const versions = this.args.versionedDiagrams || [];
+    const current = this.args.currentDiagrams || [];
+
+    return versions.some((item) => {
+      const index = current.indexOf(item);
+      return index === -1;
+    });
   }
 }

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -46,6 +46,7 @@ export default class ProcessesProcessIndexController extends Controller {
   loadVersionedProcess = restartableTask(async (versionId) => {
     this.versionedProcess = versionId
       ? await this.store.findRecord('versioned-process', versionId, {
+          reload: true,
           include: [
             'ipdc-products',
             'relevant-administrative-units',

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -34,6 +34,7 @@ export default class ProcessesProcessIndexController extends Controller {
   @service eventTracking;
 
   @tracked versionedProcess = null;
+  @tracked versionedDiagrams = [];
   @tracked isEditingDetails = false;
   @tracked selectedDiagramFile;
   @tracked isWizardModalOpen;
@@ -58,6 +59,8 @@ export default class ProcessesProcessIndexController extends Controller {
           ].join(','),
         })
       : null;
+    this.versionedDiagrams =
+      (await this.versionedProcess?.diagramLists?.[0]?.diagrams) ?? [];
   });
 
   get canEdit() {

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -68,16 +68,11 @@
   <span>
     <div class="au-u-flex au-u-flex--between au-u-margin-bottom-small">
       <AuHeading @level="2" @skin="3">Diagrammen
-
         <Process::StatusWithVersioned
           @isShown={{this.versionedProcess}}
-          @countOfVersioned={{get
-            (get this.versionedProcess.diagramLists "0")
-            "diagrams.length"
-          }}
-          @countOfCurrent={{@model.diagramList.diagrams.length}}
+          @versionedDiagrams={{this.versionedDiagrams}}
+          @currentDiagrams={{@model.diagramList.diagrams}}
         />
-
       </AuHeading>
       <AuButtonGroup>
         <File::DownloadMultipleAsZip


### PR DESCRIPTION
## 🗒️ Description
The diagram count check is not correct as when i just edit the title of the process it should not show the status pills.

## 🦮 How to test

1. create a process
2. edit a title 
3. upload new diagrams
4. edit the description of the process

The diagram version pills should only show when the process diagrams changed not in the upcoming updates

## 🔗 Links to other PR's

- https://github.com/lblod/frontend-openproceshuis/pull/210

## 🖼️ Attachments

<img width="794" height="121" alt="image" src="https://github.com/user-attachments/assets/23ba4f61-73c4-461e-9845-e8e37eee703c" />
