### PR TITLE
OPH-1111 | allocating diagrams is incorrect

### DIFF
--- a/app/components/diagram-list/drag-and-drop-sort.js
+++ b/app/components/diagram-list/drag-and-drop-sort.js
@@ -35,14 +35,16 @@ export default class DiagramListDragAndDropSort extends Component {
         ];
       }
 
-      return subItems.map((subItem) => {
-        return {
-          label: subItem.diagramFile.name,
-          self: subItem,
-          parent: _listItem,
-          isSubItem: true,
-        };
-      });
+      return subItems
+        .sort((a, b) => a.position - b.position)
+        .map((subItem) => {
+          return {
+            label: subItem.diagramFile.name,
+            self: subItem,
+            parent: _listItem,
+            isSubItem: true,
+          };
+        });
     };
 
     return sortedByPosition.map((listItem) => ({
@@ -65,8 +67,6 @@ export default class DiagramListDragAndDropSort extends Component {
     const effectiveTarget = replacedWith ?? targetList[targetList.length - 1];
 
     if (!effectiveTarget) return;
-
-    const movedItemOldPosition = movedItem.self.position;
 
     if (movedItem.parent.id !== effectiveTarget.parent.id) {
       const hasSubItems = Boolean(movedItem.self.subItems?.length);
@@ -118,9 +118,17 @@ export default class DiagramListDragAndDropSort extends Component {
       if (!replacedWith) {
         movedItem.self.position = effectiveTarget.self.position + 1;
       } else {
-        const replacedItemOldPosition = replacedWith.self.position;
-        replacedWith.self.position = movedItemOldPosition;
-        movedItem.self.position = replacedItemOldPosition;
+        const targetPosition = replacedWith.self.position;
+        if (sourceIndex < targetIndex) {
+          sourceList.slice(sourceIndex + 1, targetIndex + 1).forEach((item) => {
+            item.self.position -= 1;
+          });
+        } else {
+          sourceList.slice(targetIndex, sourceIndex).forEach((item) => {
+            item.self.position += 1;
+          });
+        }
+        movedItem.self.position = targetPosition;
       }
     }
 

--- a/app/routes/processes/process/manage-diagrams.js
+++ b/app/routes/processes/process/manage-diagrams.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class ProcessesProcessManageDiagramsRoute extends Route {
@@ -38,5 +39,14 @@ export default class ProcessesProcessManageDiagramsRoute extends Route {
       diagramList: diagramList,
       files: this.diagram.getAvailableFilesFromList(diagramList),
     };
+  }
+
+  @action
+  async willTransition() {
+    // eslint-disable-next-line ember/no-controller-access-in-routes
+    const controller = this.controller;
+    if (controller.isListChanged) {
+      await controller.onResetStructure();
+    }
   }
 }


### PR DESCRIPTION
## 🗒️ Description

When moving items the items trade places instead of shuffling along. when having 1,2,3,4 and moving 3 to 1 we get 3214 instead of 3124

## 🦮 How to test

1. go to a process with multiple diagrams
2. move around the main diagrams and see if the position is correct now
3. do the same for sub items
4. when leaving the route with changes the diagra structure gets reset

## 🖼️ Attachments

<img width="1918" height="973" alt="image" src="https://github.com/user-attachments/assets/ddc90355-9947-4c33-8bf4-a35a80e60a89" />

