### PR TITLE
OPH-1049 | Archived resources cannot be visited through the frontend

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -43,7 +43,6 @@ Router.map(function () {
   this.route('shared-processes', { path: 'gedeelde-processen' }, function () {
     this.route('process', { path: '/:id/' }, function () {
       this.route('index', { path: '' });
-      this.route('diagrams', { path: 'diagrammen' });
     });
   });
 
@@ -53,7 +52,6 @@ Router.map(function () {
     function () {
       this.route('process', { path: '/:id/' }, function () {
         this.route('index', { path: '' });
-        this.route('diagrams', { path: 'diagrammen' });
       });
     },
   );

--- a/app/routes/diagrams/diagram/index.js
+++ b/app/routes/diagrams/diagram/index.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 export default class DiagramsDiagramIndexRoute extends Route {
   @service session;
   @service store;
+  @service router;
 
   queryParams = [
     { previousRouteTitle: { refreshModel: false } },
@@ -22,6 +23,11 @@ export default class DiagramsDiagramIndexRoute extends Route {
       include: ['diagram-file', 'sub-items'].join(','),
       reload: true,
     });
+
+    if (diagram.isArchived || diagram.diagramFile?.isArchived) {
+      this.router.replaceWith('not-found');
+    }
+
     const processes = await this.store.query('process', {
       'filter[diagram-lists][diagrams][id]': diagram.id,
       reload: true,

--- a/app/routes/diagrams/diagram/index.js
+++ b/app/routes/diagrams/diagram/index.js
@@ -5,7 +5,6 @@ import { service } from '@ember/service';
 export default class DiagramsDiagramIndexRoute extends Route {
   @service session;
   @service store;
-  @service router;
 
   queryParams = [
     { previousRouteTitle: { refreshModel: false } },
@@ -25,7 +24,9 @@ export default class DiagramsDiagramIndexRoute extends Route {
     });
 
     if (diagram.isArchived || diagram.diagramFile?.isArchived) {
-      this.router.replaceWith('not-found');
+      throw new Error(
+        'Dit diagram is verwijderd en kan niet meer bekeken worden.',
+      );
     }
 
     const processes = await this.store.query('process', {

--- a/app/routes/information-assets/information-asset.js
+++ b/app/routes/information-assets/information-asset.js
@@ -29,6 +29,10 @@ export default class InformationAssetsInformationAssetRoute extends Route {
       await this.redirectToCanonical(canonicalAssetId, params);
     }
 
+    if (canonicalAsset.isArchived) {
+      this.router.replaceWith('not-found');
+    }
+
     let versionedAsset;
     if (versionedAssetId) {
       versionedAsset = await this.fetchVersionedAsset(versionedAssetId);

--- a/app/routes/information-assets/information-asset.js
+++ b/app/routes/information-assets/information-asset.js
@@ -30,7 +30,9 @@ export default class InformationAssetsInformationAssetRoute extends Route {
     }
 
     if (canonicalAsset.isArchived) {
-      this.router.replaceWith('not-found');
+      throw new Error(
+        'Deze informatie asset is verwijderd en kan niet meer bekeken worden.',
+      );
     }
 
     let versionedAsset;

--- a/app/routes/my-local-government/process/diagrams.js
+++ b/app/routes/my-local-government/process/diagrams.js
@@ -1,3 +1,0 @@
-import ProcessesProcessDiagramsRoute from '../../processes/process/diagrams';
-
-export default class MyLocalGovernmentProcessDiagramsRoute extends ProcessesProcessDiagramsRoute {}

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -79,6 +79,11 @@ export default class ProcessesProcessIndexRoute extends Route {
       ].join(','),
       reload: true,
     });
+
+    if (process.isArchived) {
+      this.router.replaceWith('not-found');
+    }
+
     let stats = process.processStatistics;
     if (!stats) {
       stats = this.store.createRecord('process-statistic', {

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -81,7 +81,9 @@ export default class ProcessesProcessIndexRoute extends Route {
     });
 
     if (process.isArchived) {
-      this.router.replaceWith('not-found');
+      throw new Error(
+        'Dit process is verwijderd en kan niet meer bekeken worden.',
+      );
     }
 
     let stats = process.processStatistics;

--- a/app/routes/shared-processes/process/diagrams.js
+++ b/app/routes/shared-processes/process/diagrams.js
@@ -1,3 +1,0 @@
-import ProcessesProcessDiagramsRoute from '../../processes/process/diagrams';
-
-export default class SharedProcessesProcessDiagramsRoute extends ProcessesProcessDiagramsRoute {}

--- a/app/templates/my-local-government/error.hbs
+++ b/app/templates/my-local-government/error.hbs
@@ -1,0 +1,10 @@
+{{page-title "Process niet gevonden"}}
+
+<LayoutDetail>
+  <Oops
+    @title="Het lijkt erop dat het proces waarnaar je zoekt niet bestaat of niet meer beschikbaar is."
+    @content="Controleer even of je de juiste link gebruikt of neem contact op met de beheerder indien je denkt dat dit een fout is."
+    @image="/assets/images/page-not-found.svg"
+  />
+  {{outlet}}
+</LayoutDetail>

--- a/app/templates/shared-processes/error.hbs
+++ b/app/templates/shared-processes/error.hbs
@@ -1,0 +1,10 @@
+{{page-title "Process niet gevonden"}}
+
+<LayoutDetail>
+  <Oops
+    @title="Het lijkt erop dat het proces waarnaar je zoekt niet bestaat of niet meer beschikbaar is."
+    @content="Controleer even of je de juiste link gebruikt of neem contact op met de beheerder indien je denkt dat dit een fout is."
+    @image="/assets/images/page-not-found.svg"
+  />
+  {{outlet}}
+</LayoutDetail>


### PR DESCRIPTION
## 🗒️ Description
Now when routing to a process that is archived the process page is still shown as normal. We should block this and show a not found page.

## 🦮 How to test

1. Create a process, information asset (diagram list item)
2. Save the url's to the models
3. Archive all of them
4. Try to go back to these pages
5. For diagram list item it will show the not found page when the diagramlist item is archived or if the file itself gets archived 

## 🖼️ Attachments

<img width="1317" height="570" alt="image" src="https://github.com/user-attachments/assets/9272a175-b5f5-4f4e-8ca9-49c743f6be78" />

<img width="1317" height="570" alt="image" src="https://github.com/user-attachments/assets/c47a6699-d4ec-464c-9605-f3371c35dca5" />


<img width="1317" height="570" alt="image" src="https://github.com/user-attachments/assets/dcdc9fe3-939f-40f8-946f-dfd73eb828f8" />

