### PR TITLE
OPH-1119 | re-calculate positions when diagram is removed

### DIFF
--- a/app/controllers/processes/process/manage-diagrams.js
+++ b/app/controllers/processes/process/manage-diagrams.js
@@ -98,7 +98,7 @@ export default class ProcessesProcessManageDiagramsController extends Controller
   });
 
   @action
-  async onResetStructure() {
+  onResetStructure() {
     const diagramList = this.model.diagramList;
 
     for (const main of diagramList.diagrams) {
@@ -108,7 +108,6 @@ export default class ProcessesProcessManageDiagramsController extends Controller
       main.rollbackAttributes();
     }
     diagramList.rollbackAttributes();
-    await this.router.refresh();
     this.isListChanged = false;
   }
 

--- a/app/models/diagram-list.js
+++ b/app/models/diagram-list.js
@@ -45,6 +45,13 @@ export default class DiagramListModel extends Model {
         _diagram.position = expectedPosition;
         _diagram.save();
       }
+      _diagram.subItems.map((_subDiagram, index) => {
+        const expectedPosition = index + 1;
+        if (_subDiagram.position !== expectedPosition) {
+          _subDiagram.position = expectedPosition;
+          _subDiagram.save();
+        }
+      });
     });
   }
 }

--- a/app/models/diagram-list.js
+++ b/app/models/diagram-list.js
@@ -37,4 +37,14 @@ export default class DiagramListModel extends Model {
     this.modified = new Date();
     await super.save(...arguments);
   }
+
+  async recalculateDiagramPositions() {
+    this.diagrams.map((_diagram, index) => {
+      const expectedPosition = index + 1;
+      if (_diagram.position !== expectedPosition) {
+        _diagram.position = expectedPosition;
+        _diagram.save();
+      }
+    });
+  }
 }

--- a/app/routes/processes/process/manage-diagrams.js
+++ b/app/routes/processes/process/manage-diagrams.js
@@ -33,6 +33,7 @@ export default class ProcessesProcessManageDiagramsRoute extends Route {
 
     const process = await this.store.findRecord('process', processId);
     const diagramList = await this.diagram.getLatestDiagramList(processId);
+    await diagramList.recalculateDiagramPositions();
 
     return {
       process: process,

--- a/app/services/router.js
+++ b/app/services/router.js
@@ -1,0 +1,28 @@
+import RouterService from '@ember/routing/router-service';
+import { tracked } from '@glimmer/tracking';
+
+export default class AppRouterService extends RouterService {
+  @tracked _activeTransition = null;
+
+  constructor() {
+    super(...arguments);
+
+    this.on('routeWillChange', (transition) => {
+      this._activeTransition = transition;
+    });
+
+    this.on('routeDidChange', () => {
+      this._activeTransition = null;
+    });
+  }
+
+  get isLoading() {
+    return this._activeTransition !== null;
+  }
+
+  willDestroy() {
+    this.off('routeWillChange');
+    this.off('routeDidChange');
+    super.willDestroy();
+  }
+}

--- a/app/styles/components/_c-loader.scss
+++ b/app/styles/components/_c-loader.scss
@@ -2,7 +2,7 @@
   position: fixed;
   inset: 0;
   z-index: 9999;
-  background: rgba(255, 255, 255, 0.3);
+  background: rgb(255 255 255 / 30%);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/styles/components/_c-loader.scss
+++ b/app/styles/components/_c-loader.scss
@@ -1,3 +1,14 @@
+.c-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(255, 255, 255, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
 .circular-loader {
   border: 0.45rem solid var(--au-gray-200);
   border-top: 0.45rem solid var(--au-yellow-300);

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -6,6 +6,12 @@
 }}
 {{breadcrumb "Beheer proces diagrammen"}}
 
+{{#if this.router.isLoading}}
+  <div class="c-loading-overlay">
+    <Shared::Loader />
+  </div>
+{{/if}}
+
 <AuBodyContainer class="au-o-box au-o-flow" @scroll={{true}}>
   <div class="au-o-grid au-o-grid--small">
     <div class="au-o-grid__item au-u-4-6@medium">


### PR DESCRIPTION
## 🗒️ Description

When we removed a  file from the  diagram list the positions where not re calculated, this is core functionality so we should update this.

## 🦮 How to test

1. go to the diagrams structure route
2. check the order
3. remove a file from the structure (preferably a file from the middle so you can see the position update)
4. the files should have a correct position after the file was removed
5. also added an overlay loader to the page so users are aware that there is still something going


