### PR TITLE
OPH-1161 | Improve the file upload

### DIFF
--- a/app/components/data-card.js
+++ b/app/components/data-card.js
@@ -5,6 +5,11 @@ import { tracked } from '@glimmer/tracking';
 export default class DataCard extends Component {
   @tracked isCollapsed = false;
 
+  constructor() {
+    super(...arguments);
+    this.isCollapsed = this.args.isInitiallyClosed ?? false;
+  }
+
   @action
   toggleCollapse() {
     this.isCollapsed = !this.isCollapsed;

--- a/app/components/process/attachments.hbs
+++ b/app/components/process/attachments.hbs
@@ -1,4 +1,4 @@
-<DataCard>
+<DataCard @isInitiallyClosed={{true}}>
   <:title>Bijlagen
     {{#unless this.versionedFiles.isRunning}}
       <Process::ChangedStatusPills::Count

--- a/app/components/process/diagram/version.hbs
+++ b/app/components/process/diagram/version.hbs
@@ -1,4 +1,4 @@
-<DataCard>
+<DataCard @isInitiallyClosed={{true}}>
   <:title>Diagram versies</:title>
   <:header></:header>
   <:subheader>

--- a/app/components/process/diagram/version.js
+++ b/app/components/process/diagram/version.js
@@ -69,12 +69,12 @@ export default class ProcessDiagramVersion extends Component {
   });
 
   fetchVersions = task({ restartable: true }, async () => {
-    const latestDiagramList = await this.diagram.getLatestDiagramList(
-      this.args.process.id,
-    );
     const lists = await this.diagram.getDiagramListsForProcess(
       this.args.process.id,
     );
+    const latestDiagramList = [...lists].sort(
+      (a, b) => new Date(b.created) - new Date(a.created),
+    )[0];
     const filteredLists = await this.getListsWithAppliedFilters(lists);
     this.versionsTableMeta = filteredLists.meta;
 

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -397,12 +397,17 @@ export default class ProcessWizard extends Component {
     this.areFilesCreated = true;
   }
 
-  async createNewDiagramListVersion(_diagramList, orderedItems = null) {
+  async createNewDiagramListVersion(
+    _diagramList,
+    orderedItems = null,
+    newFiles = [],
+  ) {
     const currentLists = Array.from(this.args.process.diagramLists);
     const newDiagramList = await this.diagram.cloneDiagramList(
       _diagramList,
       `v0.0.${currentLists.length}`,
       orderedItems,
+      newFiles,
     );
     this.args.process.diagramLists = [...currentLists, newDiagramList];
 
@@ -517,41 +522,15 @@ export default class ProcessWizard extends Component {
     await this.uploadFiles(this.fileWrappers);
     if (this.files.length === 0) return;
 
-    const now = new Date();
     const existingItems = Array.from(this.args.diagramList.diagrams);
-    const maxPosition = existingItems.reduce(
-      (max, item) => Math.max(max, item.position ?? 0),
-      0,
-    );
     this.successMessage = null;
-    this.loadingMessage = 'Bestanden toevoegen als diagrammen';
+    this.loadingMessage = 'Proces uitbreiden met nieuwe diagrammen';
     try {
-      const newItems = await runInBatches(
+      await this.createNewDiagramListVersion(
+        this.args.diagramList,
+        existingItems,
         this.files,
-        async (file, index) => {
-          const item = this.store.createRecord('diagram-list-item', {
-            position: maxPosition + index + 1,
-            created: now,
-            modified: now,
-            diagramFile: file,
-            subItems: [],
-          });
-          await item.save();
-          return item;
-        },
-        {
-          batchSize: 2,
-          onBatch: async (_, batchStart) => {
-            const processedCount = Math.min(batchStart + 2, this.files.length);
-            this.loadingMessage = `Bestand toevoegen aan diagram (${processedCount}/${this.files.length})`;
-          },
-        },
       );
-      this.loadingMessage = 'Proces uitbreiden met nieuwe diagrammen';
-      await this.createNewDiagramListVersion(this.args.diagramList, [
-        ...existingItems,
-        ...newItems,
-      ]);
       await this.args.process.save();
       this.successMessage = 'Bestanden succesvol toegevoegd';
       this.loadingMessage = null;

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -364,7 +364,7 @@ export default class ProcessWizard extends Component {
     this.loadingMessage = 'Organizing the uploaded files';
     const fileModels = await this.store.query('file', {
       'filter[id]': fileIds.join(','),
-      page: { size: this.maxFileUpload },
+      page: { size: this.maxUploadAmount },
     });
     this.files.push(...fileModels);
     this.files = [...this.files, ...this.libraryFiles];

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -513,6 +513,7 @@ export default class ProcessWizard extends Component {
       (max, item) => Math.max(max, item.position ?? 0),
       0,
     );
+    this.successMessage = null;
     this.loadingMessage = 'Bestanden toevoegen als diagrammen';
     try {
       const newItems = await runInBatches(

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -366,7 +366,17 @@ export default class ProcessWizard extends Component {
       'filter[id]': fileIds.join(','),
       page: { size: this.maxUploadAmount },
     });
-    this.files.push(...fileModels);
+    for (const fileModel of fileModels) {
+      if (fileModel.isBpmnFile) {
+        this.loadingMessage = 'Processtappen extraheren (bpmn)';
+        this.extractBboElementsFromBpmnFile(fileModel.id);
+      }
+      if (fileModel.isVisioFile) {
+        this.loadingMessage = 'Processtappen extraheren (visio)';
+        this.extractBboElementsFromVisioFile(fileModel.id);
+      }
+      this.files.push(fileModel);
+    }
     this.files = [...this.files, ...this.libraryFiles];
 
     if (this.files.length === 0) {

--- a/app/components/process/wizard.js
+++ b/app/components/process/wizard.js
@@ -339,6 +339,7 @@ export default class ProcessWizard extends Component {
         }
       },
       {
+        batchSize: 1,
         onBatch: async (batchResults, batchStart) => {
           const processedCount = batchStart + batchResults.length;
           this.loadingMessage = `Bestanden worden opgeladen (${processedCount}/${fileWrappers.length})`;
@@ -365,17 +366,7 @@ export default class ProcessWizard extends Component {
       'filter[id]': fileIds.join(','),
       page: { size: this.maxFileUpload },
     });
-    for (const fileModel of fileModels) {
-      if (fileModel.isBpmnFile) {
-        this.loadingMessage = 'Processtappen extraheren (bpmn)';
-        this.extractBboElementsFromBpmnFile(fileModel.id);
-      }
-      if (fileModel.isVisioFile) {
-        this.loadingMessage = 'Processtappen extraheren (visio)';
-        this.extractBboElementsFromVisioFile(fileModel.id);
-      }
-      this.files.push(fileModel);
-    }
+    this.files.push(...fileModels);
     this.files = [...this.files, ...this.libraryFiles];
 
     if (this.files.length === 0) {

--- a/app/routes/processes/process/manage-diagrams.js
+++ b/app/routes/processes/process/manage-diagrams.js
@@ -31,8 +31,10 @@ export default class ProcessesProcessManageDiagramsRoute extends Route {
       processId = process?.id;
     }
 
-    const process = await this.store.findRecord('process', processId);
-    const diagramList = await this.diagram.getLatestDiagramList(processId);
+    const [process, diagramList] = await Promise.all([
+      this.store.findRecord('process', processId),
+      this.diagram.getLatestDiagramList(processId),
+    ]);
     const diagramListWithFiles =
       await this.diagram.fetchDiagramListWithDiagrams(diagramList?.id, true);
     return {

--- a/app/services/diagram.js
+++ b/app/services/diagram.js
@@ -168,6 +168,7 @@ export default class DiagramService extends Service {
         return diagramListItem;
       },
       {
+        batchSize: 1,
         onBatch: async (batchResults) => {
           if (mainDiagramListItem) {
             mainDiagramListItem.subItems.push(...batchResults);
@@ -202,6 +203,7 @@ export default class DiagramService extends Service {
           _diagrams != null ? index + 1 : null,
         ),
       {
+        batchSize: 1,
         onBatch: async (batchResults) => {
           newList.diagrams.push(
             ...batchResults.filter((item) => item !== null),

--- a/app/services/diagram.js
+++ b/app/services/diagram.js
@@ -181,7 +181,12 @@ export default class DiagramService extends Service {
     return diagramList;
   }
 
-  async cloneDiagramList(_diagramList, _versionString, _diagrams = null) {
+  async cloneDiagramList(
+    _diagramList,
+    _versionString,
+    _diagrams = null,
+    _newFiles = [],
+  ) {
     const now = new Date();
     const newList = this.store.createRecord('diagram-list', {
       created: now,
@@ -202,7 +207,23 @@ export default class DiagramService extends Service {
       { batchSize: 1 },
     );
 
-    newList.diagrams.push(...clonedItems.filter((item) => item !== null));
+    const newItems = [];
+    for (let i = 0; i < _newFiles.length; i++) {
+      const item = this.store.createRecord('diagram-list-item', {
+        position: sourceItems.length + i + 1,
+        created: now,
+        modified: now,
+        diagramFile: _newFiles[i],
+        subItems: [],
+      });
+      await item.save();
+      newItems.push(item);
+    }
+
+    newList.diagrams.push(
+      ...clonedItems.filter((item) => item !== null),
+      ...newItems,
+    );
     await newList.save();
 
     return newList;

--- a/app/services/diagram.js
+++ b/app/services/diagram.js
@@ -3,9 +3,9 @@ import Service from '@ember/service';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
-import ENV from 'frontend-openproceshuis/config/environment';
 
 import { runInBatches } from '../utils/batch';
+import { ARCHIVED_STATUS_URI } from '../utils/well-known-uris';
 
 export default class DiagramService extends Service {
   @service store;
@@ -32,7 +32,7 @@ export default class DiagramService extends Service {
       return [];
     }
 
-    return Array.from(processesWithLists[0]?.diagramLists).filter(
+    return Array.from(processesWithLists[0]?.diagramLists ?? []).filter(
       (_list) => !_list.isArchived,
     );
   }
@@ -109,7 +109,7 @@ export default class DiagramService extends Service {
     const diagrams = sortedDiagrams.filter(
       (diagram) =>
         (diagram.diagramFile.isBpmnFile || diagram.diagramFile.isVisioFile) &&
-        diagram.diagramFile.status !== ENV.resourceStates.archived,
+        diagram.diagramFile.status !== ARCHIVED_STATUS_URI,
     );
     return diagrams?.[0]?.diagramFile;
   }

--- a/app/services/diagram.js
+++ b/app/services/diagram.js
@@ -154,7 +154,7 @@ export default class DiagramService extends Service {
       await diagramList.save();
     }
 
-    await runInBatches(
+    const items = await runInBatches(
       files,
       async (file, index) => {
         const diagramListItem = this.store.createRecord('diagram-list-item', {
@@ -167,19 +167,16 @@ export default class DiagramService extends Service {
         await diagramListItem.save();
         return diagramListItem;
       },
-      {
-        batchSize: 1,
-        onBatch: async (batchResults) => {
-          if (mainDiagramListItem) {
-            mainDiagramListItem.subItems.push(...batchResults);
-            await mainDiagramListItem.save();
-          } else {
-            diagramList.diagrams.push(...batchResults);
-            await diagramList.save();
-          }
-        },
-      },
+      { batchSize: 1 },
     );
+
+    if (mainDiagramListItem) {
+      mainDiagramListItem.subItems.push(...items);
+      await mainDiagramListItem.save();
+    } else {
+      diagramList.diagrams.push(...items);
+      await diagramList.save();
+    }
 
     return diagramList;
   }
@@ -195,23 +192,18 @@ export default class DiagramService extends Service {
     await newList.save();
 
     const sourceItems = _diagrams ?? Array.from(_diagramList.diagrams);
-    await runInBatches(
+    const clonedItems = await runInBatches(
       sourceItems,
       (_listItem, index) =>
         this.cloneDiagramListItem(
           _listItem,
           _diagrams != null ? index + 1 : null,
         ),
-      {
-        batchSize: 1,
-        onBatch: async (batchResults) => {
-          newList.diagrams.push(
-            ...batchResults.filter((item) => item !== null),
-          );
-          await newList.save();
-        },
-      },
+      { batchSize: 1 },
     );
+
+    newList.diagrams.push(...clonedItems.filter((item) => item !== null));
+    await newList.save();
 
     return newList;
   }


### PR DESCRIPTION
## 🗒️ Description

Investigate further if we can improve the upload of files performance wise.

**Notes**
- batching is only for GET calls
- POST, PATCH & PUT will be executed one by one
- Try to limit redundant network calls
- as extra a closed the diagram and attachment section on the process step this because we save up 100ms (on the dev server) per diagram version fetched (5 every time = 500ms) + attachments average of 250ms

## 🦮 How to test

- Process page should update as usual
- Load a process page with some diagram versions or attachments => clear the network calls and then open (for the first time) the collapsed sections (diagram versions) see what network we safe if not initally used by the user
- The uploading of files is one by one
- Method for adding more files to an exisint diagram list is improved and should be faster
- While uploading check the docker compose stats as we still do the process step extraction which causes a CPU spike for bpmn, resource and database service => added an extra solution to our [gitbook](https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/XKRwfgAcZ0dhzZWkI6YJ/feature-passports-and-analysis-features-being-build/introduction-of-subprocesses/improvements#solution-1) to address this 
- Testing out the upload wizard without bpmn visio extraction you can just temporary block the url in your browser => dont forget to activate it again :)  (it doe snot imrpove uploadings so much but further creation of the process as now it does not spike cpu for the process step extraction)
<img width="554" height="392" alt="image" src="https://github.com/user-attachments/assets/614fb108-73cd-4e3c-a3dd-90a1aeb39a3c" />

- Test out on dev https://dev.openproceshuis.lblod.info/
- Compare with QA https://openproceshuis.lblod.info/

## 🔗 Links to other PR's

- /

## 🖼️ Attachments

- /
