### PR TITLE
OPH-1100 | compare string values with all spaces removed at the end

### DIFF
--- a/app/components/shared/text-compare.js
+++ b/app/components/shared/text-compare.js
@@ -14,6 +14,10 @@ export default class SharedTextCompared extends Component {
       });
     }
 
+    if (typeof old === 'string') {
+      return old.trim() !== current.trim();
+    }
+
     return old !== current;
   }
 


### PR DESCRIPTION
## 🗒️ Description

When users left the last state of a process with spaces in the title or description they will see a change of those values at the creation of the first version. 

## 🦮 How to test

1. Go to pittem "diagram" process
2. Change the description
3. IT should not show the change of the ipdc products
4. Go to titel aan te passen in pittem see that the title has a space

## 🔗 Links to other PR's

- https://github.com/lblod/app-openproceshuis/pull/162

## 🖼️ Attachments

<img width="2025" height="750" alt="image" src="https://github.com/user-attachments/assets/6a218b0e-24d2-4982-91ff-49e870344700" />


<img width="2025" height="750" alt="image" src="https://github.com/user-attachments/assets/cab17ab2-1146-4d73-9f47-359b748328a8" />

