### PR TITLE
OPH-1074, -1073 | Diagram count is off when doing multiple edits

### DIFF
--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -2,7 +2,7 @@
   <:title>Bijlagen
     {{#unless this.versionedFiles.isRunning}}
       <Process::ChangedStatusPills::Attachments
-        @isShown={{@versionedProcess}}
+        @isShown={{and @versionedProcess (not this.fetchFilesForComparison.isRunning)}}
         @versioned={{this.versionedFiles.value.forVersion}}
         @current={{this.versionedFiles.value.forCurrent}}
         @singularLabel="bestand"
@@ -11,7 +11,7 @@
     {{/unless}}
     {{#unless this.versionedLinks.isRunning}}
       <Process::ChangedStatusPills::Attachments
-        @isShown={{@versionedProcess}}
+        @isShown={{and @versionedProcess (not this.fetchRelevantLinksForComparison.isRunning)}}
         @versioned={{this.versionedLinks.value.forVersion}}
         @current={{this.versionedLinks.value.forCurrent}}
         @singularLabel="link"

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -61,8 +61,10 @@ export default class ProcessesProcessIndexController extends Controller {
           ].join(','),
         })
       : null;
-    this.versionedDiagrams =
-      (await this.versionedProcess?.diagramLists?.[0]?.diagrams) ?? [];
+    const latestVersionedList = await this.diagram.getLatestDiagramList(
+      this.versionedProcessId,
+    );
+    this.versionedDiagrams = latestVersionedList?.diagrams ?? [];
   });
 
   get canEdit() {

--- a/app/services/diagram.js
+++ b/app/services/diagram.js
@@ -42,6 +42,10 @@ export default class DiagramService extends Service {
   }
 
   async getLatestDiagramList(processId) {
+    if (!processId) {
+      return null;
+    }
+
     const allDiagramLists =
       await this.getDiagramListsWithFilesForProcess(processId);
     const sortedOnCreatedLists = allDiagramLists.sort(

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -71,7 +71,7 @@
     <div class="au-u-flex au-u-flex--between au-u-margin-bottom-small">
       <AuHeading @level="2" @skin="3">Diagrammen
         <Process::StatusWithVersioned
-          @isShown={{this.versionedProcess}}
+          @isShown={{and this.versionedProcess (not this.loadVersionedProcess.isRunning)}}
           @versionedDiagrams={{this.versionedDiagrams}}
           @currentDiagrams={{@model.diagramList.diagrams}}
         />


### PR DESCRIPTION
## 🗒️ Description

- A bug ticket mentioned the count being off when doing multiple edits.
- Fixed the status pills also shown when no edit was done to the diagrams

**Added**
- hide the status pills when the data is loading
- The status pills are not shown when going to a version where they did not change

## 🦮 How to test

https://dev.openproceshuis.lblod.info/gedeelde-processen/6A1545D87F896D5A0379C364

- Check the counts, always compare the current visual state with what was changed in the selected version
- For diagrams and attachments (pull app => development for this)

**Steps**
1. create a process
2. change the diagrams
3. change the title description and email in 3 separate saves
4. all changes of the description should not be changed

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

https://github.com/user-attachments/assets/f2fffb70-9675-47d8-80cc-ec896786dcf9


