### PR TITLE
OPH-1106 | Test out ember drag sort for re-ordening of diagrams

### DIFF
--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -3,12 +3,55 @@
     <div
       class="au-u-flex au-u-flex--between au-u-flex--vertical-center au-u-background-gray-100 border-line-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
     >
-      <div class="au-u-flex au-u-flex--row au-u-flex--vertical-center">
+      <div
+        class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"
+      >
         <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
         <div class="au-u-margin-left-small">
           <p>{{item.label}}</p>
+          <p class="au-u-muted">Hoofddiagram</p>
         </div>
       </div>
+    </div>
+    <div class="au-u-margin-left">
+      <DragSortList
+        @items={{item.subItems}}
+        @additionalArgs={{hash mainDiagram=item.self}}
+        @dragEndAction={{this.dragEnd}}
+        as |subItem|
+      >
+        {{#if subItem.isPlaceholder}}
+          <div
+            class="cursor-not-allowed au-u-flex au-u-flex--between au-u-flex--vertical-center border-line-dashed-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
+          >
+            <div
+              class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"
+            >
+              <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
+              <div class="au-u-margin-left-small">
+                <p class="au-u-muted">Sleep hier om een subdiagram toe te voegen</p>
+              </div>
+            </div>
+          </div>
+        {{else}}
+          <div
+            class="au-u-flex au-u-flex--between au-u-flex--vertical-center border-line-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
+          >
+            <div
+              class="width-full au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"
+            >
+              <div class="au-u-flex au-u-flex--row au-u-flex--vertical-center">
+                <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
+                <div class="au-u-margin-left-small">
+                  <p>{{subItem.label}}</p>
+                  <p class="au-u-muted">Subdiagram</p>
+                </div>
+              </div>
+              <AuButton @skin="naked">Maak hoofddiagram</AuButton>
+            </div>
+          </div>
+        {{/if}}
+      </DragSortList>
     </div>
   </DragSortList>
 </div>

--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -37,7 +37,7 @@
           </div>
         {{else}}
           <div
-            class="au-u-flex au-u-flex--between au-u-flex--vertical-center border-line-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
+            class="tree-node--sub au-u-flex au-u-flex--between au-u-flex--vertical-center border-line-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
           >
             <div
               class="width-full au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"

--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -16,7 +16,6 @@
     <div class="au-u-margin-left">
       <DragSortList
         @items={{item.subItems}}
-        @additionalArgs={{hash mainDiagram=item.self}}
         @dragEndAction={{this.dragEnd}}
         as |subItem|
       >

--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -4,13 +4,16 @@
       class="au-u-flex au-u-flex--between au-u-flex--vertical-center au-u-background-gray-100 border-line-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
     >
       <div
-        class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"
+        class="width-full au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"
       >
-        <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
-        <div class="au-u-margin-left-small">
-          <p>{{item.label}}</p>
-          <p class="au-u-muted">Hoofddiagram</p>
+        <div class="au-u-flex au-u-flex--row au-u-flex--vertical-center">
+          <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
+          <div class="au-u-margin-left-small">
+            <p class="au-u-h5">{{item.label}}</p>
+            <p class="au-u-muted">Hoofddiagram</p>
+          </div>
         </div>
+        <AuIcon @icon="drag-handle" @size="large" class="au-u-margin-right" />
       </div>
     </div>
     <div class="au-u-margin-left">
@@ -42,11 +45,15 @@
               <div class="au-u-flex au-u-flex--row au-u-flex--vertical-center">
                 <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
                 <div class="au-u-margin-left-small">
-                  <p>{{subItem.label}}</p>
+                  <p class="au-u-h5">{{subItem.label}}</p>
                   <p class="au-u-muted">Subdiagram</p>
                 </div>
               </div>
-              <AuButton @skin="naked">Maak hoofddiagram</AuButton>
+              <AuIcon
+                @icon="drag-handle"
+                @size="large"
+                class="au-u-margin-right"
+              />
             </div>
           </div>
         {{/if}}

--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -1,0 +1,14 @@
+<div>
+  <DragSortList @items={{this.items}} @dragEndAction={{this.dragEnd}} as |item|>
+    <div
+      class="au-u-flex au-u-flex--between au-u-flex--vertical-center au-u-background-gray-100 border-line-200 border-radius au-u-padding-small au-u-padding-left-tiny au-u-padding-right-tiny au-u-margin-top-tiny au-u-margin-bottom-tiny"
+    >
+      <div class="au-u-flex au-u-flex--row au-u-flex--vertical-center">
+        <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
+        <div class="au-u-margin-left-small">
+          <p>{{item.label}}</p>
+        </div>
+      </div>
+    </div>
+  </DragSortList>
+</div>

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+
+import { action } from '@ember/object';
+import { ARCHIVED_STATUS_URI } from '../../utils/well-known-uris';
+
+export default class DiagramListDragAndDropSort extends Component {
+  get items() {
+    if (!this.args.diagramList) {
+      return [];
+    }
+
+    const nonArchivedItems = Array.from(this.args.diagramList.diagrams).filter(
+      (listItem) => listItem.diagramFile.status !== ARCHIVED_STATUS_URI,
+    );
+    const sortedByPosition = nonArchivedItems.sort(
+      (a, b) => a.position - b.position,
+    );
+
+    return sortedByPosition.map((listItem) => ({
+      label: listItem.diagramFile.name,
+      parent: listItem,
+    }));
+  }
+
+  @action
+  dragEnd({ sourceList, sourceIndex, targetList, targetIndex }) {
+    if (sourceList === targetList && sourceIndex === targetIndex) return;
+
+    const movedItem = sourceList[sourceIndex];
+    const replacedWith = targetList[targetIndex];
+    const movedItemOldPosition = movedItem.parent.position;
+    const replacedItemOldPosition = replacedWith.parent.position;
+
+    replacedWith.parent.position = movedItemOldPosition;
+    movedItem.parent.position = replacedItemOldPosition;
+  }
+}

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -16,9 +16,29 @@ export default class DiagramListDragAndDropSort extends Component {
       (a, b) => a.position - b.position,
     );
 
+    const mapSubItems = (_listItem) => {
+      if (_listItem.subItems?.length === 0) {
+        return [
+          {
+            isPlaceholder: true,
+          },
+        ];
+      }
+
+      return _listItem.subItems.map((subItem) => {
+        return {
+          label: subItem.diagramFile.name,
+          self: subItem,
+          parent: _listItem,
+        };
+      });
+    };
+
     return sortedByPosition.map((listItem) => ({
       label: listItem.diagramFile.name,
-      parent: listItem,
+      self: listItem,
+      parent: this.args.diagramList,
+      subItems: mapSubItems(listItem),
     }));
   }
 
@@ -28,10 +48,10 @@ export default class DiagramListDragAndDropSort extends Component {
 
     const movedItem = sourceList[sourceIndex];
     const replacedWith = targetList[targetIndex];
-    const movedItemOldPosition = movedItem.parent.position;
-    const replacedItemOldPosition = replacedWith.parent.position;
+    const movedItemOldPosition = movedItem.self.position;
+    const replacedItemOldPosition = replacedWith.self.position;
 
-    replacedWith.parent.position = movedItemOldPosition;
-    movedItem.parent.position = replacedItemOldPosition;
+    replacedWith.self.position = movedItemOldPosition;
+    movedItem.self.position = replacedItemOldPosition;
   }
 }

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -54,6 +54,8 @@ export default class DiagramListDragAndDropSort extends Component {
 
   @action
   dragEnd({ sourceList, sourceIndex, targetList, targetIndex }) {
+    const maxPosition = (items) =>
+      Math.max(0, ...items.map((item) => item.position ?? 0));
     if (sourceList === targetList && sourceIndex === targetIndex) return;
 
     const movedItem = sourceList[sourceIndex];
@@ -92,19 +94,32 @@ export default class DiagramListDragAndDropSort extends Component {
         effectiveTarget.parent.subItems = [movedItem.self];
       } else if (effectiveTarget.isSubItem) {
         const targetSubDiagrams = effectiveTarget.parent.subItems ?? [];
-        movedItem.self.position = targetSubDiagrams.length + 1;
+        movedItem.self.position = maxPosition(targetSubDiagrams) + 1;
         effectiveTarget.parent.subItems = [
           ...targetSubDiagrams,
           movedItem.self,
         ];
+      } else if (effectiveTarget.isMainDiagram) {
+        const mainDiagrams = effectiveTarget.parent.diagrams ?? [];
+        if (replacedWith) {
+          const insertAt = effectiveTarget.self.position;
+          mainDiagrams.forEach((d) => {
+            if (d.position >= insertAt) d.position += 1;
+          });
+          movedItem.self.position = insertAt;
+        } else {
+          movedItem.self.position = maxPosition(mainDiagrams) + 1;
+        }
+        effectiveTarget.parent.diagrams = [...mainDiagrams, movedItem.self];
       }
     } else {
       if (!replacedWith) {
-        return;
+        movedItem.self.position = effectiveTarget.self.position + 1;
+      } else {
+        const replacedItemOldPosition = replacedWith.self.position;
+        replacedWith.self.position = movedItemOldPosition;
+        movedItem.self.position = replacedItemOldPosition;
       }
-      const replacedItemOldPosition = replacedWith.self.position;
-      replacedWith.self.position = movedItemOldPosition;
-      movedItem.self.position = replacedItemOldPosition;
     }
   }
 }

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -58,11 +58,13 @@ export default class DiagramListDragAndDropSort extends Component {
 
     const movedItem = sourceList[sourceIndex];
     const replacedWith = targetList[targetIndex];
+    const effectiveTarget = replacedWith ?? targetList[targetList.length - 1];
+
+    if (!effectiveTarget) return;
 
     const movedItemOldPosition = movedItem.self.position;
-    const replacedItemOldPosition = replacedWith.self.position;
 
-    if (movedItem.parent.id !== replacedWith.parent.id) {
+    if (movedItem.parent.id !== effectiveTarget.parent.id) {
       const hasSubItems = Boolean(movedItem.self.subItems?.length);
       if (movedItem.isMainDiagram && hasSubItems) {
         this.toaster.error(
@@ -85,15 +87,22 @@ export default class DiagramListDragAndDropSort extends Component {
           (item) => item.id !== movedItem.self.id,
         );
       }
-      if (replacedWith.isPlaceholder) {
+      if (effectiveTarget.isPlaceholder) {
         movedItem.self.position = 1;
-        replacedWith.parent.subItems = [movedItem.self];
-      } else if (replacedWith.isSubItem) {
-        const targetSubDiagrams = replacedWith.parent.subItems ?? [];
+        effectiveTarget.parent.subItems = [movedItem.self];
+      } else if (effectiveTarget.isSubItem) {
+        const targetSubDiagrams = effectiveTarget.parent.subItems ?? [];
         movedItem.self.position = targetSubDiagrams.length + 1;
-        replacedWith.parent.subItems = [...targetSubDiagrams, movedItem.self];
+        effectiveTarget.parent.subItems = [
+          ...targetSubDiagrams,
+          movedItem.self,
+        ];
       }
     } else {
+      if (!replacedWith) {
+        return;
+      }
+      const replacedItemOldPosition = replacedWith.self.position;
       replacedWith.self.position = movedItemOldPosition;
       movedItem.self.position = replacedItemOldPosition;
     }

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
+import { service } from '@ember/service';
+
 import { ARCHIVED_STATUS_URI } from '../../utils/well-known-uris';
 
 export default class DiagramListDragAndDropSort extends Component {
+  @service toaster;
+
   get items() {
     if (!this.args.diagramList) {
       return [];
@@ -61,12 +65,23 @@ export default class DiagramListDragAndDropSort extends Component {
     if (movedItem.parent.id !== replacedWith.parent.id) {
       const hasSubItems = Boolean(movedItem.self.subItems?.length);
       if (movedItem.isMainDiagram && hasSubItems) {
-        console.log('cannot move main diagram with sub items');
+        this.toaster.error(
+          'Je kan geen hoofddiagram met sub-diagrammen verplaatsen onder een andere hoofddiagram',
+          undefined,
+          {
+            timeOut: 2500,
+          },
+        );
         return;
       }
       if (movedItem.isMainDiagram && !hasSubItems) {
         const sourceItems = movedItem.parent.diagrams ?? [];
         movedItem.parent.diagrams = sourceItems.filter(
+          (item) => item.id !== movedItem.self.id,
+        );
+      } else if (movedItem.isSubItem) {
+        const sourceItems = movedItem.parent.subItems ?? [];
+        movedItem.parent.subItems = sourceItems.filter(
           (item) => item.id !== movedItem.self.id,
         );
       }

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -121,5 +121,35 @@ export default class DiagramListDragAndDropSort extends Component {
         movedItem.self.position = replacedItemOldPosition;
       }
     }
+
+    this.updatePositionsAfterReorder();
+    this.args.onUpdatedStructure?.(this.args.diagramList);
   }
+
+  updatePositionsAfterReorder() {
+    this.updatePositionsAsc(this.args.diagramList.diagrams);
+    this.args.diagramList.diagrams.forEach((m) =>
+      this.updatePositionsAsc(m.subItems ?? []),
+    );
+
+    const finalState = this.args.diagramList.diagrams.map((m) => ({
+      id: m.id,
+      position: m.position,
+      subItems: (m.subItems ?? []).map((s) => ({
+        id: s.id,
+        position: s.position,
+      })),
+    }));
+    console.log('finalState', finalState);
+  }
+
+  updatePositionsAsc = (items) => {
+    return items
+      .slice()
+      .sort((a, b) => a.position - b.position)
+      .map((item, index) => {
+        item.position = index + 1;
+        return item;
+      });
+  };
 }

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -21,6 +21,10 @@ export default class DiagramListDragAndDropSort extends Component {
         return [
           {
             isPlaceholder: true,
+            self: {
+              position: 1,
+            },
+            parent: _listItem,
           },
         ];
       }
@@ -30,6 +34,7 @@ export default class DiagramListDragAndDropSort extends Component {
           label: subItem.diagramFile.name,
           self: subItem,
           parent: _listItem,
+          isSubItem: true,
         };
       });
     };
@@ -39,6 +44,7 @@ export default class DiagramListDragAndDropSort extends Component {
       self: listItem,
       parent: this.args.diagramList,
       subItems: mapSubItems(listItem),
+      isMainDiagram: true,
     }));
   }
 
