### PR TITLE
OPH-1082 | Also show the tooltips for the ICR filters (check boxes for personal info)

### DIFF
--- a/app/components/icr/contains-personal-data-tooltip.hbs
+++ b/app/components/icr/contains-personal-data-tooltip.hbs
@@ -1,4 +1,5 @@
 <Shared::Tooltip
+  @alignment={{@alignment}}
   @show={{true}}
   @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
 >

--- a/app/components/icr/contains-personal-data-tooltip.hbs
+++ b/app/components/icr/contains-personal-data-tooltip.hbs
@@ -1,0 +1,11 @@
+<Shared::Tooltip
+  @show={{true}}
+  @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
+>
+  <AuIcon
+    class="color--info"
+    @icon="circle-question"
+    @size="large"
+    @alignment="right"
+  />
+</Shared::Tooltip>

--- a/app/components/icr/contains-professional-data-tooltip.hbs
+++ b/app/components/icr/contains-professional-data-tooltip.hbs
@@ -1,0 +1,12 @@
+<Shared::Tooltip
+  @show={{true}}
+  @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
+  @placement="top"
+>
+  <AuIcon
+    class="color--info"
+    @icon="circle-question"
+    @size="large"
+    @alignment="right"
+  />
+</Shared::Tooltip>

--- a/app/components/icr/contains-professional-data-tooltip.hbs
+++ b/app/components/icr/contains-professional-data-tooltip.hbs
@@ -1,4 +1,5 @@
 <Shared::Tooltip
+  @alignment={{@alignment}}
   @show={{true}}
   @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
   @placement="top"

--- a/app/components/icr/contains-special-personal-data-tooltip.hbs
+++ b/app/components/icr/contains-special-personal-data-tooltip.hbs
@@ -1,4 +1,5 @@
 <Shared::Tooltip
+  @alignment={{@alignment}}
   @show={{true}}
   @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
 >

--- a/app/components/icr/contains-special-personal-data-tooltip.hbs
+++ b/app/components/icr/contains-special-personal-data-tooltip.hbs
@@ -1,0 +1,11 @@
+<Shared::Tooltip
+  @show={{true}}
+  @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
+>
+  <AuIcon
+    class="color--info"
+    @icon="circle-question"
+    @size="large"
+    @alignment="right"
+  />
+</Shared::Tooltip>

--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -141,18 +141,7 @@
                       @disabled="true"
                     >
                       <label for="contains-personal-data">Professionele gegevens</label>
-                      <Shared::Tooltip
-                        @show={{true}}
-                        @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
-                        @placement="top"
-                      >
-                        <AuIcon
-                          class="color--info"
-                          @icon="circle-question"
-                          @size="large"
-                          @alignment="right"
-                        />
-                      </Shared::Tooltip>
+                      <Icr::ContainsProfessionalDataTooltip />
                     </AuCheckbox>
                   </Shared::TextCompare>
                 </div>
@@ -169,17 +158,7 @@
                       <label
                         for="contains-professional-data"
                       >Persoonsgegevens</label>
-                      <Shared::Tooltip
-                        @show={{true}}
-                        @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
-                      >
-                        <AuIcon
-                          class="color--info"
-                          @icon="circle-question"
-                          @size="large"
-                          @alignment="right"
-                        />
-                      </Shared::Tooltip>
+                      <Icr::ContainsPersonalDataTooltip />
                     </AuCheckbox>
                   </Shared::TextCompare>
                 </div>
@@ -195,17 +174,7 @@
                     >
                       <label for="contains-sensitive-personal-data">Bijzondere
                         persoonsgegevens</label>
-                      <Shared::Tooltip
-                        @show={{true}}
-                        @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
-                      >
-                        <AuIcon
-                          class="color--info"
-                          @icon="circle-question"
-                          @size="large"
-                          @alignment="right"
-                        />
-                      </Shared::Tooltip>
+                      <Icr::ContainsSpecialPersonalDataTooltip />
                     </AuCheckbox>
                   </Shared::TextCompare>
                 </div>

--- a/app/components/process/icr-modal.hbs
+++ b/app/components/process/icr-modal.hbs
@@ -79,18 +79,7 @@
           @onChange={{fn (mut @selected.containsProfessionalData)}}
         >
           <label for="contains-personal-data">Professionele gegevens</label>
-          <Shared::Tooltip
-            @show={{true}}
-            @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
-            @placement="top"
-          >
-            <AuIcon
-              class="color--info"
-              @icon="circle-question"
-              @size="large"
-              @alignment="right"
-            />
-          </Shared::Tooltip>
+          <Icr::ContainsProfessionalDataTooltip />
         </AuCheckbox>
         <AuCheckbox
           id="contains-professional-data"
