### PR TITLE
OPH-1056 | Move the structuring of the diagrams to a separate route for full page edit

### DIFF
--- a/app/components/diagram-list/table.hbs
+++ b/app/components/diagram-list/table.hbs
@@ -44,6 +44,7 @@
         {{#let (gt diagram.subItems.length 0) as |hasSubItems|}}
           <DiagramList::Table::Row
             @process={{@process}}
+            @processRouteName={{@processRouteName}}
             @diagram={{diagram}}
             @selectedDiagramFile={{@selectedDiagramFile}}
             @hasSubItems={{hasSubItems}}
@@ -56,6 +57,7 @@
                   <DiagramList::Table::Row
                     @isSubRow={{true}}
                     @process={{@process}}
+                    @processRouteName={{@processRouteName}}
                     @diagram={{subDiagram}}
                     @selectedDiagramFile={{@selectedDiagramFile}}
                     @onDiagramFileSelected={{@onDiagramFileSelected}}

--- a/app/components/diagram-list/table/row.hbs
+++ b/app/components/diagram-list/table/row.hbs
@@ -43,7 +43,7 @@
     @query={{hash
       previousRouteTitle=@process.title
       previousRouteModelId=@process.id
-      previousRouteName="processes.process"
+      previousRouteName=(or @processRouteName "processes.process")
     }}
   >
     Detail

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -1,5 +1,4 @@
 <AuModal
-  class="process-wizard-modal"
   @modalOpen={{true}}
   @closable={{true}}
   @closeModal={{@onCloseModal}}
@@ -25,8 +24,9 @@
     {{#unless this.executeStepActionAsTask.isRunning}}
       {{#if (eq this.activeStep.step this.wizardStep.SELECT_ACTION)}}
         <Wizard::Actions
-          @onActionSelected={{this.onActionSelected}}
+          @onQuickActionSelected={{this.onQuickActionSelected}}
           @disabledActions={{this.disabledActions}}
+          @onManageDiagrams={{this.manageDiagrams}}
         />
       {{/if}}
       {{#if (eq this.activeStep.step this.wizardStep.UPLOAD_FILES)}}

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -67,15 +67,6 @@
           {{/if}}
         {{/if}}
       {{/if}}
-      {{#if (eq this.activeStep.step this.wizardStep.STRUCTURE_DIAGRAMS)}}
-        <p class="au-u-muted au-u-italic">Hieronder vind je al de diagrammen die
-          opgeladen werden. Door een diagram vast te nemen en te verplaatsen pas
-          je de positie van het diagram aan, waarbij het bovenste diagram je
-          hoofd diagram is.</p>
-        <div class="au-o-box">
-          <DiagramList::DragAndDropSort @diagramList={{this.diagramList}} />
-        </div>
-      {{/if}}
     {{/unless}}
   </:body>
   <:footer>

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -182,6 +182,10 @@ export default class ProcessWizard extends Component {
   @action
   manageDiagrams() {
     this.args.onCloseModal?.();
+    this.router.transitionTo(
+      'processes.process.manage-diagrams',
+      this.args.process.id,
+    );
   }
 
   @action

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -182,9 +182,17 @@ export default class ProcessWizard extends Component {
   @action
   manageDiagrams() {
     this.args.onCloseModal?.();
+    const processRouteName = this.router.currentRouteName.replace('.index', '');
     this.router.transitionTo(
-      'processes.process.manage-diagrams',
+      `${processRouteName}.manage-diagrams`,
       this.args.process.id,
+      {
+        queryParams: {
+          previousRouteName: processRouteName,
+          previousRouteModelId: this.args.process.id,
+          previousRouteTitle: this.args.process.title,
+        },
+      },
     );
   }
 

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -180,7 +180,12 @@ export default class ProcessWizard extends Component {
   }
 
   @action
-  async onActionSelected(action) {
+  manageDiagrams() {
+    this.args.onCloseModal?.();
+  }
+
+  @action
+  async onQuickActionSelected(action) {
     this.currentAction = action;
     if (this.currentAction === WizardAction.CHANGE_MAIN_PROCESS) {
       this.mainProcessFile = null;
@@ -188,6 +193,7 @@ export default class ProcessWizard extends Component {
     if (this.currentAction === WizardAction.REPLACE_DIAGRAMS) {
       this.diagramList = null;
       this.files = [];
+      this.fileWrappers = [];
     }
     this.nextStep();
   }

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -36,7 +36,6 @@ export default class ProcessWizard extends Component {
     UPLOAD_FILES: 'upload_files',
     SELECT_MAIN_PROCESS: 'select_main_process',
     CHANGE_MAIN_PROCESS: 'change_main_process',
-    STRUCTURE_DIAGRAMS: 'structure_diagrams',
     CREATE_PROCESS: 'create_process',
     UPDATE_PROCESS: 'update_process',
     CREATE_DIAGRAM_VERSION: 'create_diagram_version',
@@ -98,16 +97,6 @@ export default class ProcessWizard extends Component {
         canGoToNextStep: this.currentAction,
         nextStepButtonLabel: null,
         action: async () => await this.prepareWizard(),
-      },
-      {
-        step: this.wizardStep.STRUCTURE_DIAGRAMS,
-        title: 'Diagrammen structuur',
-        isStepShown: this.currentAction === WizardAction.STRUCTURE_DIAGRAMS,
-        canGoToNextStep: true,
-        nextStepButtonLabel: 'Aanpassen',
-        canCancelStep: true,
-        actionAtEndOfStep: async () =>
-          await this.saveDiagramStructure(this.diagramList),
       },
       {
         step: this.wizardStep.UPLOAD_FILES,
@@ -235,21 +224,6 @@ export default class ProcessWizard extends Component {
         this.disabledActions = [WizardAction.CHANGE_MAIN_PROCESS];
       }
     }
-  }
-
-  async saveDiagramStructure(diagramList) {
-    for (const main of diagramList.diagrams) {
-      await main.save();
-    }
-
-    const subItems = diagramList.diagrams.flatMap(
-      (main) => main.subItems ?? [],
-    );
-    for (const sub of subItems) {
-      await sub.save();
-    }
-
-    await diagramList.save();
   }
 
   async saveFileInDatabase(uploadedFile) {

--- a/app/components/wizard/actions.hbs
+++ b/app/components/wizard/actions.hbs
@@ -1,22 +1,53 @@
-<div class="wizard-actions" ...attributes>
-  {{#each this.actions as |action|}}
-    {{! template-lint-disable no-invalid-interactive }}
-    <div
-      class="{{if action.isDisabled 'is-disabled-action'}}
-        width-full border-radius animate-up"
-      {{on "click" action.next}}
-    >
-      <AuIcon
-        @icon={{action.icon}}
-        @size="large"
-        @alignment="left"
-        style={{action.iconColorClass}}
-      />
-      <p class="au-u-h4 au-u-medium">{{action.label}}</p>
-      <p>{{action.description}}</p>
-      {{#if action.isDisabled}}
-        <AuHelpText @warning={{true}}>{{action.disabledReason}}</AuHelpText>
-      {{/if}}
+<div class="au-u-flex au-u-flex--column au-u-flex--spaced" ...attributes>
+  <div class="au-u-flex au-u-flex--column">
+    <div class="wizard-action-grid">
+      {{#each this.quickActions as |action|}}
+        <button
+          type="button"
+          class="wizard-action-card
+            {{if action.isDisabled 'is-disabled-action'}}"
+          disabled={{action.isDisabled}}
+          {{on "click" action.onSelect}}
+        >
+          <AuIcon
+            @icon={{action.icon}}
+            @size="large"
+            @alignment="left"
+            style={{action.iconStyle}}
+          />
+          <p class="au-u-h4 au-u-medium">{{action.label}}</p>
+          <p>{{action.description}}</p>
+          {{#if action.isDisabled}}
+            <AuHelpText @warning={{true}}>{{action.disabledReason}}</AuHelpText>
+          {{/if}}
+        </button>
+      {{/each}}
     </div>
-  {{/each}}
+  </div>
+
+  <div class="au-u-flex au-u-flex--column">
+    <p class="au-u-h4 au-u-muted au-u-margin-bottom-small">GEAVANCEERD</p>
+    <button
+      type="button"
+      class="wizard-action-card wizard-action-card--advanced
+        {{if this.isManageDiagramsDisabled 'is-disabled-action'}}"
+      disabled={{this.isManageDiagramsDisabled}}
+      {{on "click" this.onManageDiagrams}}
+    >
+      <div class="au-u-flex au-u-flex--center">
+        <AuIcon @icon="sitemap" @size="large" @alignment="left" />
+        <div>
+          <p class="au-u-h4 au-u-medium">Diagrammen beheren</p>
+          <p>Toevoegen, verwijderen en structureren in een aparte pagina.</p>
+          {{#if this.isManageDiagramsDisabled}}
+            <AuHelpText @warning={{true}}>Deze actie is tijdelijk niet
+              beschikbaar</AuHelpText>
+          {{/if}}
+        </div>
+      </div>
+      {{#unless this.isManageDiagramsDisabled}}
+        <AuIcon @icon="chevron-right" @size="large" />
+      {{/unless}}
+    </button>
+  </div>
 </div>

--- a/app/components/wizard/actions.js
+++ b/app/components/wizard/actions.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export const WizardAction = Object.freeze({
   REPLACE_DIAGRAMS: 'replace_diagrams',
@@ -7,55 +8,52 @@ export const WizardAction = Object.freeze({
 });
 
 export default class WizardActions extends Component {
-  get actions() {
+  get quickActions() {
     return [
       {
+        id: WizardAction.REPLACE_DIAGRAMS,
         label: 'Bestanden vervangen',
         icon: 'upload',
-        iconColorClass: 'fill: var(--au-blue-900) !important',
-        description: 'Upload nieuwe bestanden om de diagrammen te vervangen.',
-        next: () => {
-          if (this.isActionDisabled(WizardAction.REPLACE_DIAGRAMS)) {
-            return;
-          }
-          this.args.onActionSelected(WizardAction.REPLACE_DIAGRAMS);
-        },
+        iconStyle: 'fill: var(--au-blue-900) !important',
+        description: 'Upload nieuwe versies van bestaande diagrammen.',
         isDisabled: this.isActionDisabled(WizardAction.REPLACE_DIAGRAMS),
         disabledReason: 'Deze actie is tijdelijk niet beschikbaar',
+        onSelect: () => {
+          if (!this.isActionDisabled(WizardAction.REPLACE_DIAGRAMS)) {
+            this.args.onQuickActionSelected(WizardAction.REPLACE_DIAGRAMS);
+          }
+        },
       },
       {
+        id: WizardAction.CHANGE_MAIN_PROCESS,
         label: 'Hoofdproces wijzigen',
         icon: 'ordered-list',
-        iconColorClass: 'fill: var(--au-green-500) !important',
-        description: 'Wijzig het hoofdproces van het proces.',
-        next: () => {
-          if (this.isActionDisabled(WizardAction.CHANGE_MAIN_PROCESS)) {
-            return;
-          }
-          this.args.onActionSelected(WizardAction.CHANGE_MAIN_PROCESS);
-        },
+        iconStyle: 'fill: var(--au-green-500) !important',
+        description: 'Kies welk diagram het hoofdproces is.',
         isDisabled: this.isActionDisabled(WizardAction.CHANGE_MAIN_PROCESS),
         disabledReason:
           'Je hebt één diagram geüpload. Dit is automatisch het hoofddiagram.',
-      },
-      {
-        label: 'Diagrammen structuur wijzigen',
-        icon: 'filter',
-        iconColorClass: 'fill: var(--au-orange-500) !important',
-        description: 'Wijzig de structuur/positie van de diagrammen.',
-        next: () => {
-          if (this.isActionDisabled(WizardAction.STRUCTURE_DIAGRAMS)) {
-            return;
+        onSelect: () => {
+          if (!this.isActionDisabled(WizardAction.CHANGE_MAIN_PROCESS)) {
+            this.args.onQuickActionSelected(WizardAction.CHANGE_MAIN_PROCESS);
           }
-          this.args.onActionSelected(WizardAction.STRUCTURE_DIAGRAMS);
         },
-        isDisabled: this.isActionDisabled(WizardAction.STRUCTURE_DIAGRAMS),
-        disabledReason: 'Deze actie is tijdelijk niet beschikbaar',
       },
     ];
   }
 
+  get isManageDiagramsDisabled() {
+    return this.isActionDisabled(WizardAction.STRUCTURE_DIAGRAMS);
+  }
+
   isActionDisabled(action) {
     return this.args.disabledActions?.includes(action);
+  }
+
+  @action
+  onManageDiagrams() {
+    if (!this.isManageDiagramsDisabled) {
+      this.args.onManageDiagrams?.();
+    }
   }
 }

--- a/app/controllers/my-local-government/process/manage-diagrams.js
+++ b/app/controllers/my-local-government/process/manage-diagrams.js
@@ -1,0 +1,3 @@
+import ProcessesProcessManageDiagramsController from '../../processes/process/manage-diagrams';
+
+export default class MyLocalGovernmentProcessManageDiagramsController extends ProcessesProcessManageDiagramsController {}

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -45,6 +45,10 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked selectedDiagramFile;
   @tracked isWizardModalOpen;
 
+  get processRouteName() {
+    return this.router.currentRouteName.replace('.index', '');
+  }
+
   get process() {
     return this.model.process;
   }

--- a/app/controllers/processes/process/manage-diagrams.js
+++ b/app/controllers/processes/process/manage-diagrams.js
@@ -1,7 +1,15 @@
 import Controller from '@ember/controller';
+
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
+import { task } from 'ember-concurrency';
+
 export default class ProcessesProcessManageDiagramsController extends Controller {
+  @service router;
+  @service toaster;
+
   queryParams = [
     'previousRouteTitle',
     'previousRouteModelId',
@@ -11,6 +19,41 @@ export default class ProcessesProcessManageDiagramsController extends Controller
   @tracked previousRouteTitle;
   @tracked previousRouteModelId;
   @tracked previousRouteName;
+
+  saveDiagramStructure = task({ drop: true }, async (diagramList) => {
+    try {
+      for (const main of diagramList.diagrams) {
+        await main.save();
+      }
+
+      const subItems = diagramList.diagrams.flatMap(
+        (main) => main.subItems ?? [],
+      );
+      for (const sub of subItems) {
+        await sub.save();
+      }
+
+      await diagramList.save();
+
+      this.toaster.success('Diagrammen structuur werd aangepast', undefined, {
+        timeOut: 2500,
+      });
+    } catch (error) {
+      this.toaster.success(
+        'Er liep iets mis bij het aanpassen van de diagrammen structuur',
+        undefined,
+        {
+          timeOut: 5000,
+        },
+      );
+    }
+  });
+
+  @action
+  onCancel() {
+    this.model.diagramList.rollbackAttributes();
+    this.router.transitionTo(this.breadcrumbRouteName, this.breadcrumbModel);
+  }
 
   get hasPreviousRouteBreadCrumb() {
     return (

--- a/app/controllers/processes/process/manage-diagrams.js
+++ b/app/controllers/processes/process/manage-diagrams.js
@@ -1,0 +1,34 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class ProcessesProcessManageDiagramsController extends Controller {
+  queryParams = [
+    'previousRouteTitle',
+    'previousRouteModelId',
+    'previousRouteName',
+  ];
+
+  @tracked previousRouteTitle;
+  @tracked previousRouteModelId;
+  @tracked previousRouteName;
+
+  get hasPreviousRouteBreadCrumb() {
+    return (
+      this.previousRouteTitle &&
+      this.previousRouteModelId &&
+      this.previousRouteName
+    );
+  }
+
+  get breadcrumbTitle() {
+    return this.previousRouteTitle ?? this.model.process.title;
+  }
+
+  get breadcrumbModel() {
+    return this.previousRouteModelId ?? this.model.process.id;
+  }
+
+  get breadcrumbRouteName() {
+    return this.previousRouteName ?? 'processes.process';
+  }
+}

--- a/app/controllers/shared-processes/process/manage-diagrams.js
+++ b/app/controllers/shared-processes/process/manage-diagrams.js
@@ -1,0 +1,3 @@
+import ProcessesProcessManageDiagramsController from '../../processes/process/manage-diagrams';
+
+export default class SharedProcessesProcessManageDiagramsController extends ProcessesProcessManageDiagramsController {}

--- a/app/router.js
+++ b/app/router.js
@@ -44,6 +44,7 @@ Router.map(function () {
   this.route('shared-processes', { path: 'gedeelde-processen' }, function () {
     this.route('process', { path: '/:id/' }, function () {
       this.route('index', { path: '' });
+      this.route('manage-diagrams', { path: 'diagrammen-beheren' });
     });
   });
 
@@ -53,6 +54,7 @@ Router.map(function () {
     function () {
       this.route('process', { path: '/:id/' }, function () {
         this.route('index', { path: '' });
+        this.route('manage-diagrams', { path: 'diagrammen-beheren' });
       });
     },
   );

--- a/app/router.js
+++ b/app/router.js
@@ -30,6 +30,7 @@ Router.map(function () {
   this.route('processes', { path: 'processen' }, function () {
     this.route('process', { path: '/:id/' }, function () {
       this.route('index', { path: '' });
+      this.route('manage-diagrams', { path: 'diagrammen-beheren' });
     });
   });
 

--- a/app/routes/my-local-government/process/manage-diagrams.js
+++ b/app/routes/my-local-government/process/manage-diagrams.js
@@ -1,0 +1,3 @@
+import ProcessesProcessManageDiagramsRoute from '../../processes/process/manage-diagrams';
+
+export default class MyLocalGovernmentProcessManageDiagramsRoute extends ProcessesProcessManageDiagramsRoute {}

--- a/app/routes/processes/process/manage-diagrams.js
+++ b/app/routes/processes/process/manage-diagrams.js
@@ -7,6 +7,12 @@ export default class ProcessesProcessManageDiagramsRoute extends Route {
   @service store;
   @service diagram;
 
+  queryParams = [
+    { previousRouteTitle: { refreshModel: false } },
+    { previousRouteModelId: { refreshModel: false } },
+    { previousRouteName: { refreshModel: false } },
+  ];
+
   beforeModel(transition) {
     if (!this.session.isAuthenticated) {
       this.session.requireAuthentication(transition, 'auth.login');
@@ -30,7 +36,6 @@ export default class ProcessesProcessManageDiagramsRoute extends Route {
     return {
       process: process,
       diagramList: diagramList,
-      breadcrumbRouteName: parentRouteName,
     };
   }
 }

--- a/app/routes/processes/process/manage-diagrams.js
+++ b/app/routes/processes/process/manage-diagrams.js
@@ -1,0 +1,36 @@
+import Route from '@ember/routing/route';
+
+import { service } from '@ember/service';
+
+export default class ProcessesProcessManageDiagramsRoute extends Route {
+  @service session;
+  @service store;
+  @service diagram;
+
+  beforeModel(transition) {
+    if (!this.session.isAuthenticated) {
+      this.session.requireAuthentication(transition, 'auth.login');
+    }
+  }
+
+  async model(params, transition) {
+    const parentRouteName = transition.to?.name?.replace(
+      '.manage-diagrams',
+      '',
+    );
+    let processId = params.id;
+    if (!processId) {
+      const { process } = this.modelFor(parentRouteName);
+      processId = process?.id;
+    }
+
+    const process = await this.store.findRecord('process', processId);
+    const diagramList = await this.diagram.getLatestDiagramList(processId);
+
+    return {
+      process: process,
+      diagramList: diagramList,
+      breadcrumbRouteName: parentRouteName,
+    };
+  }
+}

--- a/app/routes/shared-processes/process/manage-diagrams.js
+++ b/app/routes/shared-processes/process/manage-diagrams.js
@@ -1,0 +1,3 @@
+import ProcessesProcessManageDiagramsRoute from '../../processes/process/manage-diagrams';
+
+export default class SharedProcessesProcessManageDiagramsRoute extends ProcessesProcessManageDiagramsRoute {}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -72,6 +72,10 @@
   width: 32px;
 }
 
+.au-c-modal {
+  border-radius: 10px !important;
+}
+
 .modal-diagram {
   height: 20%;
 }
@@ -224,11 +228,6 @@ tr:hover .inventory-row-button-group .au-c-button {
 
 .u-preserve-line-breaks {
   white-space: pre-wrap;
-}
-
-.process-wizard-modal.au-c-modal {
-  height: 50vh !important;
-  border-radius: 5px !important;
 }
 
 .au-c-file-upload-label__title {

--- a/app/styles/components/_c-wizard.scss
+++ b/app/styles/components/_c-wizard.scss
@@ -9,25 +9,52 @@
   }
 }
 
-.wizard-actions {
+.wizard-action-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
-.wizard-actions > div {
+.wizard-action-card {
   display: flex;
   flex-direction: column;
-  align-items: left;
-  justify-content: top;
+  align-items: flex-start;
   gap: 0.5rem;
   border: 1px solid var(--au-gray-200);
-  padding: 2rem 1rem;
+  border-radius: 10px;
+  padding: 1.5rem 1rem;
   cursor: pointer;
+  background: transparent;
+  text-align: left;
+  width: 100%;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  &:hover:not(:disabled) {
+    border-color: var(--au-blue-600);
+    box-shadow: 0 2px 6px rgb(0 0 0 / 6%);
+  }
 
   .au-c-icon {
     fill: var(--au-gray-700) !important;
+  }
+}
+
+.wizard-action-card--advanced {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--au-orange-200);
+  border-color: var(--au-orange-400);
+
+  &:hover:not(:disabled) {
+    border-color: var(--au-orange-500);
+    box-shadow: 0 2px 6px rgb(0 0 0 / 6%);
+  }
+
+  .au-c-icon {
+    fill: var(--au-orange-600) !important;
   }
 }
 

--- a/app/templates/my-local-government/process/manage-diagrams.js
+++ b/app/templates/my-local-government/process/manage-diagrams.js
@@ -1,0 +1,1 @@
+export { default } from '../../processes/process/manage-diagrams';

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -108,6 +108,7 @@
           @selectedDiagramFile={{this.selectedDiagramFile}}
           @onDiagramFileSelected={{this.openDiagramFile}}
           @process={{@model.process}}
+          @processRouteName={{this.processRouteName}}
           @page={{this.diagramsPage}}
           @sort={{this.diagramsSort}}
         />

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -5,4 +5,35 @@
   model=this.breadcrumbModel
 }}
 {{breadcrumb "Beheer process diagrammen"}}
-{{outlet}}
+
+<AuToolbar @border="bottom" @size="large" as |Group|>
+  <Group />
+  <Group>
+    <AuButtonGroup>
+      <AuButton
+        class="border-radius"
+        @skin="secondary"
+        {{on "click" this.onCancel}}
+      >
+        Annuleer
+      </AuButton>
+      <AuButton
+        @disabled={{this.saveDiagramStructure.isRunning}}
+        @loading={{this.saveDiagramStructure.isRunning}}
+        @loadingMessage="Aanpassen"
+        @skin="primary"
+        class="border-radius"
+        {{on "click" (perform this.saveDiagramStructure @model.diagramList)}}
+      >
+        Wijzigingen opslaan
+      </AuButton>
+    </AuButtonGroup>
+  </Group>
+</AuToolbar>
+<div class="au-o-box">
+  <p class="au-u-muted au-u-italic">Hieronder vind je al de diagrammen die
+    opgeladen werden. Door een diagram vast te nemen en te verplaatsen pas je de
+    positie van het diagram aan, waarbij het bovenste diagram je hoofd diagram
+    is.</p>
+  <DiagramList::DragAndDropSort @diagramList={{@model.diagramList}} />
+</div>

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -1,0 +1,7 @@
+{{page-title "Beheer process diagrammen"}}
+{{breadcrumb
+  this.model.process.title
+  route=this.model.breadcrumbRouteName
+  models=this.model.process.id
+}}
+{{outlet}}

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -2,6 +2,7 @@
 {{breadcrumb
   this.model.process.title
   route=this.model.breadcrumbRouteName
-  models=this.model.process.id
+  model=this.model.process.id
 }}
+{{breadcrumb "Beheer process diagrammen"}}
 {{outlet}}

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -1,8 +1,8 @@
 {{page-title "Beheer process diagrammen"}}
 {{breadcrumb
-  this.model.process.title
-  route=this.model.breadcrumbRouteName
-  model=this.model.process.id
+  this.breadcrumbTitle
+  route=this.breadcrumbRouteName
+  model=this.breadcrumbModel
 }}
 {{breadcrumb "Beheer process diagrammen"}}
 {{outlet}}

--- a/app/templates/shared-processes/process/manage-diagrams.js
+++ b/app/templates/shared-processes/process/manage-diagrams.js
@@ -1,0 +1,1 @@
+export { default } from '../../processes/process/manage-diagrams';


### PR DESCRIPTION
## 🗒️ Description

We want the user to add a single diagram file to the diagram list, so they do not need to upload all the previous diagrams + that single one.

## 🦮 How to test

1. use the wizard, all actions should be still working (replace + set main diagram)
2. go to the advanved action for structuring of the diagrams
3. adding will be done in a separate PR so its cleared what happens?

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

**wizard actions**
<img width="920" height="607" alt="image" src="https://github.com/user-attachments/assets/60eb4dcc-b49c-4860-80c1-3b3835fe5afe" />

**new page for diagram structuring**
<img width="1508" height="594" alt="image" src="https://github.com/user-attachments/assets/44c36350-a155-44f3-902b-4e9575ba6742" />