@@ -48,10 +54,33 @@ export default class DiagramListDragAndDropSort extends Component {
 
     const movedItem = sourceList[sourceIndex];
     const replacedWith = targetList[targetIndex];
+
     const movedItemOldPosition = movedItem.self.position;
     const replacedItemOldPosition = replacedWith.self.position;
 
-    replacedWith.self.position = movedItemOldPosition;
-    movedItem.self.position = replacedItemOldPosition;
+    if (movedItem.parent.id !== replacedWith.parent.id) {
+      const hasSubItems = Boolean(movedItem.self.subItems?.length);
+      if (movedItem.isMainDiagram && hasSubItems) {
+        console.log('cannot move main diagram with sub items');
+        return;
+      }
+      if (movedItem.isMainDiagram && !hasSubItems) {
+        const sourceItems = movedItem.parent.diagrams ?? [];
+        movedItem.parent.diagrams = sourceItems.filter(
+          (item) => item.id !== movedItem.self.id,
+        );
+      }
+      if (replacedWith.isPlaceholder) {
+        movedItem.self.position = 1;
+        replacedWith.parent.subItems = [movedItem.self];
+      } else if (replacedWith.isSubItem) {
+        const targetSubDiagrams = replacedWith.parent.subItems ?? [];
+        movedItem.self.position = targetSubDiagrams.length + 1;
+        replacedWith.parent.subItems = [...targetSubDiagrams, movedItem.self];
+      }
+    } else {
+      replacedWith.self.position = movedItemOldPosition;
+      movedItem.self.position = replacedItemOldPosition;
+    }
   }
 }

