### PR TITLE
OPH-864 | Allow structuring of diagrams

### DIFF
--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -16,7 +16,7 @@
         <AuIcon @icon="drag-handle" @size="large" class="au-u-margin-right" />
       </div>
     </div>
-    <div class="au-u-margin-left">
+    {{!-- <div class="au-u-margin-left">
       <DragSortList
         @items={{item.subItems}}
         @dragEndAction={{this.dragEnd}}
@@ -57,7 +57,7 @@
             </div>
           </div>
         {{/if}}
-      </DragSortList>
-    </div>
+      </DragSortList> 
+    </div>--}}
   </DragSortList>
 </div>

--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -122,25 +122,11 @@ export default class DiagramListDragAndDropSort extends Component {
       }
     }
 
-    this.updatePositionsAfterReorder();
-    this.args.onUpdatedStructure?.(this.args.diagramList);
-  }
-
-  updatePositionsAfterReorder() {
     this.updatePositionsAsc(this.args.diagramList.diagrams);
     this.args.diagramList.diagrams.forEach((m) =>
       this.updatePositionsAsc(m.subItems ?? []),
     );
-
-    const finalState = this.args.diagramList.diagrams.map((m) => ({
-      id: m.id,
-      position: m.position,
-      subItems: (m.subItems ?? []).map((s) => ({
-        id: s.id,
-        position: s.position,
-      })),
-    }));
-    console.log('finalState', finalState);
+    this.args.onUpdatedStructure?.(this.args.diagramList);
   }
 
   updatePositionsAsc = (items) => {

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -67,6 +67,9 @@
           {{/if}}
         {{/if}}
       {{/if}}
+      {{#if (eq this.activeStep.step this.wizardStep.STRUCTURE_DIAGRAMS)}}
+        <DiagramList::DragAndDropSort @diagramList={{this.diagramList}} />
+      {{/if}}
     {{/unless}}
   </:body>
   <:footer>

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -22,7 +22,7 @@
         {{/if}}
       </div>
     {{/if}}
-    {{#unless this.executeCurrentStepActionAsTask.isRunning}}
+    {{#unless this.executeStepActionAsTask.isRunning}}
       {{#if (eq this.activeStep.step this.wizardStep.SELECT_ACTION)}}
         <Wizard::Actions
           @onActionSelected={{this.onActionSelected}}
@@ -89,6 +89,7 @@
         {{#if this.activeStep.nextStepButtonLabel}}
           <AuButton
             class="border-radius"
+            @loading={{this.executeStepActionAsTask.isRunning}}
             {{on "click" this.nextStep}}
             @disabled={{not this.activeStep.canGoToNextStep}}
           >

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -76,6 +76,16 @@
     <AuToolbar as |Group|>
       <Group />
       <Group>
+        {{#if this.activeStep.canCancelStep}}
+          <AuButton
+            class="border-radius"
+            @skin="secondary"
+            {{on "click" this.restoreAndCloseWizard}}
+            @disabled={{not this.activeStep.canCancelStep}}
+          >
+            Annuleer
+          </AuButton>
+        {{/if}}
         {{#if this.activeStep.nextStepButtonLabel}}
           <AuButton
             class="border-radius"

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -68,7 +68,13 @@
         {{/if}}
       {{/if}}
       {{#if (eq this.activeStep.step this.wizardStep.STRUCTURE_DIAGRAMS)}}
-        <DiagramList::DragAndDropSort @diagramList={{this.diagramList}} />
+        <p class="au-u-muted au-u-italic">Hieronder vind je al de diagrammen die
+          opgeladen werden. Door een diagram vast te nemen en te verplaatsen pas
+          je de positie van het diagram aan, waarbij het bovenste diagram je
+          hoofd diagram is.</p>
+        <div class="au-o-box">
+          <DiagramList::DragAndDropSort @diagramList={{this.diagramList}} />
+        </div>
       {{/if}}
     {{/unless}}
   </:body>

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -36,6 +36,7 @@ export default class ProcessWizard extends Component {
     UPLOAD_FILES: 'upload_files',
     SELECT_MAIN_PROCESS: 'select_main_process',
     CHANGE_MAIN_PROCESS: 'change_main_process',
+    STRUCTURE_DIAGRAMS: 'structure_diagrams',
     CREATE_PROCESS: 'create_process',
     UPDATE_PROCESS: 'update_process',
     CREATE_DIAGRAM_VERSION: 'create_diagram_version',
@@ -96,6 +97,13 @@ export default class ProcessWizard extends Component {
         canGoToNextStep: this.currentAction,
         nextStepButtonLabel: null,
         action: async () => await this.prepareWizard(),
+      },
+      {
+        step: this.wizardStep.STRUCTURE_DIAGRAMS,
+        title: 'Diagrammen structuur',
+        isStepShown: this.currentAction === WizardAction.STRUCTURE_DIAGRAMS,
+        canGoToNextStep: true,
+        nextStepButtonLabel: 'Aanpassen',
       },
       {
         step: this.wizardStep.UPLOAD_FILES,

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -104,6 +104,7 @@ export default class ProcessWizard extends Component {
         isStepShown: this.currentAction === WizardAction.STRUCTURE_DIAGRAMS,
         canGoToNextStep: true,
         nextStepButtonLabel: 'Aanpassen',
+        canCancelStep: true,
       },
       {
         step: this.wizardStep.UPLOAD_FILES,
@@ -167,6 +168,12 @@ export default class ProcessWizard extends Component {
         nextStepButtonLabel: null,
       },
     ];
+  }
+
+  @action
+  async restoreAndCloseWizard() {
+    this.loadingMessage = 'We sluiten de wizard af';
+    await this.router.refresh();
   }
 
   @action

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -68,6 +68,7 @@ export default class ProcessWizard extends Component {
     if (!this.steps[this.activeStepIndex].canGoToNextStep) {
       return null;
     }
+    await this.activeStep.actionAtEndOfStep?.();
     let nextStepIndex = this.activeStepIndex + 1;
     if (this.activeStepIsFinalStep) {
       return null;
@@ -105,6 +106,8 @@ export default class ProcessWizard extends Component {
         canGoToNextStep: true,
         nextStepButtonLabel: 'Aanpassen',
         canCancelStep: true,
+        actionAtEndOfStep: async () =>
+          await this.diagramList.saveDiagramStructure(),
       },
       {
         step: this.wizardStep.UPLOAD_FILES,

--- a/app/components/wizard/actions.js
+++ b/app/components/wizard/actions.js
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 export const WizardAction = Object.freeze({
   REPLACE_DIAGRAMS: 'replace_diagrams',
   CHANGE_MAIN_PROCESS: 'change_main_process',
+  STRUCTURE_DIAGRAMS: 'structure_diagrams',
 });
 
 export default class WizardActions extends Component {
@@ -36,6 +37,20 @@ export default class WizardActions extends Component {
         isDisabled: this.isActionDisabled(WizardAction.CHANGE_MAIN_PROCESS),
         disabledReason:
           'Je hebt één diagram geüpload. Dit is automatisch het hoofddiagram.',
+      },
+      {
+        label: 'Diagrammen structuur wijzigen',
+        icon: 'filter',
+        iconColorClass: 'fill: var(--au-orange-500) !important',
+        description: 'Wijzig het hoofdproces van het proces.',
+        next: () => {
+          if (this.isActionDisabled(WizardAction.STRUCTURE_DIAGRAMS)) {
+            return;
+          }
+          this.args.onActionSelected(WizardAction.STRUCTURE_DIAGRAMS);
+        },
+        isDisabled: this.isActionDisabled(WizardAction.STRUCTURE_DIAGRAMS),
+        disabledReason: 'Deze actie is tijdelijk niet beschikbaar',
       },
     ];
   }

--- a/app/components/wizard/actions.js
+++ b/app/components/wizard/actions.js
@@ -42,7 +42,7 @@ export default class WizardActions extends Component {
         label: 'Diagrammen structuur wijzigen',
         icon: 'filter',
         iconColorClass: 'fill: var(--au-orange-500) !important',
-        description: 'Wijzig het hoofdproces van het proces.',
+        description: 'Wijzig de structuur/positie van de diagrammen.',
         next: () => {
           if (this.isActionDisabled(WizardAction.STRUCTURE_DIAGRAMS)) {
             return;

--- a/app/models/diagram-list.js
+++ b/app/models/diagram-list.js
@@ -28,4 +28,21 @@ export default class DiagramListModel extends Model {
   archive() {
     this.status = ENV.resourceStates.archived;
   }
+
+  async saveDiagramStructure() {
+    const subItemSavePromises = this.diagrams
+      .map((main) => main.subItems)
+      .flat();
+    await Promise.all(subItemSavePromises);
+    const mainDiagramSavePromises = this.diagrams.map(
+      async (main) => await main.save(),
+    );
+    await Promise.all(mainDiagramSavePromises);
+    await this.save();
+  }
+
+  async save() {
+    this.modified = new Date();
+    await super.save(...arguments);
+  }
 }

--- a/app/styles/components/_c-wizard.scss
+++ b/app/styles/components/_c-wizard.scss
@@ -10,9 +10,10 @@
 }
 
 .wizard-actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .wizard-actions > div {


### PR DESCRIPTION
## 🗒️ Description

The epic of this ticket is SUB-PROCESSES but we can actually only allow main diagrams in the diagram table. Prepare this functionality so we can also add diagrams under a main diagram. To do this use the ember-drag-sort library.

[!NOTE]
The template for subprocess is commented out as we do not show these sub items in the diagrams table just yet

## 🦮 How to test

1. Create a new process
2. Edit that process by changing the main process
3. Edit the same process but change the structure of it
4. Changes are applied and order is correct
5. Sub items is not allowed as we do not show these in the table

## 🔗 Links to other PR's

- From https://github.com/lblod/frontend-openproceshuis/pull/240

## 🖼️ Attachments

**Action added**
<img width="1746" height="1123" alt="image" src="https://github.com/user-attachments/assets/d67eea99-bceb-47fb-b543-2a4581172525" />


**Re structure**
<img width="1746" height="1123" alt="image" src="https://github.com/user-attachments/assets/ac712430-e2f1-43bb-a2a2-f84fb7869c76" />

