### PR TITLE
OPH-1098 | Prevent action on enter date input

### DIFF
--- a/app/components/inventory/select-number.hbs
+++ b/app/components/inventory/select-number.hbs
@@ -6,4 +6,5 @@
   min="0"
   class="grow"
   {{on "input" (perform this.onChange)}}
+  {{prevent-action-on-enter}}
 />

--- a/app/components/process-overview.hbs
+++ b/app/components/process-overview.hbs
@@ -40,6 +40,7 @@
                 @id="filter-modified-since"
                 @value={{this.modifiedSince}}
                 @onChange={{this.setModifiedSince}}
+                {{prevent-action-on-enter}}
               />
             </div>
           {{/if}}

--- a/app/modifiers/prevent-action-on-enter.js
+++ b/app/modifiers/prevent-action-on-enter.js
@@ -1,0 +1,15 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element) => {
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+    }
+  };
+
+  element.addEventListener('keydown', handleKeyDown);
+
+  return () => {
+    element.removeEventListener('keydown', handleKeyDown);
+  };
+});


### PR DESCRIPTION
## 🗒️ Description

When pressin genter in the date input of laats aangepast on the processes overview the page reloads, this is not something we want.

## 🦮 How to test

1. go to the process overview and press enter in the field (reload)
2. go to inventory processes and press enter in the nummer filter (reload)
3. Check out this pr and do the same, now it should not do anything on enter but the filter should remain functional
4. That should be all fields where this happens, go look for others so we cover all of them
