### PR TITLE
OPH-1109 | Relevant links show gekoppeld aan

### DIFF
--- a/app/components/diagram-list/table/row.hbs
+++ b/app/components/diagram-list/table/row.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable no-invalid-interactive }}
 <td
-  class="{{if
+  class="au-u-1-2 {{if
       (eq @diagram.diagramFile.id @selectedDiagramFile.id)
       'border-left-selected'
       'border-left-transparent'
@@ -14,7 +14,7 @@
     />
   </span>
   <AuButton
-    class={{if @isSubRow "au-u-margin-left-large" ""}}
+    class={{if @isSubRow "au-u-margin-left" ""}}
     @skin="link"
     {{on "click" (fn @onDiagramFileSelected @diagram.diagramFile)}}
   >

--- a/app/components/icr/attachments.hbs
+++ b/app/components/icr/attachments.hbs
@@ -47,12 +47,17 @@
 
   <:card>
     <Process::RelevantLinks
-      @process={{@informationAsset}}
+      @informationAsset={{@informationAsset}}
       @canEdit={{@canEdit}}
+      @page={{@linksPage}}
+      @size={{@linksSize}}
+      @sort={{@linksSort}}
       @isAddModalOpen={{this.isAddLinkModalOpen}}
       @onLinkAdded={{fn (mut this.isAddLinkModalOpen) false}}
       @closeModal={{fn (mut this.isAddLinkModalOpen) false}}
+      @onSaved={{@onSaved}}
     />
+    <br />
     <AuDataTable
       @content={{this.attachments}}
       @isLoading={{this.attachmentsAreLoading}}
@@ -95,27 +100,25 @@
           </TableMessage>
         {{else}}
           <c.body as |attachment|>
-            <td>{{attachment.name}}</td>
+            <td class="au-u-1-2">
+              {{attachment.name}}
+            </td>
             <td>{{file-size-format attachment.size}}</td>
             <td>{{attachment.extension}}</td>
             <td>{{date-format attachment.created true}}</td>
             <td>
               <AuButton
-                @icon="download"
-                @skin="link"
+                @skin="naked"
                 @width="block"
