### PR TITLE
OPH-1152 | resolve docx comments for release to prod

### DIFF
--- a/app/components/process/diagram/version.hbs
+++ b/app/components/process/diagram/version.hbs
@@ -1,5 +1,5 @@
 <DataCard>
-  <:title>Versies</:title>
+  <:title>Diagram versies</:title>
   <:header></:header>
   <:subheader>
     <AuHelpText @skin="secondary">

--- a/app/components/process/wizard.hbs
+++ b/app/components/process/wizard.hbs
@@ -68,7 +68,7 @@
     <AuToolbar as |Group|>
       <Group>
         {{#if (eq this.activeStep.step this.wizardStep.UPLOAD_FILES)}}
-          <p class="color--warning">Maximum aantal bestanden is
+          <p class="color--warning">Maximum aantal bestanden in 1 keer is
             {{this.maxUploadAmount}}</p>
         {{/if}}
       </Group>

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -78,7 +78,9 @@ export default class ProcessWizard extends Component {
       return _fileModel;
     });
 
-    return filesWithDiagramListItemPosition.sort((a, b) => a > b);
+    return filesWithDiagramListItemPosition.sort(
+      (a, b) => a.position > b.position,
+    );
   }
 
   @action
@@ -413,15 +415,18 @@ export default class ProcessWizard extends Component {
       const items = Array.from(this.diagramList.diagrams).sort(
         (a, b) => a.position - b.position,
       );
+      const newMainIsCurrentMain = items[0]?.diagramFile.id === mainFile.id;
+      if (!newMainIsCurrentMain) {
+        const sorted = [
+          items.find((item) => item.diagramFile.id === mainFile.id),
+          ...items.filter((item) => item.diagramFile.id !== mainFile.id),
+        ];
+        this.loadingMessage = 'Nieuwe diagram versie aanmaken';
+        await this.createNewDiagramListVersion(this.diagramList, sorted);
+        this.loadingMessage = 'Nieuwe diagram versie linken aan het proces';
+        await this.args.process.save();
+      }
 
-      const sorted = [
-        items.find((item) => item.diagramFile.id === mainFile.id),
-        ...items.filter((item) => item.diagramFile.id !== mainFile.id),
-      ];
-      this.loadingMessage = 'Nieuwe diagram versie aanmaken';
-      await this.createNewDiagramListVersion(this.diagramList, sorted);
-      this.loadingMessage = 'Nieuwe diagram versie linken aan het proces';
-      await this.args.process.save();
       this.process = this.args.process;
       this.showSuccessMessage = true;
     } catch {

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -79,7 +79,7 @@ export default class ProcessWizard extends Component {
     });
 
     return filesWithDiagramListItemPosition.sort(
-      (a, b) => a.position > b.position,
+      (a, b) => a.position - b.position,
     );
   }
 

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -482,9 +482,11 @@ export default class ProcessWizard extends Component {
       const sortedFiles = this.putIdFirstInArray(files, this.mainProcessFile);
       const currentLists = await this.args.process.diagramLists;
       this.loadingMessage = 'Nieuwe diagram versie aanmaken';
+      const putFirstDiagramAsMain = true;
       const diagramList = await this.diagram.createDiagramListForFiles(
         sortedFiles,
         currentLists,
+        putFirstDiagramAsMain,
       );
       this.args.process.diagramLists = [...currentLists, diagramList];
       this.loadingMessage = 'Nieuwe diagram versie linken aan het proces';

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -444,9 +444,11 @@ export default class ProcessWizard extends Component {
         await this.currentSession.group.classification;
       const created = new Date();
       const sortedFiles = this.putIdFirstInArray(files, this.mainProcessFile);
+      const putFirstDiagramAsMain = true;
       const diagramList = await this.diagram.createDiagramListForFiles(
         sortedFiles,
         null,
+        putFirstDiagramAsMain,
       );
       const process = this.store.createRecord('process', {
         title: removeFileNameExtension(

--- a/app/controllers/processes/process/index.js
+++ b/app/controllers/processes/process/index.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { restartableTask, task, timeout } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { toSafeString } from '../../../utils/string-manipulation';
 
@@ -85,7 +85,7 @@ export default class ProcessesProcessIndexController extends Controller {
       this.versionedProcessId,
     );
     this.versionedDiagrams =
-      this.diagram.getAvailableFilesFromList(latestVersionedList) ?? [];
+      this.diagram.getAvailableFilesFromList(latestVersionedList);
   });
 
   get canEdit() {
@@ -204,7 +204,7 @@ export default class ProcessesProcessIndexController extends Controller {
 
   @action
   onDiagramsDownloadedAsZip() {
-    for (const file of this.diagramFiles) {
+    for (const file of this.model.allDiagramFiles) {
       this.trackDownloadFileEvent(
         file.id,
         file.name,
@@ -214,10 +214,6 @@ export default class ProcessesProcessIndexController extends Controller {
     }
   }
 
-  get diagramFiles() {
-    return this.diagram.getAvailableFilesFromList(this.model.diagramList);
-  }
-
   get diagramsDownloadFolderName() {
     if (this.model.process.title) {
       return `${toSafeString(this.model.process?.title)}`;
@@ -225,18 +221,6 @@ export default class ProcessesProcessIndexController extends Controller {
 
     return 'proces_diagrammen';
   }
-  downloadDiagrams = task({ drop: true }, async () => {
-    const diagramFiles = this.model.diagramList?.diagrams
-      ?.filter((diagrams) => !diagrams.diagramFile.isArchived)
-      ?.map((diagram) => diagram.diagramFile);
-
-    if (!diagramFiles) {
-      this.toaster.error('Er werden geen diagrammen gevonden', undefined, {
-        timeOut: 5000,
-      });
-      return;
-    }
-  });
 
   get diagramsRouteNameFromParent() {
     if (!this.model.breadcrumRouteName) {

--- a/app/controllers/processes/process/manage-diagrams.js
+++ b/app/controllers/processes/process/manage-diagrams.js
@@ -126,7 +126,9 @@ export default class ProcessesProcessManageDiagramsController extends Controller
       },
     );
 
-    return filesWithDiagramListItemPosition.sort((a, b) => a > b);
+    return filesWithDiagramListItemPosition.sort(
+      (a, b) => a.position - b.position,
+    );
   }
 
   @action

--- a/app/models/diagram-list-item.js
+++ b/app/models/diagram-list-item.js
@@ -28,7 +28,7 @@ export default class DiagramListItemModel extends Model {
   }
 
   get sortedSubItems() {
-    return Array.from(this.subItems).sort((a, b) => a.position < b.position);
+    return Array.from(this.subItems).sort((a, b) => b.position - a.position);
   }
 
   get hasSubItems() {

--- a/app/services/diagram.js
+++ b/app/services/diagram.js
@@ -124,7 +124,11 @@ export default class DiagramService extends Service {
     }
   });
 
-  async createDiagramListForFiles(fileModels, currentList = null) {
+  async createDiagramListForFiles(
+    fileModels,
+    currentList = null,
+    putFirstDiagramAsMain = false,
+  ) {
     const now = new Date();
     const diagramList = this.store.createRecord('diagram-list', {
       created: now,
@@ -134,8 +138,24 @@ export default class DiagramService extends Service {
     });
     await diagramList.save();
 
+    const files = fileModels ?? [];
+    let mainDiagramListItem = null;
+    if (putFirstDiagramAsMain && files.length > 1) {
+      const mainFile = files.shift();
+      mainDiagramListItem = this.store.createRecord('diagram-list-item', {
+        position: 1,
+        created: now,
+        modified: now,
+        diagramFile: mainFile,
+        subItems: [],
+      });
+      await mainDiagramListItem.save();
+      diagramList.diagrams.push(mainDiagramListItem);
+      await diagramList.save();
+    }
+
     await runInBatches(
-      fileModels,
+      files,
       async (file, index) => {
         const diagramListItem = this.store.createRecord('diagram-list-item', {
           position: index + 1,
@@ -149,8 +169,13 @@ export default class DiagramService extends Service {
       },
       {
         onBatch: async (batchResults) => {
-          diagramList.diagrams.push(...batchResults);
-          await diagramList.save();
+          if (mainDiagramListItem) {
+            mainDiagramListItem.subItems.push(...batchResults);
+            await mainDiagramListItem.save();
+          } else {
+            diagramList.diagrams.push(...batchResults);
+            await diagramList.save();
+          }
         },
       },
     );

--- a/app/services/event-tracking.js
+++ b/app/services/event-tracking.js
@@ -37,7 +37,7 @@ export default class EventTrackingService extends Service {
     async (targetExtension, processId) => {
       try {
         const process = await this.store.findRecord('process', processId);
-        const stats = process.processStatistics;
+        const stats = await process.processStatistics;
         switch (targetExtension) {
           case 'bpmn':
             stats.bpmnDownloads += 1;

--- a/app/templates/processes/process/index.hbs
+++ b/app/templates/processes/process/index.hbs
@@ -87,7 +87,7 @@
           @buttonLabel="Download alle"
           @buttonSkin="primary"
           @folderName={{this.diagramsDownloadFolderName}}
-          @files={{this.diagramFiles}}
+          @files={{@model.allDiagramFiles}}
           @onDownloadSuccesful={{this.onDiagramsDownloadedAsZip}}
         />
         {{#if this.isPublisherOfProcess}}

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -67,14 +67,14 @@
         <AuContent>
           {{#if this.isListChanged}}
             <AuAlert
-              @title="Acties"
+              @title="Bestandsstructuur gewijzigd"
               @skin="warning"
               @icon="info-circle"
               @size="small"
               @closable={{false}}
             >
-              <p>Er kunnen geen bestanden worden toegevoegd of verwijderd als er
-                een aanpassing is gebeurd aan de bestanden structuur</p>
+              <p>Sla je wijzigingen op voordat je bestanden kunt toevoegen of
+                verwijderen.</p>
             </AuAlert>
           {{/if}}
           <AuToolbar as |Group|>

--- a/app/templates/processes/process/manage-diagrams.hbs
+++ b/app/templates/processes/process/manage-diagrams.hbs
@@ -65,18 +65,6 @@
     <aside class="au-o-grid__item au-u-2-6@medium">
       <div class="u-top-sticky">
         <AuContent>
-          {{#if this.isListChanged}}
-            <AuAlert
-              @title="Bestandsstructuur gewijzigd"
-              @skin="warning"
-              @icon="info-circle"
-              @size="small"
-              @closable={{false}}
-            >
-              <p>Sla je wijzigingen op voordat je bestanden kunt toevoegen of
-                verwijderen.</p>
-            </AuAlert>
-          {{/if}}
           <AuToolbar as |Group|>
             <Group>
               <h2 class="au-u-h4 au-u-medium">
@@ -84,14 +72,24 @@
               </h2>
             </Group>
             <Group>
-              <AuButton
-                @disabled={{this.isListChanged}}
-                @skin="naked"
-                @icon="add"
-                {{on "click" (fn (mut this.isWizardModalOpen) true)}}
-              >
-                Toevoegen
-              </AuButton>
+              <AuTooltip @placement="left" as |tooltip|>
+                <AuButton
+                  {{tooltip.target}}
+                  @disabled={{this.isListChanged}}
+                  @skin="naked"
+                  @icon="add"
+                  {{on "click" (fn (mut this.isWizardModalOpen) true)}}
+                >
+                  Toevoegen
+                </AuButton>
+                <tooltip.Content>
+                  {{#if this.isListChanged}}
+                    <p>Sla je wijzigingen eerst op om bestanden toe te voegen</p>
+                  {{else}}
+                    <p>Voeg nieuwe bestanden toe</p>
+                  {{/if}}
+                </tooltip.Content>
+              </AuTooltip>
             </Group>
           </AuToolbar>
           <div class="c-file-list">
@@ -101,17 +99,28 @@
                 @secondaryName={{file-size-format file.size}}
               >
                 <:actions>
-                  <AuButton
-                    @disabled={{this.isListChanged}}
-                    @skin="naked"
-                    @alert="true"
-                    @icon="bin"
-                    @hideText={{true}}
-                    aria-label="Verwijder {{file.name}}"
-                    {{on "click" (fn this.onDeleteDiagram file)}}
-                  >
-                    Verwijder
-                  </AuButton>
+                  <AuTooltip @placement="left" as |tooltip|>
+                    <AuButton
+                      {{tooltip.target}}
+                      @disabled={{this.isListChanged}}
+                      @skin="naked"
+                      @alert="true"
+                      @icon="bin"
+                      @hideText={{true}}
+                      aria-label="Verwijder {{file.name}}"
+                      {{on "click" (fn this.onDeleteDiagram file)}}
+                    >
+                      Verwijder
+                    </AuButton>
+                    <tooltip.Content>
+                      {{#if this.isListChanged}}
+                        <p>Sla je wijzigingen eerst op om dit bestand te
+                          verwijderen</p>
+                      {{else}}
+                        <p>Verwijder dit bestand</p>
+                      {{/if}}
+                    </tooltip.Content>
+                  </AuTooltip>
                 </:actions>
               </File::SlimCard>
             {{/each}}


### PR DESCRIPTION
## 🗒️ Description

There are still some comments from the PM that we need to adress before going to production next week.

## 🦮 How to test

- [x] Maximum files of 10 text is updated
- [x] The warning text for the diagram structure being change is updated (to tooltips)
- [x] Versies section on process page is now called "Diagram versies"
- [x] When replacing files and selecting a main diagram the rest of the diagrams become sub items of the main diagram  instead of all main diagrams 
- [x] the order of files when selecting the main diagram file is now sorted on postion
- [x ] when the main diagram file stays the same we do not create a new diagram list 
- [x] download all diagram files really downloads all files again
- [x] the tracking for of a single file download, now does not throw an error when the process has no stats 
- [x ] sorting of items is done by "a - b" instead of using greater than ">"

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

<img width="820" height="484" alt="image" src="https://github.com/user-attachments/assets/db489f9c-a95d-472a-b0a5-6aa031ff8980" />

<img width="448" height="263" alt="image" src="https://github.com/user-attachments/assets/45785d44-a7a2-48c2-9095-3ab4841deed8" />

<img width="448" height="263" alt="image" src="https://github.com/user-attachments/assets/641fbb0c-9eee-4867-9335-fec6c9ea08a0" />

<img width="732" height="185" alt="image" src="https://github.com/user-attachments/assets/be153642-448b-4697-8a48-1e39752651e4" />

