### PR TITLE
Fix typos

### DIFF
--- a/app/components/inventory/create-category-modal.hbs
+++ b/app/components/inventory/create-category-modal.hbs
@@ -5,7 +5,7 @@
 >
   <:title>Voeg een nieuwe categorie toe</:title>
   <:body>
-    <p class="au-u-margin-bottom">Geef de label in van de categorie dat je wil
+    <p class="au-u-margin-bottom">Geef het label in van de categorie die je wil
       toevoegen.</p>
     <div class="au-u-flex au-u-flex--column">
       <AuLabel

--- a/app/components/inventory/create-domain-modal.hbs
+++ b/app/components/inventory/create-domain-modal.hbs
@@ -5,7 +5,7 @@
 >
   <:title>Voeg een nieuw domein toe</:title>
   <:body>
-    <p class="au-u-margin-bottom">Geef de label in van het domein dat je wil
+    <p class="au-u-margin-bottom">Geef het label in van het domein dat je wil
       toevoegen.</p>
     <div class="au-u-flex au-u-flex--column">
       <AuLabel

--- a/app/components/inventory/edit-toolbar.hbs
+++ b/app/components/inventory/edit-toolbar.hbs
@@ -104,7 +104,7 @@
   @closable={{true}}
   @closeModal={{fn (mut this.isCannotArchiveModelOpen) false}}
 >
-  <:title>Archiveren niet toegstaan</:title>
+  <:title>Archiveren niet toegestaan</:title>
   <:body>
     <span class="au-u-medium">{{@model.label}} </span>
     kan niet gearchiveerd worden.

--- a/app/components/inventory/upsert-process-modal.hbs
+++ b/app/components/inventory/upsert-process-modal.hbs
@@ -73,7 +73,7 @@
               @size="large"
               @alignment="right"
             />
-            <p>Dit process heeft gearchiveerde parameters.</p>
+            <p>Dit proces heeft gearchiveerde parameters.</p>
           </div>
         {{/if}}
       </Group>

--- a/app/components/process/inventory-process-card.js
+++ b/app/components/process/inventory-process-card.js
@@ -36,7 +36,7 @@ export default class ProcessInventoryProcessCard extends Component {
       return 'Dit proces werd gearchiveerd';
     }
     if (this.args.process.linkedConcept?.processGroup?.isArchived) {
-      return 'Dit process heeft gearchiveerde parameters';
+      return 'Dit proces heeft gearchiveerde parameters';
     }
 
     return null;

--- a/app/components/process/inventory-process-card/popup.hbs
+++ b/app/components/process/inventory-process-card/popup.hbs
@@ -156,7 +156,7 @@
               @size="large"
               @alignment="right"
             />
-            <p>Dit process heeft gearchiveerde parameters.</p>
+            <p>Dit proces heeft gearchiveerde parameters.</p>
           </div>
         {{/if}}
       </Group>

--- a/app/components/process/relevant-links.hbs
+++ b/app/components/process/relevant-links.hbs
@@ -151,7 +151,7 @@
 >
   <:title>Pas link aan</:title>
   <:body>
-    <p>Pas de link aan naar een aangepast waarde.</p>
+    <p>Pas de link aan naar een aangepaste waarde.</p>
     <div class="au-u-margin-top">
       <AuLabel @error={{not this.isLabelValid}} for="edit-relevant-link-label">
         Label

--- a/app/components/process/usage.hbs
+++ b/app/components/process/usage.hbs
@@ -1,11 +1,11 @@
 <DataCard>
-  <:title>Gebruik van dit process</:title>
+  <:title>Gebruik van dit proces</:title>
   <:header>
   </:header>
 
   <:subheader>
     <AuHelpText @skin="secondary">
-      Onderstaande organisaties hebben aangevinkt dat ze dit process gebruiken.
+      Onderstaande organisaties hebben aangevinkt dat ze dit proces gebruiken.
     </AuHelpText>
   </:subheader>
   <:card>
