### PR TITLE
OPH-1099 |  Transform relevant links to a table with modified dates

### DIFF
--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -179,7 +179,7 @@
 </DataCard>
 
 <FileUploadModal
-  @header="Voeg rotoe"
+  @header="Voeg bijlage toe"
   @title="Bestand selecteren"
   @helpTextDragDrop="Bestand wordt meteen toegevoegd aan bibliotheek na selectie"
   @forbidden=".bpmn,.vsdx"

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -2,7 +2,10 @@
   <:title>Bijlagen
     {{#unless this.versionedFiles.isRunning}}
       <Process::ChangedStatusPills::Attachments
-        @isShown={{and @versionedProcess (not this.fetchFilesForComparison.isRunning)}}
+        @isShown={{and
+          @versionedProcess
+          (not this.fetchFilesForComparison.isRunning)
+        }}
         @versioned={{this.versionedFiles.value.forVersion}}
         @current={{this.versionedFiles.value.forCurrent}}
         @singularLabel="bestand"
@@ -11,7 +14,10 @@
     {{/unless}}
     {{#unless this.versionedLinks.isRunning}}
       <Process::ChangedStatusPills::Attachments
-        @isShown={{and @versionedProcess (not this.fetchRelevantLinksForComparison.isRunning)}}
+        @isShown={{and
+          @versionedProcess
+          (not this.fetchRelevantLinksForComparison.isRunning)
+        }}
         @versioned={{this.versionedLinks.value.forVersion}}
         @current={{this.versionedLinks.value.forCurrent}}
         @singularLabel="link"
@@ -63,14 +69,6 @@
     </AuHelpText>
   </:subheader>
   <:card>
-    <Process::RelevantLinks
-      @process={{@process}}
-      @canEdit={{@canEdit}}
-      @isAddModalOpen={{this.isAddLinkModalOpen}}
-      @onLinkAdded={{fn (mut this.isAddLinkModalOpen) false}}
-      @closeModal={{fn (mut this.isAddLinkModalOpen) false}}
-      @onSaved={{@onSaved}}
-    />
     <AuDataTable
       @content={{this.attachments.value}}
       @isLoading={{this.fetchAttachments.isRunning}}
@@ -143,21 +141,17 @@
             </td>
             <td>
               <AuButton
-                @icon="download"
-                @skin="link"
+                @skin="naked"
                 @width="block"
-                @hideText="true"
                 {{on "click" (fn this.downloadFile attachment)}}
               >Download</AuButton>
             </td>
             {{#if @canEdit}}
               <td>
                 <AuButton
-                  @icon="bin"
                   @skin="naked"
                   @alert="true"
                   @width="block"
-                  @hideText="true"
                   @disabled={{attachment.informationAsset}}
                   {{on "click" (fn this.openDeleteModal attachment)}}
                 >Verwijder</AuButton>
@@ -171,11 +165,23 @@
       @metadata={{this.filesMeta}}
       @pageQueryParamName="attachmentsPage"
     />
+    <br />
+    <Process::RelevantLinks
+      @process={{@process}}
+      @canEdit={{@canEdit}}
+      @page={{@linksPage}}
+      @size={{@linksSize}}
+      @sort={{@linksSort}}
+      @isAddModalOpen={{this.isAddLinkModalOpen}}
+      @onLinkAdded={{fn (mut this.isAddLinkModalOpen) false}}
+      @closeModal={{fn (mut this.isAddLinkModalOpen) false}}
+      @onSaved={{@onSaved}}
+    />
   </:card>
 </DataCard>
 
 <FileUploadModal
-  @header="Voeg bijlage toe"
+  @header="Voeg rotoe"
   @title="Bestand selecteren"
   @helpTextDragDrop="Bestand wordt meteen toegevoegd aan bibliotheek na selectie"
   @forbidden=".bpmn,.vsdx"

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -33,7 +33,6 @@
         <AuDropdown @title="Voeg toe" @skin="secondary" @alignment="center">
           <AuButton
             role="menuitem"
-            @icon="link-external"
             @iconAlignment="left"
             @skin="link"
             {{on "click" (fn (mut this.isAddLinkModalOpen) true)}}
@@ -42,7 +41,6 @@
           </AuButton>
           <AuButton
             role="menuitem"
-            @icon="file"
             @iconAlignment="left"
             @skin="link"
             {{on "click" this.openAddModal}}

--- a/app/components/process/blueprint-card.hbs
+++ b/app/components/process/blueprint-card.hbs
@@ -48,7 +48,6 @@
       {{#if @canEdit}}
         <AuButton
           @skin="naked"
-          @icon="pencil"
           {{on "click" this.toggleEdit}}
         >Wijzig</AuButton>
       {{/if}}

--- a/app/components/process/details-card.hbs
+++ b/app/components/process/details-card.hbs
@@ -143,7 +143,6 @@
       {{#if @canEdit}}
         <AuButton
           @skin="naked"
-          @icon="pencil"
           {{on "click" this.toggleEdit}}
         >Wijzig</AuButton>
       {{/if}}

--- a/app/components/process/icr-card.hbs
+++ b/app/components/process/icr-card.hbs
@@ -76,7 +76,6 @@
       {{#if @canEdit}}
         <AuButton
           @skin="naked"
-          @icon="pencil"
           {{on "click" this.toggleEdit}}
         >Wijzig</AuButton>
       {{/if}}

--- a/app/components/process/inventory-process-card.hbs
+++ b/app/components/process/inventory-process-card.hbs
@@ -6,7 +6,6 @@
     {{#if (and @canEdit (not this.edit))}}
       <AuButton
         @skin="naked"
-        @icon="pencil"
         {{on "click" this.toggleEdit}}
       >Wijzig</AuButton>
     {{/if}}

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -1,9 +1,34 @@
-<AuList @divider={{true}} class="au-u-margin-bottom" as |Item|>
-  {{#each this.relevantLinks as |link|}}
-    <Item>
-      <div
-        class="au-u-padding-left show-element-on-hover au-u-flex au-u-flex--between"
-      >
+<AuDataTable
+  @content={{this.relevantLinks}}
+  @noDataMessage="Er werden geen relevante links gevonden"
+  @hidePagination={{true}}
+  @page={{@page}}
+  @size={{@size}}
+  @sort={{@sort}}
+  as |t|
+>
+  <t.content class="au-c-data-table__table--small" as |c|>
+    <c.header>
+      <AuDataTableThSortable
+        @field="href"
+        @currentSorting={{@sort}}
+        @label="Url"
+      />
+      <AuDataTableThSortable
+        @field="created"
+        @currentSorting={{@sort}}
+        @label="Toegevoegd op"
+      />
+      <AuDataTableThSortable
+        @field="modified"
+        @currentSorting={{@sort}}
+        @label="Aangepast op"
+      />
+      <th></th>
+      {{#if @canEdit}}<th></th>{{/if}}
+    </c.header>
+    <c.body as |link|>
+      <td class="au-u-1-2">
         <AuLinkExternal
           href={{link.href}}
           @icon="external-link"
@@ -12,30 +37,33 @@
         >
           {{link.displayLabel}}
         </AuLinkExternal>
-        {{#if @canEdit}}
-          <AuButtonGroup
-            @inline={{true}}
-            class="show-element-on-hover--element"
-          >
-            <AuButton
-              @icon="pencil"
-              @skin="naked"
-              @size="large"
-              {{on "click" (fn this.openEditModal link)}}
-            />
-            <AuButton
-              @icon="bin"
-              @skin="naked"
-              @size="large"
-              @alert={{true}}
-              {{on "click" (fn this.openDeleteModal link)}}
-            />
-          </AuButtonGroup>
-        {{/if}}
-      </div>
-    </Item>
-  {{/each}}
-</AuList>
+      </td>
+      <td>{{or (date-format link.created) "/"}}</td>
+      <td>{{or (date-format link.modified) "/"}}</td>
+      {{#if @canEdit}}
+        <td>
+          <AuButton
+            @skin="naked"
+            @width="block"
+            {{on "click" (fn this.openEditModal link)}}
+          >Wijzig</AuButton>
+        </td>
+        <td>
+          <AuButton
+            @skin="naked"
+            @width="block"
+            @alert="true"
+            {{on "click" (fn this.openDeleteModal link)}}
+          >Verwijder</AuButton>
+        </td>
+      {{/if}}
+    </c.body>
+  </t.content>
+</AuDataTable>
+<Shared::TablePagination
+  @metadata={{this.filesMeta}}
+  @pageQueryParamName="attachmentsPage"
+/>
 
 <AuModal @modalOpen={{@isAddModalOpen}} @closeModal={{this.closeAddModal}}>
   <:title>Voeg link toe</:title>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -1,7 +1,8 @@
 <AuDataTable
-  @content={{this.relevantLinks}}
+  @content={{this.links.value}}
+  @isLoading={{this.fetchLinks.isRunning}}
   @noDataMessage="Er werden geen relevante links gevonden"
-  @hidePagination={{true}}
+  {{!-- @hidePagination={{true}} --}}
   @page={{@page}}
   @size={{@size}}
   @sort={{@sort}}
@@ -12,7 +13,7 @@
       <AuDataTableThSortable
         @field="href"
         @currentSorting={{@sort}}
-        @label="Url"
+        @label="Link"
       />
       <AuDataTableThSortable
         @field="created"
@@ -38,8 +39,8 @@
           {{link.displayLabel}}
         </AuLinkExternal>
       </td>
-      <td>{{or (date-format link.created) "/"}}</td>
-      <td>{{or (date-format link.modified) "/"}}</td>
+      <td>{{or (date-format link.created true) "/"}}</td>
+      <td>{{or (date-format link.modified true) "/"}}</td>
       {{#if @canEdit}}
         <td>
           <AuButton
@@ -60,10 +61,6 @@
     </c.body>
   </t.content>
 </AuDataTable>
-<Shared::TablePagination
-  @metadata={{this.filesMeta}}
-  @pageQueryParamName="attachmentsPage"
-/>
 
 <AuModal @modalOpen={{@isAddModalOpen}} @closeModal={{this.closeAddModal}}>
   <:title>Voeg link toe</:title>
@@ -104,13 +101,14 @@
     <AuButtonGroup class="au-u-flex--end">
       <AuButton
         @skin="secondary"
+        class="border-radius"
         {{on "click" this.closeAddModal}}
       >Annuleer</AuButton>
       <AuButton
-        @icon="plus"
         @disabled={{not this.canSaveChanges}}
         @loading={{this.isExecutingAction}}
         @loadingMessage="Link toevoegen"
+        class="border-radius"
         {{on "click" this.addLink}}
       >Voeg toe</AuButton>
     </AuButtonGroup>
@@ -152,11 +150,12 @@
   <:footer>
     <AuButtonGroup class="au-u-flex--end">
       <AuButton
+        class="border-radius"
         @skin="secondary"
         {{on "click" this.closeEditModal}}
       >Annuleer</AuButton>
       <AuButton
-        @icon="pencil"
+        class="border-radius"
         @disabled={{not this.canUpdateChanges}}
         @loading={{this.isExecutingAction}}
         @loadingMessage="Link aanpassen"
@@ -178,10 +177,12 @@
   <:footer>
     <AuButtonGroup class="au-u-flex--end">
       <AuButton
+        class="border-radius"
         @skin="secondary"
         {{on "click" (fn (mut this.isDeleteModalOpen) false)}}
       >Annuleer</AuButton>
       <AuButton
+        class="border-radius"
         @icon="trash"
         @alert={{true}}
         @disabled={{this.isExecutingAction}}

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -3,6 +3,8 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import { task as trackedTask } from 'reactiveweb/ember-concurrency';
 
 import { isEmptyOrUrl } from '../../utils/custom-validators';
 
@@ -20,9 +22,7 @@ export default class ProcessRelevantLinks extends Component {
   @tracked labelValue;
   @tracked linkValue;
 
-  get relevantLinks() {
-    return this.args.process?.links?.filter((link) => !link.isArchived) ?? [];
-  }
+  @tracked filesMeta = {};
 
   get isLinkValid() {
     return isEmptyOrUrl(this.linkValue);
@@ -208,4 +208,24 @@ export default class ProcessRelevantLinks extends Component {
     this.resetLabelAndValueToNull();
     this.isExecutingAction = false;
   }
+
+  fetchLinks = task({ restartable: true }, async (process) => {
+    const allLinks = process?.links?.filter((link) => !link.isArchived) ?? [];
+    const linkIds = allLinks.map((link) => link.id);
+
+    return await this.store.query('link', {
+      'filter[id]': linkIds.join(','),
+      page: {
+        number: this.args.page ?? 0,
+        size: this.args.size ?? 5,
+      },
+      sort: this.args.sort,
+    });
+  });
+
+  links = trackedTask(this, this.fetchLinks, () => [
+    this.args.process,
+    this.args.page,
+    this.args.sort,
+  ]);
 }

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -11,6 +11,9 @@ export default class ProcessesProcessIndexController extends Controller {
     'attachmentsPage',
     'attachmentsSize',
     'attachmentsSort',
+    'relevantLinksPage',
+    'relevantLinksSize',
+    'relevantLinksSort',
     'diagramVersionsPage',
     'diagramVersionsSort',
     'diagramsPage',
@@ -19,7 +22,10 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked versionedProcessId = null;
   @tracked attachmentsPage = 0;
   @tracked attachmentsSize = 5;
-  @tracked attachmentsSort = 'name';
+  @tracked attachmentsSort = '-created';
+  @tracked relevantLinksPage = 0;
+  @tracked relevantLinksSize = 5;
+  @tracked relevantLinksSort = '-created';
   @tracked diagramVersionsPage = 0;
   @tracked diagramVersionsSort = '-created';
   @tracked diagramsPage = 0;

--- a/app/models/link.js
+++ b/app/models/link.js
@@ -5,6 +5,14 @@ export default class LinkModel extends Model {
   @attr('string') label;
   @attr('string') href;
   @attr('string') status;
+  @attr('iso-date', {
+    default: new Date(),
+  })
+  created;
+  @attr('iso-date', {
+    default: new Date(),
+  })
+  modified;
 
   get displayLabel() {
     if (!this.label) {
@@ -15,5 +23,10 @@ export default class LinkModel extends Model {
 
   get isArchived() {
     return this.status === ENV.resourceStates.archived;
+  }
+
+  async save() {
+    this.modified = new Date();
+    await super.save(...arguments);
   }
 }

--- a/app/models/link.js
+++ b/app/models/link.js
@@ -26,6 +26,10 @@ export default class LinkModel extends Model {
   }
 
   async save() {
+    if (!this.created) {
+      this.created = new Date();
+    }
+
     this.modified = new Date();
     await super.save(...arguments);
   }

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -12,31 +12,33 @@ export default class ProcessesProcessIndexRoute extends Route {
     versionedProcessId: {
       replace: true,
     },
-
     attachmentsPage: {
       replace: true,
     },
-
     attachmentsSize: {
       replace: true,
     },
-
     attachmentsSort: {
       replace: true,
     },
-
+    relevantLinksPage: {
+      replace: true,
+    },
+    relevantLinksSize: {
+      replace: true,
+    },
+    relevantLinksSort: {
+      replace: true,
+    },
     diagramVersionsPage: {
       replace: true,
     },
-
     diagramVersionsSort: {
       replace: true,
     },
-
     diagramsPage: {
       replace: true,
     },
-
     diagramsSort: {
       replace: true,
     },

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -160,6 +160,9 @@
     @page={{this.attachmentsPage}}
     @size={{this.attachmentsSize}}
     @sort={{this.attachmentsSort}}
+    @linksPage={{this.relevantLinksPage}}
+    @linksSize={{this.relevantLinksSize}}
+    @linksSort={{this.relevantLinksSort}}
     @reloadTableData={{this.fetchAttachments}}
     @onSaved={{this.clearVersionedProcess}}
   />


### PR DESCRIPTION
## 🗒️ Description

Now that the process page can show the differences between versions we want to see the modified and created date. Transform the list to a table for the relevant links.

## 🦮 How to test

1. Links are in a table
2. Can sort the table
3. created is added when adding a link
4. modified is updated when the link gets change
5. can remove a link
6. datatable info gets updated on change 

## 🔗 Links to other PR's

- https://github.com/lblod/app-openproceshuis/pull/161

## 🖼️ Attachments

**v2**
<img width="2260" height="867" alt="image" src="https://github.com/user-attachments/assets/eb936961-fa87-4324-82f8-e4fa57d723af" />


