### PR TITLE
OPH-1072 | Archive the diagram-list-items from a diagram-list 

### DIFF
--- a/app/components/process/diagram/version.js
+++ b/app/components/process/diagram/version.js
@@ -42,6 +42,14 @@ export default class ProcessDiagramVersion extends Component {
 
     try {
       await this.diagramListToDelete.save();
+      await Promise.all(
+        this.diagramListToDelete.diagrams
+          .filter((item) => !item.isArchived)
+          .map((item) => {
+            item.setArchivedStatus();
+            return item.save();
+          }),
+      );
       this.toaster.success(
         'Diagrammen versie succesvol verwijderd',
         'Gelukt!',

--- a/app/models/diagram-list-item.js
+++ b/app/models/diagram-list-item.js
@@ -1,5 +1,6 @@
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
-import ENV from 'frontend-openproceshuis/config/environment';
+
+import { ARCHIVED_STATUS_URI } from '../utils/well-known-uris';
 
 export default class DiagramListItemModel extends Model {
   @attr('number', {
@@ -18,6 +19,10 @@ export default class DiagramListItemModel extends Model {
   subItems;
 
   get isArchived() {
-    return this.status === ENV.resourceStates.archived;
+    return this.status === ARCHIVED_STATUS_URI;
+  }
+
+  setArchivedStatus() {
+    this.status = ARCHIVED_STATUS_URI;
   }
 }


### PR DESCRIPTION
## 🗒️ Description

The code to check if the diagram list item was archived was already in place. But when removing a version (aka diagram list) of a process not all the list items where archived with it. 

## 🦮 How to test

1. Vissit the detail of a diagram in the diagrams of the process (open in a new tab)
2. Upload new process diagrams
3. Archive the old version
4. GO to your second tab and refresh the page => this should end up in a diagram not found page

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

<img width="2339" height="691" alt="image" src="https://github.com/user-attachments/assets/deb7fbed-0913-48b9-851c-284c66f25a44" />

