### PR TITLE
OPH-867 | attachments can have any extension (none forbidden)

### DIFF
--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -178,7 +178,7 @@
   @header="Voeg bijlage toe"
   @title="Bestand selecteren"
   @helpTextDragDrop="Bestand wordt meteen toegevoegd aan bibliotheek na selectie"
-  @forbidden=".bpmn,.vsdx"
+  @forbidden=""
   @multiple="true"
   @updateModel={{this.addFilesToProcess}}
   @onFinishUpload={{this.attachmentsUploaded}}


### PR DESCRIPTION
## 🗒️ Description

Attachments can have any type of extension also bpmn and visio. These are not counted as diagrams! But as the resource domain sets the predicate to be associated media this will not be the case.

## 🦮 How to test

1. upload a bpmn file
2. upload a vsdx file
3. upload something else
4. Files are still limited to be a max size of 20mb!

## 🖼️ Attachments

<img width="1116" height="657" alt="image" src="https://github.com/user-attachments/assets/0548911c-70d3-4470-900a-14df55b380df" />