@@ -98,18 +87,7 @@
           @onChange={{fn (mut @selected.containsPersonalData)}}
         >
           <label for="contains-professional-data">Persoonsgegevens</label>
-
-          <Shared::Tooltip
-            @show={{true}}
-            @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
-          >
-            <AuIcon
-              class="color--info"
-              @icon="circle-question"
-              @size="large"
-              @alignment="right"
-            />
-          </Shared::Tooltip>
+          <Icr::ContainsPersonalDataTooltip />
         </AuCheckbox>
         <AuCheckbox
           id="contains-sensitive-personal-data"
@@ -118,17 +96,7 @@
         >
           <label for="contains-sensitive-personal-data">Bijzondere
             persoonsgegevens</label>
-          <Shared::Tooltip
-            @show={{true}}
-            @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
-          >
-            <AuIcon
-              class="color--info"
-              @icon="circle-question"
-              @size="large"
-              @alignment="right"
-            />
-          </Shared::Tooltip>
+          <Icr::ContainsSpecialPersonalDataTooltip />
         </AuCheckbox>
       </div>
     </form>

--- a/app/components/wizard/actions.hbs
+++ b/app/components/wizard/actions.hbs
@@ -2,7 +2,7 @@
   {{#each this.actions as |action|}}
     {{! template-lint-disable no-invalid-interactive }}
     <div
-      class="{{if action.isDisabled 'is-disabled'}}
+      class="{{if action.isDisabled 'is-disabled-action'}}
         width-full border-radius animate-up"
       {{on "click" action.next}}
     >

--- a/app/styles/components/_c-wizard.scss
+++ b/app/styles/components/_c-wizard.scss
@@ -30,7 +30,7 @@
   }
 }
 