@@ -14,7 +14,7 @@
     {{else}}
       {{#if (eq this.organizations.length 0)}}
         <p class="au-u-padding-left">
-          Er zijn momenteel geen organisaties die dit process gebruiken.</p>
+          Er zijn momenteel geen organisaties die dit proces gebruiken.</p>
       {{else}}
         <AuList
           class="au-o-layout--small au-u-padding-left"

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -517,7 +517,7 @@ export default class ProcessWizard extends Component {
 
   async goToProcess(process, isUpdateOfProcess) {
     this.showSuccessMessage = false;
-    this.loadingMessage = 'We brengen je naar het process';
+    this.loadingMessage = 'We brengen je naar het proces';
     await timeout(150);
     if (isUpdateOfProcess) {
       await this.router.refresh();

--- a/app/components/static-page.hbs
+++ b/app/components/static-page.hbs
@@ -2,7 +2,7 @@
   <m.content @scroll={{true}}>
     <AuContentHeader
       @titlePartOne="Vlaanderen"
-      @titlePartTwo="is is het Open Proces Huis"
+      @titlePartTwo="is het Open Proces Huis"
     >
       <img
         sizes="50vw"

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -78,7 +78,7 @@ export default class ProcessesProcessIndexRoute extends Route {
 
     if (process.isArchived) {
       throw new Error(
-        'Dit process is verwijderd en kan niet meer bekeken worden.',
+        'Dit proces is verwijderd en kan niet meer bekeken worden.',
       );
     }
 

--- a/app/templates/cookie-notice.hbs
+++ b/app/templates/cookie-notice.hbs
@@ -39,8 +39,8 @@
           </li>
           <li>Meten van gebruikersbezoek
             <ul><li>Namen van cookies: _ga, _gid, _gat en _umtz, _umta en gaClientId</li>
-              <li>Doel: Het gebruikersbezoek op Vlaanderen.be wordt via Google Universal Analytics op geanonimiseerde gemeten om het informatieaanbod op Vlaanderen.be te optimaliseren. De analytics cookies wordt via de Global header en footer widget op Vlaanderen.be geplaatst. Google Analytics is zo ingesteld dat het IP-adres niet wordt verwerkt, noch gegegens worden gedeeld</li>
-              <li>Cookie(s) geplaatst door: De analytics cookies worden geplaatst via het Widgets-platform dat de global header en footer aanbiedt (widgets.vlaanderen.be) en niet rechtsreeks door Google.com. Het Widgets-platform maakt hiervoor gebruik van het Google analytics object om zelf ClientID's aan te maken.</li>
+              <li>Doel: Het gebruikersbezoek op Vlaanderen.be wordt via Google Universal Analytics op geanonimiseerde gemeten om het informatieaanbod op Vlaanderen.be te optimaliseren. De analytics cookies wordt via de Global header en footer widget op Vlaanderen.be geplaatst. Google Analytics is zo ingesteld dat het IP-adres niet wordt verwerkt, noch gegevens worden gedeeld</li>
+              <li>Cookie(s) geplaatst door: De analytics cookies worden geplaatst via het Widgets-platform dat de global header en footer aanbiedt (widgets.vlaanderen.be) en niet rechtstreeks door Google.com. Het Widgets-platform maakt hiervoor gebruik van het Google analytics object om zelf ClientID's aan te maken.</li>
               <li>Ontvanger(s) van de gegevens: Google</li>
               <li>Geldigheid: permanente cookies met een geldigheid van maximaal 2 jaar</li>
             </ul></li>

--- a/app/templates/disclaimer.hbs
+++ b/app/templates/disclaimer.hbs
@@ -7,7 +7,7 @@
         <AuHeading>Disclaimer</AuHeading>
         <h2>Gebruik van de website</h2>
         <p>De Vlaamse overheid besteedt veel aandacht en zorg aan haar websites, en streeft ernaar dat alle informatie zo volledig, juist, begrijpelijk, nauwkeurig en actueel mogelijk is. Ondanks alle inspanningen kan het gebeuren dat de informatie niet volledig, juist, nauwkeurig, bijgewerkt is of wordt weergegeven.</p>
-        <p>Als de informatie die u vindt op deze website of ontvangt via telefoon, e-mail of sociale media tekortkomingen vertoont, zal de Vlaamse overheid al het mogelijke doen om dat zo snel mogelijk recht te zetten. Als u onjuistheden vaststelt, kan u met ons contact opnemen. Wij streven ernaar om uw melding zo snel mogelijk te behandelen. De Vlaamse overheid spant zich ook in om onderbrekingen van technische aard zo veel mogelijk te voorkomen. De Vlaamse overheid kan echter niet garanderen dat de websit volledig vrij is van onderbrekingen en andere technische problemen.</p>
+        <p>Als de informatie die u vindt op deze website of ontvangt via telefoon, e-mail of sociale media tekortkomingen vertoont, zal de Vlaamse overheid al het mogelijke doen om dat zo snel mogelijk recht te zetten. Als u onjuistheden vaststelt, kan u met ons contact opnemen. Wij streven ernaar om uw melding zo snel mogelijk te behandelen. De Vlaamse overheid spant zich ook in om onderbrekingen van technische aard zo veel mogelijk te voorkomen. De Vlaamse overheid kan echter niet garanderen dat de website volledig vrij is van onderbrekingen en andere technische problemen.</p>
         <p>Het is mogelijk dat bepaalde inhoud van onze website kan gedownload worden. Dit is steeds op eigen risico. Schade ten gevolge van verlies van data of schade aan de computer valt volledig en uitsluitend onder de verantwoordelijkheid van de gebruiker.</p>
         <p>Derden, bezoekers aan de website en gebruikers van diensten moeten zich onthouden van handelingen die het gebruik van de website in gevaar kunnen brengen. Stel dat een dergelijke handelingen die goede werkingen en/of het veilige karakter van de website en/of haar diensten in gedrang breng en/of tot de gebrekkige toegankelijkheid.</p>
         <h3>Inhoud en informatie op de website</h3>
@@ -15,7 +15,7 @@
         <h3>Hyperlinks en verwijzingen</h3>
         <p>Deze site bevat hyperlinks naar websites van andere overheden, instanties en organisaties, en naar informatiebronnen die door derden worden beheerd. De Vlaamse overheid beschikt voor deze sites over geen enkele technische of inhoudelijke controle of zeggenschap en kan daarom geen enkele garantie bieden over de volledigheid of juistheid van de inhoud en over de beschikbaarheid van de websites en informatiebronnen.</p>
 
-        <h2>Bescherming van persoonsgegegevens</h2>
+        <h2>Bescherming van persoonsgegevens</h2>
         <p>De Vlaamse overheid hecht veel belang aan de bescherming van uw persoonlijke levenssfeer. De gegevens worden steeds verwerkt in overeenstemming met de bepalingen van de algemene verordening gegevensbescherming (AVG), en met de bepalingen van de federale en Vlaamse regelgeving over de bescherming van natuurlijke personen bij de verwerking van persoonsgegevens.</p>
       </AuContent>
     </div>

--- a/app/templates/inventory/admin.hbs
+++ b/app/templates/inventory/admin.hbs
@@ -1,4 +1,4 @@
-{{page-title "Beheer inventaris processsen"}}
+{{page-title "Beheer inventaris processen"}}
 {{breadcrumb "Beheer" route="inventory.admin"}}
 
 <SidebarContainer>

--- a/app/templates/inventory/admin.hbs
+++ b/app/templates/inventory/admin.hbs
@@ -58,7 +58,7 @@
               <Inventory::EditToolbar
                 class="au-u-margin-bottom"
                 @modelName="process-domain"
-                @createButtonText="Nieuwe domein"
+                @createButtonText="Nieuw domein"
                 @onCreateButtonClicked={{fn
                   this.openCreateDomainModal
                   category

--- a/app/templates/my-local-government/error.hbs
+++ b/app/templates/my-local-government/error.hbs
@@ -1,4 +1,4 @@
-{{page-title "Process niet gevonden"}}
+{{page-title "Proces niet gevonden"}}
 
 <LayoutDetail>
   <Oops

--- a/app/templates/processes/error.hbs
+++ b/app/templates/processes/error.hbs
@@ -1,4 +1,4 @@
-{{page-title "Process niet gevonden"}}
+{{page-title "Proces niet gevonden"}}
 
 <LayoutDetail>
   <Oops

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -68,7 +68,7 @@
               @closable={{false}}
             >
               <p>Er kunnen geen bestanden worden toegevoegd of verwijderd als er
-                een aanpassing is gebeurt aan de bestanden structuur</p>
+                een aanpassing is gebeurd aan de bestanden structuur</p>
             </AuAlert>
           {{/if}}
           <AuToolbar as |Group|>

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -1,10 +1,10 @@
-{{page-title "Beheer process diagrammen"}}
+{{page-title "Beheer proces diagrammen"}}
 {{breadcrumb
   this.breadcrumbTitle
   route=this.breadcrumbRouteName
   model=this.breadcrumbModel
 }}
-{{breadcrumb "Beheer process diagrammen"}}
+{{breadcrumb "Beheer proces diagrammen"}}
 
 <AuBodyContainer class="au-o-box au-o-flow" @scroll={{true}}>
   <div class="au-o-grid au-o-grid--small">

--- a/app/templates/shared-processes/error.hbs
+++ b/app/templates/shared-processes/error.hbs
@@ -1,4 +1,4 @@
-{{page-title "Process niet gevonden"}}
+{{page-title "Proces niet gevonden"}}
 
 <LayoutDetail>
   <Oops


### PR DESCRIPTION
## 🗒️ Description

Some text that OPH presents to users contained mistakes. Those have been fixed. The mistakes can be split into three main categories:
- Usage of "process" instead of "proces" in Dutch text
- Grammar mistakes
- Typos in general