### PR TITLE
OPH-1117 | Diagram structuring, issues

### DIFF
--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -33,7 +33,7 @@
           <File::DragCard
             class="tree-node--sub"
             @primaryName={{subItem.label}}
-            @secondaryName="Hoofddiagram"
+            @secondaryName="Subdiagram"
           >
             <:actions>
               <AuPill

--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -7,7 +7,6 @@
     >
       <:actions>
         <AuPill @skin="border" @size="small">{{item.self.position}}</AuPill>
-        <AuIcon @icon="drag-handle" @size="large" class="au-u-margin-right" />
       </:actions>
     </File::DragCard>
     <div class="au-u-margin-left">
@@ -40,11 +39,6 @@
                 @skin="border"
                 @size="small"
               >{{subItem.parent.position}}.{{subItem.self.position}}</AuPill>
-              <AuIcon
-                @icon="drag-handle"
-                @size="large"
-                class="au-u-margin-right"
-              />
             </:actions>
           </File::DragCard>
         {{/if}}

--- a/app/components/diagram-list/drag-and-drop-sort.hbs
+++ b/app/components/diagram-list/drag-and-drop-sort.hbs
@@ -9,7 +9,7 @@
         <AuPill @skin="border" @size="small">{{item.self.position}}</AuPill>
       </:actions>
     </File::DragCard>
-    <div class="au-u-margin-left">
+    <div class="au-u-margin-left au-u-margin-right">
       <DragSortList
         @items={{item.subItems}}
         @dragEndAction={{this.dragEnd}}

--- a/app/components/diagram-list/table.hbs
+++ b/app/components/diagram-list/table.hbs
@@ -60,9 +60,9 @@
                 <tr class="diagram-sub-row" {{show-in-parent}}>
                   <DiagramList::Table::Row
                     @isViewOnly={{@isGoToDetailsHidden}}
-                    @isSubRow={{true}}
                     @process={{@process}}
                     @processRouteName={{@processRouteName}}
+                    @mainDiagram={{diagram}}
                     @diagram={{subDiagram}}
                     @selectedDiagramFile={{@selectedDiagramFile}}
                     @onDiagramFileSelected={{@onDiagramFileSelected}}

--- a/app/components/diagram-list/table/row.hbs
+++ b/app/components/diagram-list/table/row.hbs
@@ -11,7 +11,7 @@
     {{@diagram.diagramFile.name}}
   {{else}}
     <AuButton
-      class={{if @isSubRow "au-u-margin-left" ""}}
+      class={{if @mainDiagram "au-u-margin-left" ""}}
       @skin="link"
       {{on "click" (fn @onDiagramFileSelected @diagram.diagramFile)}}
     >
@@ -22,9 +22,9 @@
 <td>{{date-format @diagram.diagramFile.created true}}</td>
 <td>{{file-size-format @diagram.diagramFile.size}}</td>
 <td>
-  {{#if @isSubRow}}
+  {{#if @mainDiagram}}
     <AuPill @skin="info" @size="small">Subdiagram
-      {{@diagram.position}}</AuPill>
+      {{@mainDiagram.position}}.{{@diagram.position}}</AuPill>
   {{else}}
     <AuPill @skin="success" @size="small">Hoofddiagram
       {{@diagram.position}}</AuPill>

--- a/app/components/file/drag-card.hbs
+++ b/app/components/file/drag-card.hbs
@@ -6,7 +6,7 @@
     class="width-full au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--between"
   >
     <div class="au-u-flex au-u-flex--row au-u-flex--vertical-center">
-      <AuIcon @icon="file" @size="large" class="au-u-margin-left" />
+      <AuIcon @icon="drag-handle" @size="large" class="au-u-margin-left" />
       <div class="au-u-margin-left-small">
         <p class="au-u-h5">{{@primaryName}}</p>
         {{#if @secondaryName}}
@@ -14,7 +14,9 @@
         {{/if}}
       </div>
     </div>
-    <div class="au-u-flex au-u-flex--spaced au-u-flex--vertical-center">
+    <div
+      class="au-u-flex au-u-flex--spaced au-u-flex--vertical-center au-u-margin-right-small"
+    >
       {{yield to="actions"}}
     </div>
   </div>

--- a/app/styles/_diagrams.scss
+++ b/app/styles/_diagrams.scss
@@ -132,3 +132,13 @@
     border-bottom-left-radius: 5px;
   }
 }
+
+.dragSortList .dragSortItem.-placeholderBefore::before,
+.dragSortList .dragSortItem.-placeholderAfter::before {
+  left: 0;
+  right: 0;
+  height: 0.5rem;
+  border-radius: 10px;
+  background-color: var(--au-blue-300);
+  line-height: unset;
+}


### PR DESCRIPTION
## 🗒️ Description

- [x] the subitems in the drag and drop are showing "Hoofddiagram" instead of "Subdiagram"
- [x] the position of the sub diagrams should start with the position of the main diagram 

## 🦮 How to test

1. Go to diagrammen beheren and see that sub diagrams have a secondary title of "Subdiagram" and not "hoofddiagram"
2. The diagram table should show the position as we do in the structuring drag and drop
3. Removed the drag handle at the end of the drag card and replaced it with the icon in front so users grab the card at the beginning which should make it easier to navigate 
4. Tried improving the drop of an item by showing a blue line when the dragged item is traversing the structure


## 🖼️ Attachments

**Secondary title + drag-handle**
<img width="1120" height="554" alt="image" src="https://github.com/user-attachments/assets/fcb09128-7296-4f23-8623-21bbf492c945" />


**position update x.x**
<img width="1627" height="363" alt="image" src="https://github.com/user-attachments/assets/a8b3d7f0-9344-4240-9cc5-e41a568ef63c" />

<img width="1627" height="428" alt="image" src="https://github.com/user-attachments/assets/ec5758da-c880-4b9f-8646-3e84ab7223ae" />
