### PR TITLE
OPH-1055 | Do not create a version when the users value gets updated in the details card of the process

### DIFF
--- a/app/components/process/details-card.hbs
+++ b/app/components/process/details-card.hbs
@@ -140,13 +140,13 @@
       Algemene informatie
     </:title>
     <:header>
-      {{#unless this.currentSession.readOnly}}
+      {{#if @canEdit}}
         <AuButton
           @skin="naked"
           @icon="pencil"
           {{on "click" this.toggleEdit}}
         >Wijzig</AuButton>
-      {{/unless}}
+      {{/if}}
     </:header>
     <:card as |Card|>
       <Card.Columns>

--- a/app/components/process/details-card.hbs
+++ b/app/components/process/details-card.hbs
@@ -117,15 +117,6 @@
                 {{date-format @process.created true}}
               </:content>
             </Item>
-            <Item>
-              <:label>Wij gebruiken dit proces</:label>
-              <:content>
-                <AuCheckbox
-                  @checked={{this.processUsedByUs}}
-                  @onChange={{this.updateProcessUsedByUs}}
-                />
-              </:content>
-            </Item>
             {{#if @process.isPublishedByAbbOrDv}}
               <Item>
                 <:label>Blauwdruk</:label>

--- a/app/components/process/details-card.hbs
+++ b/app/components/process/details-card.hbs
@@ -122,7 +122,7 @@
               <:content>
                 <AuCheckbox
                   @checked={{this.processUsedByUs}}
-                  @onChange={{this.setProcessUsedByUs}}
+                  @onChange={{this.updateProcessUsedByUs}}
                 />
               </:content>
             </Item>
@@ -283,8 +283,8 @@
             <:label>Wij gebruiken dit proces</:label>
             <:content>
               <AuCheckbox
-                @disabled={{not this.isEditing}}
                 @checked={{this.processUsedByUs}}
+                @onChange={{this.updateProcessUsedByUs}}
               />
             </:content>
           </Item>

--- a/app/components/process/details-card.js
+++ b/app/components/process/details-card.js
@@ -9,12 +9,11 @@ export default class ProcessDetailsCardComponent extends Component {
   @service store;
   @service currentSession;
   @service toaster;
+  @service router;
 
   @tracked _isEditing = false;
   @tracked formIsValid = false;
   @tracked draftIpdcProducts = [];
-  @tracked processUserChanged = undefined;
-  @tracked originalUsers = undefined;
   @tracked relevantAdministrativeUnitsChanged = false;
 
   get processUsedByUs() {
@@ -33,8 +32,6 @@ export default class ProcessDetailsCardComponent extends Component {
   @action
   toggleEdit() {
     this.draftIpdcProducts = this.args.process?.ipdcProducts;
-    if (!this.isEditing)
-      this.originalUsers = this.args.process?.users?.slice() || [];
     this.isEditing = !this.isEditing;
     this.validateForm();
   }
@@ -45,13 +42,6 @@ export default class ProcessDetailsCardComponent extends Component {
     this.draftIpdcProducts = this.args.process?.ipdcProducts ?? [];
     this.relevantAdministrativeUnitsChanged = false;
 
-    if (this.processUserChanged && this.originalUsers) {
-      const users = this.args.process?.users;
-      users.splice(0, users.length);
-      this.originalUsers.forEach((user) => users.push(user));
-      this.processUserChanged = false;
-    }
-
     this.isEditing = false;
   }
 
@@ -59,7 +49,6 @@ export default class ProcessDetailsCardComponent extends Component {
     this.formIsValid =
       this.args.process?.validate() &&
       (this.args.process?.hasDirtyAttributes ||
-        this.processUserChanged ||
         this.relevantAdministrativeUnitsChanged ||
         this.draftIpdcProducts.length <
           this.args.process?.ipdcProducts?.length ||
@@ -158,8 +147,7 @@ export default class ProcessDetailsCardComponent extends Component {
   }
 
   @action
-  async setProcessUsedByUs(isChecked) {
-    this.processUserChanged = true;
+  async updateProcessUsedByUs(isChecked) {
     const currentUser = this.currentSession.group;
     const users = await this.args.process?.users;
     if (isChecked) {
@@ -170,7 +158,18 @@ export default class ProcessDetailsCardComponent extends Component {
         users.splice(index, 1);
       }
     }
-    this.validateForm();
+    await this.args.process.save({
+      adapterOptions: { skipVersioning: true },
+    });
+
+    this.toaster.success(
+      isChecked ? 'Proces in gebruik genomen' : 'Proces niet langer in gebruik',
+      undefined,
+      {
+        timeOut: 2500,
+      },
+    );
+    this.router.refresh();
   }
 
   @action

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -146,10 +146,18 @@ export default class ProcessModel extends Model {
     this.email = this.email?.trim();
   }
 
+  get canCreateProcessVersion() {
+    const isNotVersionedModel = this.baseModelName !== 'versioned-process';
+    const isOwnerOfProcess = this.publisher.id === this.currentSession.group.id;
+
+    return isNotVersionedModel && isOwnerOfProcess;
+  }
+
   async save() {
     this.modified = new Date();
+
     await super.save(...arguments);
-    if (this.baseModelName !== 'versioned-process') {
+    if (this.canCreateProcessVersion) {
       this.applyVersioning.perform();
     }
   }

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -146,18 +146,10 @@ export default class ProcessModel extends Model {
     this.email = this.email?.trim();
   }
 
-  get canCreateProcessVersion() {
-    const isNotVersionedModel = this.baseModelName !== 'versioned-process';
-    const isOwnerOfProcess = this.publisher.id === this.currentSession.group.id;
-
-    return isNotVersionedModel && isOwnerOfProcess;
-  }
-
   async save() {
     this.modified = new Date();
-
     await super.save(...arguments);
-    if (this.canCreateProcessVersion) {
+    if (this.baseModelName !== 'versioned-process') {
       this.applyVersioning.perform();
     }
   }

--- a/app/models/process.js
+++ b/app/models/process.js
@@ -146,10 +146,11 @@ export default class ProcessModel extends Model {
     this.email = this.email?.trim();
   }
 
-  async save() {
+  async save(options = {}) {
+    const { skipVersioning = false } = options.adapterOptions || {};
     this.modified = new Date();
     await super.save(...arguments);
-    if (this.baseModelName !== 'versioned-process') {
+    if (this.baseModelName !== 'versioned-process' && !skipVersioning) {
       this.applyVersioning.perform();
     }
   }


### PR DESCRIPTION
## 🗒️ Description

We do not want a process version to be created when the "wij gebruiken dit process" checkbox changes. For this to work we made this checkbox editable without pressing a button for "wijzig" (directly editable in the UI).  

## 🦮 How to test

1. When you do not own the process the wijzig button is not shown in the details card
2. When you click the checkbox you will see a toaster message that this is updated
3. When the value is updated in the last card, where you can see what organizations are using this process the information is re-fetched
4. When you are owner of the process and press "wijzig" on this card the "wij gebruiken dit process" checkbox is not shown

## 🖼️ Attachments

<img width="1484" height="591" alt="image" src="https://github.com/user-attachments/assets/f0cc3ea0-d6d5-46d4-8fec-89ed6ccd9acc" />

