### PR TITLE
OPH-1145 | Disable use of library files in upload wizard

### DIFF
--- a/app/components/wizard/add-diagrams.hbs
+++ b/app/components/wizard/add-diagrams.hbs
@@ -9,14 +9,16 @@
       >
         Uploaden
       </AuButton>
-      <AuButton
-        @skin="naked"
-        class="c-add-diagrams__tab
-          {{if (eq this.activeTab 'library') 'c-add-diagrams__tab--active'}}"
-        {{on "click" (fn this.setActiveTab "library")}}
-      >
-        Uit bibliotheek
-      </AuButton>
+      {{#if this.isLibraryFileSearchEnabled}}
+        <AuButton
+          @skin="naked"
+          class="c-add-diagrams__tab
+            {{if (eq this.activeTab 'library') 'c-add-diagrams__tab--active'}}"
+          {{on "click" (fn this.setActiveTab "library")}}
+        >
+          Uit bibliotheek
+        </AuButton>
+      {{/if}}
     </div>
 
     <div hidden={{not (eq this.activeTab "upload")}}>

--- a/app/components/wizard/add-diagrams.js
+++ b/app/components/wizard/add-diagrams.js
@@ -13,6 +13,10 @@ export default class WizardAddDiagrams extends Component {
     return [...this.fileWrappers, ...this.files] ?? [];
   }
 
+  get isLibraryFileSearchEnabled() {
+    return false;
+  }
+
   @action
   setActiveTab(tab) {
     this.activeTab = tab;


### PR DESCRIPTION
## 🗒️ Description

We do not want the library search for files in the release of v2.8.0 

## 🦮 How to test

1. When opening the wizard we can not select files from the database

## 🖼️ Attachments

<img width="966" height="649" alt="image" src="https://github.com/user-attachments/assets/7ee0bd30-b5a4-4540-a698-254ac0f2adcd" />