-.is-disabled {
+.is-disabled-action {
   opacity: 0.5;
   background-color: var(--au-gray-200) !important;
   cursor: not-allowed !important;

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -49,8 +49,7 @@
               @checked={{this.containsProfessionalData}}
               @onChange={{this.setContainsProfessionalData}}
             >
-              <label for="filter-professional-data">Professionele gegevens
-              </label>
+              <label for="filter-professional-data">Professionele gegevens</label>
             </AuCheckbox>
             <AuCheckbox
               id="filter-personal-data"

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -50,22 +50,23 @@
               @onChange={{this.setContainsProfessionalData}}
             >
               <label for="filter-professional-data">Professionele gegevens</label>
+              <Icr::ContainsProfessionalDataTooltip />
             </AuCheckbox>
             <AuCheckbox
               id="filter-personal-data"
               @checked={{this.containsPersonalData}}
               @onChange={{this.setContainsPersonalData}}
             >
-              <label for="filter-personal-data">Persoonsgegevens
-              </label>
+              <label for="filter-personal-data">Persoonsgegevens</label>
+              <Icr::ContainsPersonalDataTooltip />
             </AuCheckbox>
             <AuCheckbox
               id="filter-sensitive-data"
               @checked={{this.containsSensitivePersonalData}}
               @onChange={{this.setContainsSensitivePersonalData}}
             >
-              <label for="filter-sensitive-data">Bijzondere persoonsgegevens
-              </label>
+              <label for="filter-sensitive-data">Bijzondere persoonsgegevens</label>
+              <Icr::ContainsSpecialPersonalDataTooltip />
             </AuCheckbox>
           </div>
           <div class="au-u-flex au-u-flex--end">

--- a/app/templates/information-assets/index.hbs
+++ b/app/templates/information-assets/index.hbs
@@ -50,15 +50,15 @@
               @onChange={{this.setContainsProfessionalData}}
             >
               <label for="filter-professional-data">Professionele gegevens</label>
-              <Icr::ContainsProfessionalDataTooltip />
+              <Icr::ContainsProfessionalDataTooltip @alignment="right" />
             </AuCheckbox>
             <AuCheckbox
               id="filter-personal-data"
               @checked={{this.containsPersonalData}}
               @onChange={{this.setContainsPersonalData}}
             >
-              <label for="filter-personal-data">Persoonsgegevens</label>
-              <Icr::ContainsPersonalDataTooltip />
+              <label for="filter-personal-data" class="au-u-margin-right-small">Persoonsgegevens</label>
+              <Icr::ContainsPersonalDataTooltip @alignment="right" />
             </AuCheckbox>
             <AuCheckbox
               id="filter-sensitive-data"
@@ -66,7 +66,7 @@
               @onChange={{this.setContainsSensitivePersonalData}}
             >
               <label for="filter-sensitive-data">Bijzondere persoonsgegevens</label>
-              <Icr::ContainsSpecialPersonalDataTooltip />
+              <Icr::ContainsSpecialPersonalDataTooltip @alignment="right" />
             </AuCheckbox>
           </div>
           <div class="au-u-flex au-u-flex--end">

--- a/app/templates/information-assets/information-asset.hbs
+++ b/app/templates/information-assets/information-asset.hbs
@@ -148,18 +148,7 @@
                       >
                         <label for="contains-personal-data">Professionele
                           gegevens</label>
-                        <Shared::Tooltip
-                          @show={{true}}
-                          @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
-                          @placement="top"
-                        >
-                          <AuIcon
-                            class="color--info"
-                            @icon="circle-question"
-                            @size="large"
-                            @alignment="right"
-                          />
-                        </Shared::Tooltip>
+                        <Icr::ContainsProfessionalDataTooltip />
                       </AuCheckbox>
                       <AuCheckbox
                         id="contains-professional-data"
@@ -171,17 +160,7 @@
                         <label
                           for="contains-professional-data"
                         >Persoonsgegevens</label>
-                        <Shared::Tooltip
-                          @show={{true}}
-                          @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
-                        >
-                          <AuIcon
-                            class="color--info"
-                            @icon="circle-question"
-                            @size="large"
-                            @alignment="right"
-                          />
-                        </Shared::Tooltip>
+                        <Icr::ContainsPersonalDataTooltip />
                       </AuCheckbox>
                       <AuCheckbox
                         id="contains-sensitive-personal-data"
@@ -194,17 +173,7 @@
                       >
                         <label for="contains-sensitive-personal-data">Bijzondere
                           persoonsgegevens</label>
-                        <Shared::Tooltip
-                          @show={{true}}
-                          @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
-                        >
-                          <AuIcon
-                            class="color--info"
-                            @icon="circle-question"
-                            @size="large"
-                            @alignment="right"
-                          />
-                        </Shared::Tooltip>
+                        <Icr::ContainsSpecialPersonalDataTooltip />
                       </AuCheckbox>
                     </div>
                   </:content>
@@ -308,18 +277,7 @@
                       >
                         <label for="contains-personal-data">Professionele
                           gegevens</label>
-                        <Shared::Tooltip
-                          @show={{true}}
-                          @text="Gegevens waarmee een persoon professioneel kan worden bereikt bijvoorbeeld professioneel telefoonnummer/e-mailadres, postadres van de organisatie."
-                          @placement="top"
-                        >
-                          <AuIcon
-                            class="color--info"
-                            @icon="circle-question"
-                            @size="large"
-                            @alignment="right"
-                          />
-                        </Shared::Tooltip>
+                        <Icr::ContainsProfessionalDataTooltip />
                       </AuCheckbox>
                       <AuCheckbox
                         id="contains-professional-data"
@@ -329,17 +287,7 @@
                         <label
                           for="contains-professional-data"
                         >Persoonsgegevens</label>
-                        <Shared::Tooltip
-                          @show={{true}}
-                          @text="Gegevens die direct of indirect een persoon identificeren bijvoorbeeld geboortedatum, foto, naam, thuisadres."
-                        >
-                          <AuIcon
-                            class="color--info"
-                            @icon="circle-question"
-                            @size="large"
-                            @alignment="right"
-                          />
-                        </Shared::Tooltip>
+                        <Icr::ContainsPersonalDataTooltip />
                       </AuCheckbox>
                       <AuCheckbox
                         id="contains-sensitive-personal-data"
@@ -348,17 +296,7 @@
                       >
                         <label for="contains-sensitive-personal-data">Bijzondere
                           persoonsgegevens</label>
-                        <Shared::Tooltip
-                          @show={{true}}
-                          @text="Gevoelige gegevens die extra bescherming vereisen bijvoorbeeld medische gegevens, religieuze overtuiging, etnische achtergrond, biometrische gegevens."
-                        >
-                          <AuIcon
-                            class="color--info"
-                            @icon="circle-question"
-                            @size="large"
-                            @alignment="right"
-                          />
-                        </Shared::Tooltip>
+                        <Icr::ContainsSpecialPersonalDataTooltip />
                       </AuCheckbox>
                     </div>
                   </:content>


### PR DESCRIPTION
## 🗒️ Description

The checkboxes in the filter sidebar of ICR assets do not show the tooltips. We should show them

## 🦮 How to test

1. Tooltips are available
2. Tooltips show the correct info

## 🖼️ Attachments


<img width="372" height="469" alt="image" src="https://github.com/user-attachments/assets/c8542fa7-13d4-45a8-b6b1-434c9c0b1330" />

