### PR TITLE
OPH-866 | Show the versions table with the diagram structure of that version 

### DIFF
--- a/app/components/diagram-list/table.hbs
+++ b/app/components/diagram-list/table.hbs
@@ -4,34 +4,37 @@
   @isLoading={{this.fetchDiagrams.isRunning}}
   @hidePagination={{true}}
   @page={{@page}}
-  @size={{this.size}}
+  @size={{@size}}
   @sort={{@sort}}
   as |row|
 >
   <row.content class="au-c-data-table__table--small" as |c|>
     <c.header>
-      <AuDataTableThSortable
-        @field="diagram-file.name"
-        @currentSorting={{@sort}}
-        @label="Bestandsnaam"
-      />
-      <AuDataTableThSortable
-        @field="diagram-file.created"
-        @currentSorting={{@sort}}
-        @label="Toegevoegd"
-      />
-      <AuDataTableThSortable
-        @field="diagram-file.size"
-        @currentSorting={{@sort}}
-        @label="Grootte"
-      />
-      <AuDataTableThSortable
-        @field="position"
-        @currentSorting={{@sort}}
-        @label="Positie"
-      />
-      <th></th>
-      <th></th>
+      {{#unless @isHeaderHidden}}
+        <th class="au-u-1-2">Hoofddiagram</th>
+        <AuDataTableThSortable
+          @field="diagram-file.name"
+          @currentSorting={{@sort}}
+          @label="Bestandsnaam"
+        />
+        <AuDataTableThSortable
+          @field="diagram-file.created"
+          @currentSorting={{@sort}}
+          @label="Toegevoegd"
+        />
+        <AuDataTableThSortable
+          @field="diagram-file.size"
+          @currentSorting={{@sort}}
+          @label="Grootte"
+        />
+        <AuDataTableThSortable
+          @field="position"
+          @currentSorting={{@sort}}
+          @label="Positie"
+        />
+        <th></th>
+        <th></th>
+      {{/unless}}
     </c.header>
     {{#if this.fetchDiagrams.isError}}
       <TableMessage::Error />
@@ -43,6 +46,7 @@
       <c.body as |diagram|>
         {{#let diagram.hasSubItems}}
           <DiagramList::Table::Row
+            @isViewOnly={{@isGoToDetailsHidden}}
             @process={{@process}}
             @processRouteName={{@processRouteName}}
             @diagram={{diagram}}
@@ -55,6 +59,7 @@
               {{#each diagram.sortedSubItems as |subDiagram|}}
                 <tr class="diagram-sub-row" {{show-in-parent}}>
                   <DiagramList::Table::Row
+                    @isViewOnly={{@isGoToDetailsHidden}}
                     @isSubRow={{true}}
                     @process={{@process}}
                     @processRouteName={{@processRouteName}}

--- a/app/components/diagram-list/table.js
+++ b/app/components/diagram-list/table.js
@@ -10,17 +10,13 @@ import { downloadFileByUrl } from 'frontend-openproceshuis/utils/file-downloader
 import { ARCHIVED_STATUS_URI } from '../../utils/well-known-uris';
 
 export default class DiagramListTable extends Component {
-  @service toaster;
   @service store;
-  @service plausible;
   @service eventTracking;
 
   @tracked fileToDownload;
   @tracked fileToDelete;
   @tracked canDeleteFile = true;
   @tracked diagramsTableMeta = {};
-
-  size = 5;
 
   get hasNoResults() {
     return this.fetchDiagrams?.value?.length === 0;
@@ -58,7 +54,7 @@ export default class DiagramListTable extends Component {
       sort: this.args.sort,
       page: {
         number: this.args.page,
-        size: this.size,
+        size: this.args.size,
       },
       'filter[id]': diagramsInList.map((diagram) => diagram.id).join(','),
       'filter[:not:status]': ARCHIVED_STATUS_URI,
@@ -71,5 +67,6 @@ export default class DiagramListTable extends Component {
   diagrams = trackedTask(this, this.fetchDiagrams, () => [
     this.args.process,
     this.args.sort,
+    this.args.size,
   ]);
 }

--- a/app/components/diagram-list/table/row.hbs
+++ b/app/components/diagram-list/table/row.hbs
@@ -1,11 +1,5 @@
 {{! template-lint-disable no-invalid-interactive }}
-<td
-  class="au-u-1-2 {{if
-      (eq @diagram.diagramFile.id @selectedDiagramFile.id)
-      'border-left-selected'
-      'border-left-transparent'
-    }}"
->
+<td class="au-u-1-2 {{this.classForFirstColumn}}">
   <span class={{this.subRowButtonClass}}>
     <AuButton
       @skin="naked"
@@ -35,20 +29,22 @@
 <td>
   <AuButton @skin="naked" {{on "click" @onFileDownload}}>Download</AuButton>
 </td>
-<td>
-  <AuLink
-    @route="diagrams.diagram.index"
-    @skin="button-naked"
-    @model={{@diagram.id}}
-    @query={{hash
-      previousRouteTitle=@process.title
-      previousRouteModelId=@process.id
-      previousRouteName=(or @processRouteName "processes.process")
-    }}
-  >
-    Detail
-  </AuLink>
-</td>
+{{#unless @isViewOnly}}
+  <td>
+    <AuLink
+      @route="diagrams.diagram.index"
+      @skin="button-naked"
+      @model={{@diagram.id}}
+      @query={{hash
+        previousRouteTitle=@process.title
+        previousRouteModelId=@process.id
+        previousRouteName=(or @processRouteName "processes.process")
+      }}
+    >
+      Detail
+    </AuLink>
+  </td>
+{{/unless}}
 {{#if this.isSubRowOpen}}
   {{yield}}
 {{/if}}

--- a/app/components/diagram-list/table/row.js
+++ b/app/components/diagram-list/table/row.js
@@ -18,4 +18,18 @@ export default class DiagramListTableRow extends Component {
   openCloseSubRows() {
     this.isSubRowOpen = !this.isSubRowOpen;
   }
+
+  get classForFirstColumn() {
+    if (this.args.isViewOnly) {
+      return '';
+    }
+
+    if (
+      this.args.diagram.diagramFile.id === this.args.selectedDiagramFile?.id
+    ) {
+      return 'border-left-selected';
+    } else {
+      return 'border-left-transparent';
+    }
+  }
 }

--- a/app/components/file/download-multiple-as-zip.hbs
+++ b/app/components/file/download-multiple-as-zip.hbs
@@ -14,6 +14,7 @@
 {{else}}
   <AuButton
     ...attributes
+    @skin="naked"
     class="border-radius"
     @disabled={{not this.hasFiles}}
     @loading={{this.downloadFiles.isRunning}}

--- a/app/components/process/diagram/version.hbs
+++ b/app/components/process/diagram/version.hbs
@@ -20,8 +20,8 @@
     >
       <t.content class="au-c-data-table__table--small" as |c|>
         <c.header>
-          <th class="au-u-1-2">Hoofddiagram</th>
           <AuDataTableThSortable
+            class="au-u-1-2"
             @field="created"
             @currentSorting={{@sort}}
             @label="Toegevoegd op"
@@ -39,18 +39,22 @@
         {{else}}
           <c.body as |version|>
             <td class="au-u-1-2">
-              {{version.mainDiagramFileName}}
+              <AuButton
+                @skin="naked"
+                @icon={{this.iconSubRowOpen version.list.id}}
+                {{on "click" (fn this.openCloseSubRows version.list.id)}}
+              />
+              {{date-format version.list.created true}}
               {{#unless version.canRemove}}
                 <strong>
                   <AuIcon @icon="circle-check" />
                 </strong>
               {{/unless}}
             </td>
-            <td>{{date-format version.list.created true}}</td>
             <td>{{version.diagramFiles.length}}</td>
             <td>
               <File::DownloadMultipleAsZip
-                @showAsDownloadIcon={{true}}
+                @buttonLabel="Download .zip"
                 @folderName={{version.zipFilename}}
                 @files={{version.diagramFiles}}
               />
@@ -58,14 +62,25 @@
             {{#if @canEdit}}
               <td>
                 <AuButton
-                  @icon="bin"
+                  {{!-- @icon="bin" --}}
                   @skin="naked"
                   @alert="true"
                   @width="block"
-                  @hideText="true"
+                  {{!-- @hideText="true" --}}
                   @disabled={{not version.canRemove}}
                   {{on "click" (fn this.openDeleteModal version.list)}}
                 >Verwijder</AuButton>
+              </td>
+            {{/if}}
+            {{#if (eq this.openListId version.list.id)}}
+              <td colspan="5" {{show-in-parent}}>
+                <DiagramList::Table
+                  @isHeaderHidden={{true}}
+                  @isGoToDetailsHidden={{true}}
+                  @diagramList={{version.list}}
+                  @process={{@process}}
+                  @size={{100}}
+                />
               </td>
             {{/if}}
           </c.body>

--- a/app/components/process/diagram/version.js
+++ b/app/components/process/diagram/version.js
@@ -16,6 +16,7 @@ export default class ProcessDiagramVersion extends Component {
 
   @tracked versionsTableMeta = {};
   @tracked deleteModalOpened = false;
+  @tracked openListId = null;
 
   size = 5;
 
@@ -117,4 +118,17 @@ export default class ProcessDiagramVersion extends Component {
     this.args.page,
     this.args.sort,
   ]);
+
+  iconSubRowOpen = (listId) => {
+    return this.openListId === listId ? 'nav-down' : 'nav-right';
+  };
+
+  get subRowButtonClass() {
+    return this.args.hasSubItems ? '' : 'hidden-element';
+  }
+
+  @action
+  openCloseSubRows(listId) {
+    this.openListId = this.openListId === listId ? null : listId;
+  }
 }

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -18,6 +18,7 @@ export default class ProcessesProcessIndexController extends Controller {
     'diagramVersionsSort',
     'diagramsPage',
     'diagramsSort',
+    'diagramsSize',
   ];
   @tracked versionedProcessId = null;
   @tracked attachmentsPage = 0;
@@ -30,6 +31,7 @@ export default class ProcessesProcessIndexController extends Controller {
   @tracked diagramVersionsSort = '-created';
   @tracked diagramsPage = 0;
   @tracked diagramsSort = 'position';
+  @tracked diagramsSize = 5;
 
   @service store;
   @service router;

--- a/app/routes/processes/process/index.js
+++ b/app/routes/processes/process/index.js
@@ -42,6 +42,9 @@ export default class ProcessesProcessIndexRoute extends Route {
     diagramsSort: {
       replace: true,
     },
+    diagramsSize: {
+      replace: true,
+    },
   };
 
   beforeModel(transition) {

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -111,6 +111,7 @@
           @processRouteName={{this.processRouteName}}
           @page={{this.diagramsPage}}
           @sort={{this.diagramsSort}}
+          @size={{this.diagramsSize}}
         />
       </div>
       <div class="au-o-box au-u-background-gray-100">


### PR DESCRIPTION
## 🗒️ Description

Now that a diagram version can be more than one file we want to show this to the user. The old diagram structure should be visible for the user when opening the version.

## 🦮 How to test

1. go to a process > versions section
2. table headers are updated accordingly
3. filtering on the table is  still possible (toegevoegd op)
4. When opening the diagram structure of that version is shown
5. Only one version can be opened at a time to prevent to much info on the screen at once

## 🖼️ Attachments

<img width="3041" height="805" alt="image" src="https://github.com/user-attachments/assets/0a38f10b-bed0-4359-95c9-3ff6374a1c09" />

