### PR TITLE
OPH-1053 | Replace confidentialiteit with vertrouwelijkheid

### DIFF
--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -154,6 +154,7 @@ export default class InformationAssetsInformationAssetController extends Control
 
       if (!newVersionedRecord) return;
 
+      canonicalRecord.modified = new Date();
       await canonicalRecord.save();
       await newVersionedRecord.save();
       await oldVersionedRecord.save();

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -135,9 +135,9 @@
             <span>Persoonsgegevens</span>
           </th>
           <AuDataTableThSortable
-            @field="created"
+            @field="modified"
             @currentSorting={{this.sort}}
-            @label="Aangemaakt op"
+            @label="Laatst aangepast op"
           />
           {{#if this.canEdit}}
             <th>
@@ -221,7 +221,7 @@
                 {{/if}}
               </div>
             </td>
-            <td>{{date-format informationAsset.created}}</td>
+            <td>{{date-format informationAsset.modified}}</td>
             {{#if this.canEdit}}
               <td>
                 <div class="au-u-flex au-u-flex--center">

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -27,7 +27,7 @@
             />
           </div>
           <div>
-            <AuLabel for="filter-availability">Integriteit</AuLabel>
+            <AuLabel for="filter-integrity">Integriteit</AuLabel>
             <Process::IcrCard::Score
               @id="filter-integrity"
               @selectedScore={{this.integrityScore}}
@@ -35,7 +35,7 @@
             />
           </div>
           <div>
-            <AuLabel for="filter-availability">Confidentialiteit</AuLabel>
+            <AuLabel for="filter-confidentiality">Vertrouwelijkheid</AuLabel>
             <Process::IcrCard::Score
               @id="filter-confidentiality"
               @selectedScore={{this.confidentialityScore}}
@@ -134,7 +134,7 @@
           <AuDataTableThSortable
             @field="confidentialityScore"
             @currentSorting={{this.sort}}
-            @label="Confidentialiteit"
+            @label="Vertrouwelijkheid"
           />
           <th>
             <span>Persoonsgegevens</span>

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -117,11 +117,6 @@
             @label="Beschrijving"
           />
           <AuDataTableThSortable
-            @field="creator"
-            @currentSorting={{this.sort}}
-            @label="Auteur"
-          />
-          <AuDataTableThSortable
             @field="availabilityScore"
             @currentSorting={{this.sort}}
             @label="Beschikbaarheid"
@@ -178,9 +173,6 @@
                   (truncate (trim informationAsset.description) 150 true)
                   "/"
                 }}</span>
-            </td>
-            <td>
-              {{informationAsset.creator.name}}
             </td>
             <td>
               {{if


### PR DESCRIPTION
## 🗒️ Description

- We do not use the vertrouwlijkheid value consistantly (confidentialiteit)
- The auteur column needs to go
- Aangemaakt column in ICR table needs to be Laatst aangepast op

## 🦮 How to test

1. ICR value is always vertrouwelijkheid not confidentialiteit
2. The auteur column is not visible in the overview of ICR assets
3. The created column is replaced with modified + filtering => modified is updated from canonical

## 🖼️ Attachments

<img width="1671" height="596" alt="image" src="https://github.com/user-attachments/assets/6ed7c5b1-3184-42d9-a63e-dc396df64b54" />