-                @hideText="true"
                 {{on "click" (fn this.downloadFile attachment)}}
               >Download</AuButton>
             </td>
             {{#if @canEdit}}
               <td>
                 <AuButton
-                  @icon="bin"
                   @skin="naked"
                   @alert="true"
                   @width="block"
-                  @hideText="true"
                   {{on "click" (fn this.openDeleteModal attachment)}}
                 >Verwijder</AuButton>
               </td>

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -175,7 +175,7 @@
       @isAddModalOpen={{this.isAddLinkModalOpen}}
       @onLinkAdded={{fn (mut this.isAddLinkModalOpen) false}}
       @closeModal={{fn (mut this.isAddLinkModalOpen) false}}
-      @onSaved={{@onSaved}}
+      @onSaved={{@reloadLinksData}}
     />
   </:card>
 </DataCard>

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -112,26 +112,28 @@
           </TableMessage>
         {{else}}
           <c.body as |attachment|>
-            <td>{{attachment.name}}</td>
+            <td class="au-u-1-2">
+              {{attachment.name}}
+            </td>
             <td>{{file-size-format attachment.size}}</td>
             <td>{{attachment.extension}}</td>
             <td>{{date-format attachment.created true}}</td>
-            <td>{{attachment._source}}
-              {{#if attachment.informationAssets}}
-                {{#each attachment.informationAssets as |icr|}}
-                  <AuLink
-                    @route="information-assets.information-asset"
-                    @model={{icr.id}}
-                    @query={{hash
-                      process=@process.id
-                      parentRoute=this.currentProcessRouteName
-                    }}
-                  >
-                    {{icr.title}}
-                  </AuLink>
-                {{/each}}
-
+            <td>
+              {{#if attachment._icrSource}}
+                Asset -
+                <AuLink
+                  @route="information-assets.information-asset"
+                  @model={{attachment._icrSource.id}}
+                  @query={{hash
+                    process=@process.id
+                    parentRoute=this.currentProcessRouteName
+                    edit=false
+                  }}
+                >
+                  {{attachment._icrSource.title}}
+                </AuLink>
               {{else}}
+                Proces -
                 <AuLink @route="processes.process" @model={{@process.id}}>
                   {{@process.title}}
                 </AuLink>
@@ -150,7 +152,7 @@
                   @skin="naked"
                   @alert="true"
                   @width="block"
-                  @disabled={{attachment.informationAsset}}
+                  @disabled={{attachment._icrSource}}
                   {{on "click" (fn this.openDeleteModal attachment)}}
                 >Verwijder</AuButton>
               </td>

--- a/app/components/process/attachments.js
+++ b/app/components/process/attachments.js
@@ -156,23 +156,51 @@ export default class ProcessAttachments extends Component {
     return await this.store.query('file', query);
   }
 
-  fetchAttachments = task({ restartable: true }, async (process, page = 0) => {
+  fetchAttachments = task({ restartable: true }, async (_process, page = 0) => {
     try {
-      const processFileIds = await this.fetchProcessAttachmentFileIds(
-        process.id,
-      );
-      const infoAssetFileIds = await this.fetchProcessIcrFileIds(
-        process.informationAssets,
-      );
+      const process = await this.store.findRecord('process', _process.id, {
+        include:
+          'attachments,information-assets,information-assets.attachments',
+      });
+
+      const processFiles =
+        process?.attachments?.filter((f) => !f.isArchived) ?? [];
+
+      const icrSourceMap = new Map();
+      for (const icrAsset of process.informationAssets) {
+        const files = icrAsset.attachments.filter((f) => !f.isArchived) ?? [];
+        for (const file of files) {
+          icrSourceMap.set(file.id, {
+            id: icrAsset.id,
+            title: icrAsset.title ?? '/',
+          });
+        }
+      }
+
+      const fileIds = [
+        ...processFiles.map((f) => f.id),
+        ...icrSourceMap.keys(),
+      ];
 
       this.filesMeta = {};
-      const files = await this.fetchFilesWithIds(
-        [...processFileIds, ...infoAssetFileIds],
-        page,
-        this.args.size ?? 10,
-      );
-      this.filesMeta = files.meta;
-      return files;
+      const result = await this.store.query('file', {
+        'filter[id]': fileIds.join(','),
+        page: {
+          number: page,
+          size: this.args.size ?? 10,
+        },
+        sort: this.sort,
+      });
+      this.filesMeta = result.meta;
+
+      for (const file of result) {
+        const source = icrSourceMap.get(file.id);
+        if (source) {
+          file._icrSource = source;
+        }
+      }
+
+      return result;
     } catch {
       return [];
     }

--- a/app/components/process/attachments.js
+++ b/app/components/process/attachments.js
@@ -107,7 +107,7 @@ export default class ProcessAttachments extends Component {
   });
 
   get sort() {
-    return this.args.sort ?? 'name';
+    return this.args.sort ?? 'modified';
   }
 
   async fetchProcessAttachmentFileIds(processId) {
@@ -161,6 +161,7 @@ export default class ProcessAttachments extends Component {
       const process = await this.store.findRecord('process', _process.id, {
         include:
           'attachments,information-assets,information-assets.attachments',
+        reload: true,
       });
 
       const processFiles =

--- a/app/components/process/diagram/version.hbs
+++ b/app/components/process/diagram/version.hbs
@@ -3,8 +3,8 @@
   <:header></:header>
   <:subheader>
     <AuHelpText @skin="secondary">
-      Ontdek hier vorige diagrammen versies van dit proces, geüpload in het
-      Open Proces Huis. Deze versies zijn beschikbaar om te downloaden.
+      Ontdek hier vorige diagrammen versies van dit proces, geüpload in het Open
+      Proces Huis. Deze versies zijn beschikbaar om te downloaden.
     </AuHelpText></:subheader>
 
   <:card>
@@ -38,7 +38,7 @@
           </TableMessage>
         {{else}}
           <c.body as |version|>
-            <td>
+            <td class="au-u-1-2">
               {{version.mainDiagramFileName}}
               {{#unless version.canRemove}}
                 <strong>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -25,7 +25,7 @@
         @currentSorting={{@sort}}
         @label="Aangepast op"
       />
-      <th>Gekoppeld aan</th>
+      {{#unless this.isIcr}}<th>Gekoppeld aan</th>{{/unless}}
       <th></th>
       {{#if @canEdit}}<th></th>{{/if}}
     </c.header>
@@ -42,31 +42,33 @@
       </td>
       <td>{{or (date-format link.created true) "/"}}</td>
       <td>{{or (date-format link.modified true) "/"}}</td>
-      <td>
-        {{#if link._icrSource}}
-          Asset -
-          <AuLink
-            @route="information-assets.information-asset"
-            @model={{link._icrSource.id}}
-            @query={{hash
-              process=@process.id
-              parentRoute=this.currentProcessRouteName
-              edit=false
-            }}
-          >
-            {{link._icrSource.title}}
-          </AuLink>
-        {{else}}
-          Proces -
-          <AuLink @route="processes.process" @model={{@process.id}}>
-            {{@process.title}}
-          </AuLink>
-        {{/if}}
-      </td>
+      {{#unless this.isIcr}}
+        <td>
+          {{#if link._icrSource}}
+            Asset -
+            <AuLink
+              @route="information-assets.information-asset"
+              @model={{link._icrSource.id}}
+              @query={{hash
+                process=@process.id
+                parentRoute=this.currentProcessRouteName
+                edit=false
+              }}
+            >
+              {{link._icrSource.title}}
+            </AuLink>
+          {{else}}
+            Proces -
+            <AuLink @route="processes.process" @model={{@process.id}}>
+              {{@process.title}}
+            </AuLink>
+          {{/if}}
+        </td>
+      {{/unless}}
       {{#if @canEdit}}
         <td>
           <AuButton
-            @disabled={{link._icrSource}}
+            @disabled={{and link._icrSource (not this.isIcr)}}
             @skin="naked"
             @width="block"
             {{on "click" (fn this.openEditModal link)}}
@@ -74,6 +76,7 @@
         </td>
         <td>
           <AuButton
+            @disabled={{and link._icrSource (not this.isIcr)}}
             @skin="naked"
             @width="block"
             @alert="true"

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -2,7 +2,7 @@
   @content={{this.links.value}}
   @isLoading={{this.fetchLinks.isRunning}}
   @noDataMessage="Er werden geen relevante links gevonden"
-  {{!-- @hidePagination={{true}} --}}
+  @hidePagination={{true}}
   @page={{@page}}
   @size={{@size}}
   @sort={{@sort}}
@@ -87,6 +87,10 @@
     </c.body>
   </t.content>
 </AuDataTable>
+<Shared::TablePagination
+  @metadata={{this.linksMeta}}
+  @pageQueryParamName="relevantLinksPage"
+/>
 
 <AuModal @modalOpen={{@isAddModalOpen}} @closeModal={{this.closeAddModal}}>
   <:title>Voeg link toe</:title>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -25,6 +25,7 @@
         @currentSorting={{@sort}}
         @label="Aangepast op"
       />
+      <th>Gekoppeld aan</th>
       <th></th>
       {{#if @canEdit}}<th></th>{{/if}}
     </c.header>
@@ -41,9 +42,31 @@
       </td>
       <td>{{or (date-format link.created true) "/"}}</td>
       <td>{{or (date-format link.modified true) "/"}}</td>
+      <td>
+        {{#if link._icrSource}}
+          Asset -
+          <AuLink
+            @route="information-assets.information-asset"
+            @model={{link._icrSource.id}}
+            @query={{hash
+              process=@process.id
+              parentRoute=this.currentProcessRouteName
+              edit=false
+            }}
+          >
+            {{link._icrSource.title}}
+          </AuLink>
+        {{else}}
+          Proces -
+          <AuLink @route="processes.process" @model={{@process.id}}>
+            {{@process.title}}
+          </AuLink>
+        {{/if}}
+      </td>
       {{#if @canEdit}}
         <td>
           <AuButton
+            @disabled={{link._icrSource}}
             @skin="naked"
             @width="block"
             {{on "click" (fn this.openEditModal link)}}

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -23,7 +23,7 @@ export default class ProcessRelevantLinks extends Component {
   @tracked labelValue;
   @tracked linkValue;
 
-  @tracked filesMeta = {};
+  @tracked linksMeta = {};
 
   get isLinkValid() {
     return isEmptyOrUrl(this.linkValue);
@@ -261,7 +261,10 @@ export default class ProcessRelevantLinks extends Component {
       ];
     }
 
-    if (linkIds.length === 0) return [];
+    if (linkIds.length === 0) {
+      this.linksMeta = {};
+      return [];
+    }
 
     const result = await this.store.query('link', {
       'filter[id]': linkIds.join(','),
@@ -271,6 +274,7 @@ export default class ProcessRelevantLinks extends Component {
       },
       sort: this.args.sort,
     });
+    this.linksMeta = result.meta;
 
     for (const link of result) {
       const source = linkSourceMap.get(link.id);

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -13,6 +13,7 @@ import ENV from 'frontend-openproceshuis/config/environment';
 export default class ProcessRelevantLinks extends Component {
   @service store;
   @service toaster;
+  @service router;
 
   @tracked isEditModalOpen = false;
   @tracked isDeleteModalOpen = false;
@@ -70,6 +71,10 @@ export default class ProcessRelevantLinks extends Component {
     }
 
     return false;
+  }
+
+  get currentProcessRouteName() {
+    return this.router.currentRouteName?.replace('.index', '');
   }
 
   @action
@@ -209,11 +214,30 @@ export default class ProcessRelevantLinks extends Component {
     this.isExecutingAction = false;
   }
 
-  fetchLinks = task({ restartable: true }, async (process) => {
-    const allLinks = process?.links?.filter((link) => !link.isArchived) ?? [];
-    const linkIds = allLinks.map((link) => link.id);
+  fetchLinks = task({ restartable: true }, async (_process) => {
+    const process = await this.store.findRecord('process', _process.id, {
+      include: 'links,information-assets,information-assets.links',
+    });
+    const processLinks =
+      process?.links?.filter((link) => !link.isArchived) ?? [];
 
-    return await this.store.query('link', {
+    const linkSourceMap = new Map();
+    for (const icrAsset of await process.informationAssets) {
+      const links = icrAsset.links.filter((link) => !link.isArchived) ?? [];
+      for (const link of links) {
+        linkSourceMap.set(link.id, {
+          id: icrAsset.id,
+          title: icrAsset.title ?? '/',
+        });
+      }
+    }
+
+    const linkIds = [
+      ...processLinks.map((link) => link.id),
+      ...linkSourceMap.keys(),
+    ];
+
+    const result = await this.store.query('link', {
       'filter[id]': linkIds.join(','),
       page: {
         number: this.args.page ?? 0,
@@ -221,6 +245,15 @@ export default class ProcessRelevantLinks extends Component {
       },
       sort: this.args.sort,
     });
+
+    for (const link of result) {
+      const source = linkSourceMap.get(link.id);
+      if (source) {
+        link._icrSource = source;
+      }
+    }
+
+    return result;
   });
 
   links = trackedTask(this, this.fetchLinks, () => [

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -217,6 +217,7 @@ export default class ProcessRelevantLinks extends Component {
   fetchLinks = task({ restartable: true }, async (_process) => {
     const process = await this.store.findRecord('process', _process.id, {
       include: 'links,information-assets,information-assets.links',
+      reload: true,
     });
     const processLinks =
       process?.links?.filter((link) => !link.isArchived) ?? [];

--- a/app/components/process/relevant-links.js
+++ b/app/components/process/relevant-links.js
@@ -73,6 +73,14 @@ export default class ProcessRelevantLinks extends Component {
     return false;
   }
 
+  get resource() {
+    return this.args.informationAsset ?? this.args.process;
+  }
+
+  get isIcr() {
+    return !!this.args.informationAsset;
+  }
+
   get currentProcessRouteName() {
     return this.router.currentRouteName?.replace('.index', '');
   }
@@ -125,7 +133,7 @@ export default class ProcessRelevantLinks extends Component {
       label: this.cleanLabel,
       href: this.cleanLink,
     });
-    const links = await this.args.process.links;
+    const links = await this.resource.links;
     if (links.find((l) => !l.isArchived && l.href === linkModel.href)) {
       this.toaster.error('Deze link werd al toegevoegd.', undefined, {
         timeOut: 5000,
@@ -138,8 +146,8 @@ export default class ProcessRelevantLinks extends Component {
     try {
       await linkModel.save();
       links.push(linkModel);
-      this.args.process.links = [...links];
-      await this.args.process.save();
+      this.resource.links = [...links];
+      await this.resource.save();
       this.toaster.success('Link toegevoegd', undefined, {
         timeOut: 5000,
       });
@@ -171,7 +179,9 @@ export default class ProcessRelevantLinks extends Component {
       this.toaster.success('Link succesvol verwijderd', undefined, {
         timeOut: 5000,
       });
-      this.args.process.applyVersioning.perform();
+      if (!this.isIcr) {
+        this.resource.applyVersioning.perform();
+      }
       this.args.onSaved?.();
     } catch (error) {
       console.error(error);
@@ -214,29 +224,44 @@ export default class ProcessRelevantLinks extends Component {
     this.isExecutingAction = false;
   }
 
-  fetchLinks = task({ restartable: true }, async (_process) => {
-    const process = await this.store.findRecord('process', _process.id, {
-      include: 'links,information-assets,information-assets.links',
-      reload: true,
-    });
-    const processLinks =
-      process?.links?.filter((link) => !link.isArchived) ?? [];
-
+  fetchLinks = task({ restartable: true }, async (resource) => {
     const linkSourceMap = new Map();
-    for (const icrAsset of await process.informationAssets) {
-      const links = icrAsset.links.filter((link) => !link.isArchived) ?? [];
-      for (const link of links) {
-        linkSourceMap.set(link.id, {
-          id: icrAsset.id,
-          title: icrAsset.title ?? '/',
-        });
+    let linkIds;
+
+    if (this.isIcr) {
+      const asset = await this.store.findRecord(
+        'information-asset',
+        resource.id,
+        { include: 'links', reload: true },
+      );
+      const assetLinks = asset?.links?.filter((link) => !link.isArchived) ?? [];
+      for (const link of assetLinks) {
+        linkSourceMap.set(link.id, { id: asset.id, title: asset.title ?? '/' });
       }
+      linkIds = assetLinks.map((link) => link.id);
+    } else {
+      const process = await this.store.findRecord('process', resource.id, {
+        include: 'links,information-assets,information-assets.links',
+        reload: true,
+      });
+      const processLinks =
+        process?.links?.filter((link) => !link.isArchived) ?? [];
+      for (const icrAsset of await process.informationAssets) {
+        const links = icrAsset.links.filter((link) => !link.isArchived) ?? [];
+        for (const link of links) {
+          linkSourceMap.set(link.id, {
+            id: icrAsset.id,
+            title: icrAsset.title ?? '/',
+          });
+        }
+      }
+      linkIds = [
+        ...processLinks.map((link) => link.id),
+        ...linkSourceMap.keys(),
+      ];
     }
 
-    const linkIds = [
-      ...processLinks.map((link) => link.id),
-      ...linkSourceMap.keys(),
-    ];
+    if (linkIds.length === 0) return [];
 
     const result = await this.store.query('link', {
       'filter[id]': linkIds.join(','),
@@ -258,7 +283,7 @@ export default class ProcessRelevantLinks extends Component {
   });
 
   links = trackedTask(this, this.fetchLinks, () => [
-    this.args.process,
+    this.resource,
     this.args.page,
     this.args.sort,
   ]);

--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -14,9 +14,9 @@ export default class InformationAssetsInformationAssetController extends Control
     { pageAttachments: 'page-attachments' },
     { sizeAttachments: 'size-attachments' },
     { sortAttachments: 'sort-attachments' },
-    'relevantLinksPage',
-    'relevantLinksSize',
-    'relevantLinksSort',
+    { relevantLinksPage: 'page-links' },
+    { relevantLinksSize: 'size-links' },
+    { relevantLinksSort: 'sort-links' },
   ];
 
   @service store;

--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -33,7 +33,7 @@ export default class InformationAssetsInformationAssetController extends Control
 
   @tracked pageAttachments = 0;
   @tracked sizeAttachments = 10;
-  @tracked sortAttachments = 'name';
+  @tracked sortAttachments = 'modified';
 
   get canEdit() {
     return (

--- a/app/controllers/information-assets/information-asset.js
+++ b/app/controllers/information-assets/information-asset.js
@@ -14,6 +14,9 @@ export default class InformationAssetsInformationAssetController extends Control
     { pageAttachments: 'page-attachments' },
     { sizeAttachments: 'size-attachments' },
     { sortAttachments: 'sort-attachments' },
+    'relevantLinksPage',
+    'relevantLinksSize',
+    'relevantLinksSort',
   ];
 
   @service store;
@@ -32,8 +35,11 @@ export default class InformationAssetsInformationAssetController extends Control
   @tracked errorMessageTitle;
 
   @tracked pageAttachments = 0;
-  @tracked sizeAttachments = 10;
-  @tracked sortAttachments = 'modified';
+  @tracked sizeAttachments = 5;
+  @tracked sortAttachments = '-created';
+  @tracked relevantLinksPage = 0;
+  @tracked relevantLinksSize = 5;
+  @tracked relevantLinksSort = '-modified';
 
   get canEdit() {
     return (
@@ -203,6 +209,11 @@ export default class InformationAssetsInformationAssetController extends Control
       this.isSaving = false;
     }
   });
+
+  @action
+  fetchRelevantLinks() {
+    this.relevantLinksPage = 0;
+  }
 
   @action
   openDeleteModal() {

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -25,7 +25,7 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked attachmentsSort = '-created';
   @tracked relevantLinksPage = 0;
   @tracked relevantLinksSize = 5;
-  @tracked relevantLinksSort = '-created';
+  @tracked relevantLinksSort = '-modified';
   @tracked diagramVersionsPage = 0;
   @tracked diagramVersionsSort = '-created';
   @tracked diagramsPage = 0;

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -8,12 +8,12 @@ import { toSafeString } from '../../../utils/string-manipulation';
 export default class ProcessesProcessIndexController extends Controller {
   queryParams = [
     { versionedProcessId: { as: 'versionedProcess' } },
-    'attachmentsPage',
-    'attachmentsSize',
-    'attachmentsSort',
-    'relevantLinksPage',
-    'relevantLinksSize',
-    'relevantLinksSort',
+    { pageAttachments: 'page-attachments' },
+    { sizeAttachments: 'size-attachments' },
+    { sortAttachments: 'sort-attachments' },
+    { relevantLinksPage: 'page-links' },
+    { relevantLinksSize: 'size-links' },
+    { relevantLinksSort: 'sort-links' },
     'diagramVersionsPage',
     'diagramVersionsSort',
     'diagramsPage',

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -175,6 +175,11 @@ export default class ProcessesProcessIndexController extends Controller {
   }
 
   @action
+  fetchRelevantLinks() {
+    this.relevantLinksPage = 0;
+  }
+
+  @action
   fetchAttachments() {
     this.attachmentsPage = 0;
   }

--- a/app/routes/information-assets/information-asset.js
+++ b/app/routes/information-assets/information-asset.js
@@ -7,13 +7,22 @@ export default class InformationAssetsInformationAssetRoute extends Route {
   @service router;
   @service store;
 
-  queryParams = [
-    { versionedAssetId: { refreshModel: true } },
-    { pageAttachments: { refreshModel: true } },
-    { sizeAttachments: { refreshModel: true } },
-    { sortAttachments: { refreshModel: true } },
-    { process: { refreshModel: false } },
-  ];
+  queryParams = {
+    versionedAssetId: { refreshModel: true },
+    process: { refreshModel: false },
+    pageAttachments: { replace: true },
+    sizeAttachments: { replace: true },
+    sortAttachments: { replace: true },
+    relevantLinksPage: {
+      replace: true,
+    },
+    relevantLinksSize: {
+      replace: true,
+    },
+    relevantLinksSort: {
+      replace: true,
+    },
+  };
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'auth.login');

--- a/app/templates/information-assets/information-asset.hbs
+++ b/app/templates/information-assets/information-asset.hbs
@@ -314,6 +314,10 @@
         @page={{this.pageAttachments}}
         @size={{this.sizeAttachments}}
         @sort={{this.sortAttachments}}
+        @linksPage={{this.relevantLinksPage}}
+        @linksSize={{this.relevantLinksSize}}
+        @linksSort={{this.relevantLinksSort}}
+        @onSaved={{this.fetchRelevantLinks}}
       />
     </div>
     <aside class="au-o-grid__item au-u-2-6@medium">

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -164,6 +164,7 @@
     @linksSize={{this.relevantLinksSize}}
     @linksSort={{this.relevantLinksSort}}
     @reloadTableData={{this.fetchAttachments}}
+    @reloadLinksData={{this.fetchRelevantLinks}}
     @onSaved={{this.clearVersionedProcess}}
   />
 


### PR DESCRIPTION
## 🗒️ Description

We want the relevant links table to look like the attachments table.

1. add the gekoppeld aan column
2. also fetch the links from the linked icr assets
3. show the difference for icr and process (gekoppeld aan)

## 🦮 How to test

1. Have look at the attachments and relvant links table (sort, add, etc..)
2. Make the process a blauwdrukl and link 2 icr assets
3. Add links add attachments to the icr assets
4. the icr table should work filter, add, updated
5. Go back to the process and have a look at the tables again
6. When the links are from a different source than the process we do not allow them to edit or remove them only to download it  
7. All table have the same width for the first column for a nice overview

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

<img width="2038" height="863" alt="image" src="https://github.com/user-attachments/assets/59910156-32c1-489b-b3f6-22bb82eceb87" />