--- a/app/styles/_diagrams.scss
+++ b/app/styles/_diagrams.scss
@@ -74,19 +74,17 @@
   cursor: not-allowed !important;
 }
 
-$indent: 32px;
-$node-gap: 64px;
 .tree-node--sub {
   position: relative;
-  margin-left: $indent;
+  margin-left: 32px;
 
   &::before {
     content: '';
     position: absolute;
-    left: -#{$indent / 2};
-    top: -#{$node-gap};
-    width: $indent / 2;
-    height: calc(50% + #{$node-gap});
+    left: -16px;
+    top: -64px;
+    width: 16px;
+    height: calc(50% + 64px);
     border-left: 3px solid var(--au-gray-200);
     border-bottom: 3px solid var(--au-gray-200);
     border-bottom-left-radius: 5px;

--- a/app/styles/_diagrams.scss
+++ b/app/styles/_diagrams.scss
@@ -22,6 +22,11 @@
   border: 0.2rem solid var(--au-gray-200);
 }
 
+.border-line-dashed-200 {
+  border: 0.2rem solid var(--au-gray-200);
+  border-style: dashed;
+}
+
 .border-left-selected {
   border-left: 0.45rem solid var(--au-select-text-color) !important;
   border-style: inset;
@@ -63,4 +68,8 @@
 .thin-scrollbar {
   scrollbar-width: thin;
   scrollbar-color: #888 #f1f1f1;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed !important;
 }

--- a/app/styles/_diagrams.scss
+++ b/app/styles/_diagrams.scss
@@ -73,3 +73,22 @@
 .cursor-not-allowed {
   cursor: not-allowed !important;
 }
+
+$indent: 32px;
+$node-gap: 64px;
+.tree-node--sub {
+  position: relative;
+  margin-left: $indent;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: -#{$indent / 2};
+    top: -#{$node-gap};
+    width: $indent / 2;
+    height: calc(50% + #{$node-gap});
+    border-left: 3px solid var(--au-gray-200);
+    border-bottom: 3px solid var(--au-gray-200);
+    border-bottom-left-radius: 5px;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "ember-config-helper": "^0.1.3",
         "ember-copy": "^2.0.1",
         "ember-data": "~5.3.9",
+        "ember-drag-sort": "^5.0.0",
         "ember-focus-trap": "^1.1.1",
         "ember-inflector": "^4.0.2",
         "ember-load-initializers": "^3.0.1",
@@ -19481,6 +19482,24 @@
         "qunit": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ember-drag-sort": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-drag-sort/-/ember-drag-sort-5.0.0.tgz",
+      "integrity": "sha512-7FlzGAyzQ+d3snXZyuaLoMKcFAAoAMtcq0JZrOnenwI35ePM0DdZqlvt1IoKClMQaRhxkeBbmcNXv7+kmn2uKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.9",
+        "decorator-transforms": "^2.2.2",
+        "ember-element-helper": "^0.8.8"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@ember/test-helpers": ">= 3.0.0"
       }
     },
     "node_modules/ember-element-helper": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ember-config-helper": "^0.1.3",
     "ember-copy": "^2.0.1",
     "ember-data": "~5.3.9",
+    "ember-drag-sort": "^5.0.0",
     "ember-focus-trap": "^1.1.1",
     "ember-inflector": "^4.0.2",
     "ember-load-initializers": "^3.0.1",


### PR DESCRIPTION
## 🗒️ Description

We prepared the ticket for managing main and sub process with an analysis. This mentioned an addon that we should test out first. In this PR we create the basic functionality for that ticket so we know if it is possible with this addon.

## 🦮 How to test

1. Add this line to the process detail page (index.hbs)  `  <DiagramList::DragAndDropSort @diagramList={{@model.diagramList}}/>
`
3. Can re-order main diagrams **level 0**
4. Can move a main diagram as a sub diagram ( only when it has no sub items)
5. Can re-order sub diagrams **level 1**
6. Can move a sub diagram back to a main diagram

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

**v2**
<img width="1165" height="613" alt="image" src="https://github.com/user-attachments/assets/d7e75cd7-d522-4923-a424-b875785383c7" />


